### PR TITLE
chore: land spike scripts + Spike-1 findings

### DIFF
--- a/docs/research/telegram-extraction-surface.md
+++ b/docs/research/telegram-extraction-surface.md
@@ -296,15 +296,23 @@ per-subject deletion.
 
 ## 7. UNVERIFIED — first-spike smoke-test list
 
-1. Telethon 1.44.0 wheel's actual layer (`telethon.tl.alltlobjects.LAYER`) vs 228.
-2. `photos.getUserPhotos` on a privacy-restricted non-contact: empty vs partial.
-3. `stories.getPeerStories` / `storyItem.views` as a non-contact.
-4. `fragment.getCollectibleInfo` on a stranger's collectible.
-5. `channels.getParticipants(Admins)` on a broadcast channel as subscriber
-   (expected `CHAT_ADMIN_REQUIRED`).
-6. Real `Recent` yield on a mid-size supergroup with members visible.
-7. `messages.getHistory` on a public channel **without joining** (expected OK).
-8. `updates.getChannelDifference` passive mode without joining: delete events
-   arrive?
-9. `channelParticipantsMentions` returning non-participant commenters.
-10. FLOOD_WAIT onset for sequential `getFullUser` at 1 req/s on an aged account.
+Spike 1 (2026-08-20, `scripts/spike.py` against `@telegram`, a broadcast
+channel) settled items 1, 5, 7 and the recommendation-degree leak. The rest
+need different target types (a visible supergroup, a restricted non-contact, a
+stranger's collectible) and are settled by later spikes or in the DoD smoke.
+
+1. ~~Telethon wheel layer~~ — **SETTLED: layer 227**; all core raw methods present.
+2. `photos.getUserPhotos` on a privacy-restricted non-contact: empty vs partial. *(needs a restricted user target)*
+3. `stories.getPeerStories` / `storyItem.views` as a non-contact. *(needs a user with active stories)*
+4. `fragment.getCollectibleInfo` on a stranger's collectible. *(needs a collectible-holding target)*
+5. ~~`channels.getParticipants(Admins)` on a broadcast channel as subscriber~~ — **SETTLED: `CHAT_ADMIN_REQUIRED`**, as expected. Even the admin list is walled.
+6. Real `Recent` yield on a mid-size supergroup with members visible. *(needs a supergroup target)*
+7. ~~`messages.getHistory` on a public channel without joining~~ — **SETTLED: works un-joined** (resolve + getFullChannel + getHistory all succeed; @telegram: 9.78M subs, pts=736, hidden=False).
+8. `updates.getChannelDifference` passive mode without joining: delete events arrive? *(needs a watch window)*
+9. `channelParticipantsMentions` returning non-participant commenters. *(needs a channel with a linked discussion group)*
+10. FLOOD_WAIT onset for sequential `getFullUser` at 1 req/s on an aged account. *(needs a profiles run)*
+
+**Bonus (settled):** `channels.getChannelRecommendations` returns the true
+degree in `count` (87 for @telegram) while capping the returned list at 10 for a
+non-Premium account — the true similar-channel count leaks regardless of
+Premium.

--- a/scripts/login.py
+++ b/scripts/login.py
@@ -1,0 +1,50 @@
+"""Interactive Telegram login — run this in YOUR OWN terminal.
+
+Reads api_id/api_hash from the Keychain, prompts for the phone number and the
+login code (which arrives in your existing Telegram app), and saves the
+resulting session string back to the Keychain. Prints no secrets. Do the login
+yourself so the phone number and code never enter the assistant's context.
+
+    uv run python scripts/login.py [--profile default]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+import keyring
+from telethon import TelegramClient
+from telethon.sessions import StringSession
+
+SERVICE = "paperboy"
+
+
+async def run(profile: str) -> None:
+    api_id = keyring.get_password(SERVICE, f"{profile}:api_id")
+    api_hash = keyring.get_password(SERVICE, f"{profile}:api_hash")
+    if not api_id or not api_hash:
+        raise SystemExit("Run scripts/store_api.py first.")
+
+    # NOTE: no proxy here yet — for a throwaway spike only. Real collection
+    # goes through the configured proxy (require_proxy). Do the spike over a
+    # VPN/proxy at the OS level if you want the spike itself masked.
+    client = TelegramClient(StringSession(), int(api_id), api_hash)
+    await client.start()  # prompts for phone + code (+ 2FA) on stdin
+    me = await client.get_me()
+    session = client.session.save()
+    keyring.set_password(SERVICE, f"{profile}:session", session)
+    await client.disconnect()
+    # print only non-sensitive confirmation
+    print(f"Logged in as id={me.id} (username={me.username!r}); session saved to Keychain.")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", default="default")
+    args = ap.parse_args()
+    asyncio.run(run(args.profile))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/spike.py
+++ b/scripts/spike.py
@@ -1,0 +1,94 @@
+"""Throwaway read-only spike — settles the spec §13 API unknowns.
+
+Reads the session from the Keychain (never prints it), connects, and runs a
+handful of READ-ONLY probes against a public channel you name. Prints pass/fail
+and object shapes only — no participant PII is dumped. Safe for the assistant to
+run: it authenticates from the stored session and never emits secrets.
+
+    uv run python scripts/spike.py <public_channel_username> [--profile default]
+
+This is throwaway (spec §11 Phase 0): its findings update docs/research and its
+recorded TL shapes seed test fixtures. Not part of the shipped tool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+import keyring
+from telethon import TelegramClient, functions
+from telethon.errors import ChatAdminRequiredError, RPCError
+from telethon.sessions import StringSession
+from telethon.tl.alltlobjects import LAYER
+from telethon.tl.types import ChannelParticipantsAdmins
+
+SERVICE = "paperboy"
+
+
+async def run(username: str, profile: str) -> None:
+    api_id = keyring.get_password(SERVICE, f"{profile}:api_id")
+    api_hash = keyring.get_password(SERVICE, f"{profile}:api_hash")
+    session = keyring.get_password(SERVICE, f"{profile}:session")
+    if not (api_id and api_hash and session):
+        raise SystemExit("Run scripts/store_api.py then scripts/login.py first.")
+
+    client = TelegramClient(StringSession(session), int(api_id), api_hash)
+    await client.connect()
+    if not await client.is_user_authorized():
+        raise SystemExit("Session not authorized — re-run scripts/login.py.")
+
+    print(f"[env] telethon LAYER={LAYER}")
+
+    # Resolve WITHOUT joining.
+    entity = await client.get_entity(username)
+    ch = await client(functions.channels.GetFullChannelRequest(channel=entity))
+    full = ch.full_chat
+    print(f"[#13.2] resolve+getFullChannel un-joined OK: "
+          f"participants={getattr(full, 'participants_count', None)} "
+          f"hidden={getattr(full, 'participants_hidden', None)} "
+          f"linked={getattr(full, 'linked_chat_id', None)} pts={getattr(full, 'pts', None)}")
+
+    # History WITHOUT joining.
+    n = 0
+    async for _ in client.iter_messages(entity, limit=5):
+        n += 1
+    print(f"[#13.7] getHistory un-joined returned {n} messages (expect >0 for a public channel)")
+
+    # Admin list on a broadcast channel as non-admin (expect CHAT_ADMIN_REQUIRED
+    # for a broadcast; supergroups may allow it).
+    try:
+        parts = await client(functions.channels.GetParticipantsRequest(
+            channel=entity,
+            filter=ChannelParticipantsAdmins(),
+            offset=0, limit=1, hash=0,
+        ))
+        print(f"[#13.3] getParticipants(Admins) returned (count={getattr(parts, 'count', '?')}) "
+              f"— channel likely a supergroup or you're admin")
+    except ChatAdminRequiredError:
+        print("[#13.3] getParticipants → CHAT_ADMIN_REQUIRED (expected for a broadcast channel)")
+    except RPCError as e:
+        print(f"[#13.3] getParticipants → {type(e).__name__}: {e}")
+
+    # Similar channels (public, no premium needed for the call).
+    try:
+        rec = await client(functions.channels.GetChannelRecommendationsRequest(channel=entity))
+        print(f"[#graph] getChannelRecommendations OK: "
+              f"count={getattr(rec, 'count', len(rec.chats))} returned={len(rec.chats)}")
+    except RPCError as e:
+        print(f"[#graph] getChannelRecommendations → {type(e).__name__}: {e}")
+
+    await client.disconnect()
+    print("[done] spike complete — no secrets printed.")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("username")
+    ap.add_argument("--profile", default="default")
+    args = ap.parse_args()
+    asyncio.run(run(args.username, args.profile))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/store_api.py
+++ b/scripts/store_api.py
@@ -1,0 +1,37 @@
+"""Store api_id / api_hash in the macOS Keychain — run this in YOUR OWN terminal.
+
+Values are read with getpass (no echo) and never printed. Claude never reads the
+Keychain, so once they're here they stay out of the assistant's context.
+
+    uv run python scripts/store_api.py [--profile default]
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+
+import keyring
+
+SERVICE = "paperboy"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", default="default")
+    args = ap.parse_args()
+
+    api_id = getpass.getpass("api_id (hidden): ").strip()
+    if not api_id.isdigit():
+        raise SystemExit("api_id must be an integer")
+    api_hash = getpass.getpass("api_hash (hidden): ").strip()
+    if len(api_hash) != 32:
+        raise SystemExit("api_hash should be 32 hex characters")
+
+    keyring.set_password(SERVICE, f"{args.profile}:api_id", api_id)
+    keyring.set_password(SERVICE, f"{args.profile}:api_hash", api_hash)
+    print(f"Stored api_id + api_hash for profile '{args.profile}' in the Keychain.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Spike scripts + Spike-1 findings

**Fixes a merge miss:** the Keychain credential helpers and the throwaway spike (`scripts/store_api.py`, `login.py`, `spike.py`) were pushed to `chore/bootstrap` *after* PR #4 had already merged at `a40cbdd`, so they never reached `main`. This lands them.

### Spike 1 results (`scripts/spike.py` against `@telegram`)
Read-only, no join. Settles spec §13 items 1, 5, 7 + a graph note:

| Item | Result |
|---|---|
| §13.1 layer | **227** (all core raw methods present) |
| §13.7 un-joined reading | **works** — resolve + getFullChannel + getHistory (9.78M subs, pts=736, hidden=False) |
| §13.3 broadcast participants | **`CHAT_ADMIN_REQUIRED`** — admin list walled for subscribers, as designed |
| graph | `getChannelRecommendations` count=**87** but 10 returned — true degree leaks without Premium |

Remaining §13 items (2,3,4,6,8,9,10) need other target types (a visible supergroup, a restricted non-contact, a collectible holder, a channel with a discussion group) and are settled by later spikes / the DoD smoke.

### Note
`scripts/` are throwaway Phase-0 helpers, excluded from packaging; `store_api.py`/`login.py` stay useful for re-login and additional profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)