### PR TITLE
Phase 1: paperboy core (collect-channel) — issue #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@ build/
 .env
 .env.*
 config.local.*
-data/
+/data/            # default data dir (SQLite DB, logs, media) — repo-relative
+data/             # any other data/ dir
 paperboy-data/
 *.sqlite
 *.sqlite-wal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,12 @@ database for OSINT / investigative-journalism use. Architected as an entity
 graph so later recipes (user dossier, phone lookup, watchlists) are thin
 additions. See `README.md` for the user-facing summary and disclaimer.
 
-**Status (2026-08-20):** pre-scaffold. Research and design are done; no Python
-code exists yet. Phase 0 (repo scaffold, CI, ADRs, live spike) is next.
+**Status (2026-08-21):** Phase 1 (core) shipped on `feat/core` — `paperboy
+collect`/`status`/`export`/`doctor`/`auth` work end to end against live
+Telegram (see `docs/features/collect-channel.md` for the DoD smoke
+transcript). `watch` and `lookup` are Phase 2 stubs. Phase 2 collectors
+(`discussion`, `participants`, `profiles`, `media`, `graph`, `web`) are not
+started.
 
 ## Read these first
 
@@ -65,9 +69,13 @@ code exists yet. Phase 0 (repo scaffold, CI, ADRs, live spike) is next.
 
 ## Commands
 
-Pending Phase 0 scaffold (`uv sync`, `uv run pytest`, `uv run ruff check`,
-`uv run pyright`, `uv run paperboy --help`). Update this section when the
-scaffold lands; do not add commands that don't exist yet.
+`uv sync`; `uv run pytest -q`; `uv run ruff check`; `uv run pyright`;
+`uv run paperboy --help`. The CLI: `auth`, `doctor`, `collect TARGET
+[--phases channel,history] [--unsafe]`, `status [TARGET]`, `export TARGET
+--format jsonl --out DIR` — all read `api_id`/`api_hash`/session for
+`--profile` (default `default`) from the macOS Keychain (`scripts/store_api.py`,
+`scripts/login.py`, or `paperboy auth`). `watch`/`lookup` exit 1 with a
+"Phase 2" message — not implemented yet.
 
 ## Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ started.
 `uv run paperboy --help`. The CLI: `auth`, `doctor`, `collect TARGET
 [--phases channel,history] [--unsafe]`, `status [TARGET]`, `export TARGET
 --format jsonl --out DIR` — all read `api_id`/`api_hash`/session for
-`--profile` (default `default`) from the macOS Keychain (`scripts/store_api.py`,
+`--profile` (default `default`) from the OS keychain via `keyring` (macOS/Windows/Linux; tested on macOS — see issue #10) (`scripts/store_api.py`,
 `scripts/login.py`, or `paperboy auth`). `watch`/`lookup` exit 1 with a
 "Phase 2" message — not implemented yet.
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,14 @@ discoverable and their public profiles, the forward/mention/similar-channel
 graph, and web-archive snapshots — for open-source investigation and
 journalism. Everything runs on your machine; nothing is uploaded.
 
-**Status:** design complete, implementation not started. Start with
-`docs/research/telegram-extraction-surface.md` and
-`docs/superpowers/specs/2026-08-20-paperboy-design.md`.
+**Status:** Phase 1 (core) shipped — channel metadata, full message history
+with edit revisions and deletion tombstones, `pts`-based incremental sync,
+JSONL export, and an opsec preflight (`paperboy doctor`) all work end to end
+against live Telegram. Media, comment threads, people discovery, the graph,
+and web-archive snapshots are Phase 2, not yet built. Start with
+`docs/research/telegram-extraction-surface.md`,
+`docs/superpowers/specs/2026-08-20-paperboy-design.md`, and
+`docs/features/collect-channel.md`.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,209 @@
 # paperboy
 
 A local, read-only command-line tool that collects everything obtainable about a
-Telegram channel or supergroup into a single SQLite database — messages with
-their edit and deletion history, media, comment threads, the people who are
-discoverable and their public profiles, the forward/mention/similar-channel
-graph, and web-archive snapshots — for open-source investigation and
-journalism. Everything runs on your machine; nothing is uploaded.
+Telegram **channel or supergroup** into a single SQLite database — for
+open-source investigation and journalism. Everything runs on your machine;
+nothing is uploaded.
 
-**Status:** Phase 1 (core) shipped — channel metadata, full message history
-with edit revisions and deletion tombstones, `pts`-based incremental sync,
-JSONL export, and an opsec preflight (`paperboy doctor`) all work end to end
-against live Telegram. Media, comment threads, people discovery, the graph,
-and web-archive snapshots are Phase 2, not yet built. Start with
-`docs/research/telegram-extraction-surface.md`,
-`docs/superpowers/specs/2026-08-20-paperboy-design.md`, and
-`docs/features/collect-channel.md`.
+paperboy is built as an *entity graph* (peers, messages, edges) so that today's
+channel collection and tomorrow's user dossiers, phone lookups, and watchlists
+share one store and one set of guardrails.
+
+## Status
+
+**Phase 1 (core) works end to end against live Telegram:**
+
+| Capability | State |
+|---|---|
+| Channel/supergroup metadata + snapshots | ✅ |
+| Full message history (un-joined for public channels) | ✅ |
+| Edit revisions + deletion tombstones (gap-detected) | ✅ |
+| `pts`-based incremental sync (edits & deletions) | ✅ |
+| Raw-TL preservation + normalized projections + FTS5 | ✅ |
+| JSONL export | ✅ |
+| Opsec preflight (`paperboy doctor`) | ✅ |
+| Media download, comment threads, people & profiles, forward/mention/similar-channel graph, web-archive snapshots, `watch`, phone `lookup` | 🔜 Phase 2 |
+
+## Requirements
+
+- **macOS** (credentials are stored in the macOS Keychain).
+- **Python ≥ 3.12** and [**uv**](https://docs.astral.sh/uv/).
+- A **dedicated Telegram account** for research (not your personal one — see
+  [Safety](#safety--guardrails)) and its `api_id` / `api_hash` from
+  [my.telegram.org](https://my.telegram.org).
+
+## Install
+
+```bash
+git clone https://github.com/SpencerNorris/paperboy.git
+cd paperboy
+uv sync
+uv run paperboy --help
+```
+
+`uv run paperboy …` runs the CLI inside the project environment. (Not yet
+published to PyPI.)
+
+> If the repo lives on a secondary/external volume (e.g. `/Volumes/…`), `uv
+> sync` may print `warning: Failed to clone files; falling back to full copy`.
+> That is harmless — uv's cache and your project are on different filesystems,
+> so reflinking isn't available and it copies instead. Silence it with
+> `export UV_LINK_MODE=copy`.
+
+## Quick start
+
+### 1. Get your API credentials
+
+Log in at [my.telegram.org](https://my.telegram.org) with your **research
+account's** phone number (the code arrives in your Telegram app), open **API
+development tools**, and create an app to obtain an `api_id` (integer) and
+`api_hash` (32-hex string).
+
+### 2. Store the credentials and log in
+
+Credentials go in the macOS Keychain — never a file, never the repo. Two ways:
+
+```bash
+# a) guided helper scripts (run them yourself; hidden input, nothing printed)
+uv run python scripts/store_api.py        # paste api_id, then api_hash
+uv run python scripts/login.py            # enter phone + the login code
+
+# b) or the built-in interactive command
+uv run paperboy auth                      # prompts for phone + code, saves session
+```
+
+Everything is stored under the **profile** name `default`. Use
+`--profile <name>` throughout to keep separate accounts and databases (one per
+investigation you want kept unlinkable).
+
+### 3. Run the opsec preflight
+
+```bash
+uv run paperboy doctor
+```
+
+`doctor` checks your account's posture — proxy configured, session age, 2FA,
+privacy settings, minimal profile — and **blocks `collect` if any check fails**.
+Fix the account (see [`docs/opsec.md`](docs/opsec.md)); `--unsafe` overrides the
+gate for throwaway testing only.
+
+### 4. Collect a channel
+
+```bash
+uv run paperboy collect @durov
+```
+
+This resolves the channel, pulls its full metadata and message history
+(**without joining** — public channels are readable un-joined), records edit
+revisions, and detects deletions as tombstones. It prints a per-phase summary:
+
+```
+ phase    counts                                                   stopped
+ channel  {'channels': 1, 'peers': 2}                              -
+ history  {'messages': 476, 'revisions': 476, 'tombstones': 67, …} -
+```
+
+Useful flags: `--phases channel,history` (run a subset), `--profile <name>`,
+and `--unsafe` (bypass the doctor gate — only when you accept the posture).
+`collect` is idempotent and resumable: re-running continues sync and captures
+new edits/deletions.
+
+### 5. Inspect what you collected
+
+```bash
+uv run paperboy status @durov          # counts for one channel
+uv run paperboy status                 # everything in the profile
+```
+
+The store is a plain SQLite file with an FTS index, so you can also browse it
+with [Datasette](https://datasette.io):
+
+```bash
+uvx datasette ~/.local/share/paperboy/default/paperboy.sqlite
+```
+
+### 6. Export
+
+```bash
+uv run paperboy export @durov --format jsonl --out ./out
+# writes channel.jsonl, messages.jsonl (with a revisions[] array), edges.jsonl
+```
+
+The collecting account's own record is scrubbed from exports.
+
+## Command reference
+
+| Command | Purpose |
+|---|---|
+| `paperboy auth` | Interactive login; saves the session to the Keychain. |
+| `paperboy doctor` | Opsec preflight; blocks `collect` on failure unless `--unsafe`. |
+| `paperboy collect TARGET [--phases …] [--unsafe] [--profile P]` | Collect channel metadata + history. |
+| `paperboy status [TARGET] [--profile P]` | Summarize stored data. |
+| `paperboy export TARGET --format jsonl --out DIR [--profile P]` | Export to JSONL. |
+| `paperboy watch` / `paperboy lookup` | Phase 2 — not implemented (exit with a notice). |
+
+`TARGET` accepts `@username`, `t.me/name`, `t.me/name/123`, an invite link, or a
+numeric peer id.
+
+## Configuration
+
+Settings resolve **CLI flag > `PAPERBOY_*` env var > `config.toml` > default**.
+Secrets (`api_hash`, session) live only in the Keychain. Key settings:
+
+| Setting (`PAPERBOY_…`) | Default | Meaning |
+|---|---|---|
+| `DATA_DIR` | `~/.local/share/paperboy` | Root for `<data_dir>/<profile>/paperboy.sqlite` + media. |
+| `PROXY` | *(unset)* | `socks5://…` or `mtproxy://…` to route Telegram traffic. |
+| `REQUIRE_PROXY` | `true` | `doctor` fails (and `collect` refuses) without a proxy. |
+| `MIN_SESSION_AGE_DAYS` | `7` | Guards bulk work on fresh accounts. |
+| `FLOOD_SLEEP_THRESHOLD` | `60` | Sleep through `FLOOD_WAIT`s ≤ this; stop the phase above it. |
+| `MAX_RPC_PER_RUN` | `20000` | Hard per-run request cap. |
+| `ALLOW_JOIN` / `ALLOW_PHONE_LOOKUP` | `false` | Off-by-default flag-gated behaviors (Phase 2). |
+
+## Where your data lives
+
+```
+~/.local/share/paperboy/<profile>/
+  paperboy.sqlite     # system of record: raw_records + normalized tables + FTS5
+  paperboy.log        # credential-redacted JSON log
+  media/              # (Phase 2) downloaded files, content-addressed
+```
+
+Keep this directory on an **encrypted volume**. Every TL object is stored raw in
+`raw_records` before it is projected into the normalized tables, so a Telegram
+schema bump can be re-parsed rather than re-scraped.
+
+## Safety & guardrails
+
+paperboy is deliberately constrained (enforced in code, not just docs):
+
+- **Read-only.** It never sends, reacts, votes, joins (without an explicit
+  `--join`, Phase 2), or otherwise mutates the account. Reading a public channel
+  is invisible to its admins.
+- **Rate-respecting.** Every request passes a budget gate; `FLOOD_WAIT` is
+  honored per method and `PEER_FLOOD` is a hard stop.
+- **Credential-safe.** Secrets stay in the Keychain and are redacted from logs.
+- **Opsec-aware.** `doctor` refuses to collect from an unhardened account.
+
+Read [`docs/opsec.md`](docs/opsec.md) before your first real collection — it
+covers account acquisition, proxies, handling collected files (which can phone
+home when opened), and compartmentalization.
+
+## Development
+
+```bash
+uv run pytest -q          # unit + integration tests
+uv run ruff check         # lint
+uv run pyright            # type-check
+```
+
+## Documentation
+
+- [`docs/opsec.md`](docs/opsec.md) — operator security runbook.
+- [`docs/features/collect-channel.md`](docs/features/collect-channel.md) — the core feature, with the live smoke transcript.
+- [`docs/research/telegram-extraction-surface.md`](docs/research/telegram-extraction-surface.md) — what the Telegram API does and does not expose, by access tier.
+- [`docs/superpowers/specs/2026-08-20-paperboy-design.md`](docs/superpowers/specs/2026-08-20-paperboy-design.md) — the design.
+- [`docs/adr/`](docs/adr/) — architecture decisions (library, storage, guardrails, sync).
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@ uv run paperboy --help
 `uv run paperboy …` runs the CLI inside the project environment. (Not yet
 published to PyPI.)
 
-> If the repo lives on a secondary/external volume (e.g. `/Volumes/…`), `uv
-> sync` may print `warning: Failed to clone files; falling back to full copy`.
-> That is harmless — uv's cache and your project are on different filesystems,
-> so reflinking isn't available and it copies instead. Silence it with
-> `export UV_LINK_MODE=copy`.
-
 ## Quick start
 
 ### 1. Get your API credentials

--- a/README.md
+++ b/README.md
@@ -26,8 +26,13 @@ share one store and one set of guardrails.
 
 ## Requirements
 
-- **macOS** (credentials are stored in the macOS Keychain).
 - **Python ≥ 3.12** and [**uv**](https://docs.astral.sh/uv/).
+- **macOS, Windows, or Linux.** Credentials are stored in your OS's native
+  encrypted keychain via the [`keyring`](https://pypi.org/project/keyring/)
+  library — macOS Keychain, Windows Credential Manager, or the Linux Secret
+  Service (GNOME Keyring / KWallet). Currently tested on macOS. Headless Linux
+  and WSL boxes without a Secret Service need extra setup — tracked in
+  [issue #10](https://github.com/SpencerNorris/paperboy/issues/10).
 - A **dedicated Telegram account** for research (not your personal one — see
   [Safety](#safety--guardrails)) and its `api_id` / `api_hash` from
   [my.telegram.org](https://my.telegram.org).
@@ -55,7 +60,7 @@ development tools**, and create an app to obtain an `api_id` (integer) and
 
 ### 2. Store the credentials and log in
 
-Credentials go in the macOS Keychain — never a file, never the repo. Two ways:
+Credentials go in your OS keychain — never a file, never the repo. Two ways:
 
 ```bash
 # a) guided helper scripts (run them yourself; hidden input, nothing printed)
@@ -113,7 +118,7 @@ The store is a plain SQLite file with an FTS index, so you can also browse it
 with [Datasette](https://datasette.io):
 
 ```bash
-uvx datasette ~/.local/share/paperboy/default/paperboy.sqlite
+uvx datasette ./data/default/paperboy.sqlite
 ```
 
 ### 6. Export
@@ -146,7 +151,7 @@ Secrets (`api_hash`, session) live only in the Keychain. Key settings:
 
 | Setting (`PAPERBOY_…`) | Default | Meaning |
 |---|---|---|
-| `DATA_DIR` | `~/.local/share/paperboy` | Root for `<data_dir>/<profile>/paperboy.sqlite` + media. |
+| `DATA_DIR` | `./data` | Root for `<data_dir>/<profile>/paperboy.sqlite` + media (repo-relative). |
 | `PROXY` | *(unset)* | `socks5://…` or `mtproxy://…` to route Telegram traffic. |
 | `REQUIRE_PROXY` | `true` | `doctor` fails (and `collect` refuses) without a proxy. |
 | `MIN_SESSION_AGE_DAYS` | `7` | Guards bulk work on fresh accounts. |
@@ -157,13 +162,16 @@ Secrets (`api_hash`, session) live only in the Keychain. Key settings:
 ## Where your data lives
 
 ```
-~/.local/share/paperboy/<profile>/
+./data/<profile>/        # in the repo dir by default; gitignored
   paperboy.sqlite     # system of record: raw_records + normalized tables + FTS5
   paperboy.log        # credential-redacted JSON log
   media/              # (Phase 2) downloaded files, content-addressed
 ```
 
-Keep this directory on an **encrypted volume**. Every TL object is stored raw in
+The default data dir is `./data` (relative to where you run `paperboy`), so
+collected data lands next to the code and is gitignored. Override it with
+`PAPERBOY_DATA_DIR`. Keep it on an **encrypted volume** — FileVault on macOS,
+LUKS on Linux, BitLocker/VeraCrypt on Windows. Every TL object is stored raw in
 `raw_records` before it is projected into the normalized tables, so a Telegram
 schema bump can be re-parsed rather than re-scraped.
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,46 @@ LUKS on Linux, BitLocker/VeraCrypt on Windows. Every TL object is stored raw in
 `raw_records` before it is projected into the normalized tables, so a Telegram
 schema bump can be re-parsed rather than re-scraped.
 
+## What's in the database
+
+The store is one SQLite file with an FTS index — browse it with
+[Datasette](https://datasette.io) (`uvx datasette ./data/default/paperboy.sqlite`)
+or query it with `sqlite3`. The tables you'll actually read:
+
+| Table | What it holds |
+|---|---|
+| `channels` | the channel itself — id, username, title, `participants_count`, about, flags |
+| `messages` | current state of every message — `text`, `date`, `from_uri`, `media_kind`, `deleted_at`, `content_hash` |
+| `message_revisions` | append-only edit history — every version of a message you've observed |
+| `message_tombstones` | deleted messages, with how the deletion was detected (`update`/`empty`/`gap`) |
+| `message_metrics` | time series of `views` / `forwards` / `replies` per message |
+| `edges` | the graph — `(subject, predicate, object)`, e.g. `forwarded_from` |
+| `peers` | every user/channel seen, with `min`-provenance |
+| `raw_records` | every raw Telegram object as received — the system of record |
+| `messages_fts` | full-text index over message text |
+
+A few useful queries:
+
+```sql
+-- recent posts with view counts
+SELECT m.msg_id, substr(m.date,1,10) AS date, m.text, mm.views
+FROM messages m LEFT JOIN message_metrics mm ON mm.message_uri = m.uri
+WHERE m.text <> '' ORDER BY m.msg_id DESC LIMIT 20;
+
+-- full-text search
+SELECT m.msg_id, m.text
+FROM messages_fts f JOIN messages m ON m.rowid = f.rowid
+WHERE messages_fts MATCH 'your query' ORDER BY m.msg_id DESC;
+
+-- what got deleted
+SELECT message_uri, evidence, observed_at FROM message_tombstones;
+```
+
+**Full column-by-column reference: [`docs/data-model.md`](docs/data-model.md).**
+Note that message ids are sequential per channel but only non-deleted,
+non-service messages carry text — gaps are deletions (see `message_tombstones`),
+not missing data.
+
 ## Safety & guardrails
 
 paperboy is deliberately constrained (enforced in code, not just docs):
@@ -202,6 +242,7 @@ uv run pyright            # type-check
 ## Documentation
 
 - [`docs/opsec.md`](docs/opsec.md) — operator security runbook.
+- [`docs/data-model.md`](docs/data-model.md) — the database codebook (every table and column).
 - [`docs/features/collect-channel.md`](docs/features/collect-channel.md) — the core feature, with the live smoke transcript.
 - [`docs/research/telegram-extraction-surface.md`](docs/research/telegram-extraction-surface.md) — what the Telegram API does and does not expose, by access tier.
 - [`docs/superpowers/specs/2026-08-20-paperboy-design.md`](docs/superpowers/specs/2026-08-20-paperboy-design.md) — the design.

--- a/docs/adr/0002-storage.md
+++ b/docs/adr/0002-storage.md
@@ -5,7 +5,7 @@
 ## Problem
 Store an exhaustive, re-queryable, forensically-sound channel corpus that
 survives TL schema growth, supports incremental sync, versions edits, and
-dovetails with the user's Datasette/tapedeck workflow — without prematurely
+dovetails with a Datasette-based analysis workflow — without prematurely
 committing to a graph database.
 
 ## Options
@@ -29,8 +29,7 @@ The corpus is mostly tabular by volume (messages × 30+ fields needing FTS,
 media hashes, counter time-series); the graph part is real but shallow (1–2
 hops), which SQL joins handle trivially. Provenance ("seen at T, at tier X,
 from record R") is three columns in SQL but needs reification/RDF-star in a
-triple store. The user's whole toolchain (FTS5, Datasette, tapedeck) is
-SQLite. We keep the triple shape so nothing is lost.
+triple store. The target toolchain (FTS5, Datasette) is SQLite. We keep the triple shape so nothing is lost.
 
 ## Consequences
 - A layer bump means re-parsing `raw_records`, not re-scraping.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,306 @@
+# Data model / codebook
+
+The complete reference for the SQLite database paperboy writes to
+`<data_dir>/<profile>/paperboy.sqlite` (default `./data/default/paperboy.sqlite`).
+The authoritative schema is `src/paperboy/store/migrations/0001_init.sql`; this
+document explains what each table and column means.
+
+For a quick orientation and how to browse the data (Datasette, `sqlite3`), see
+the **"What's in the database"** section of the [README](../README.md).
+
+## Cross-cutting conventions
+
+- **URI ids.** Entities are identified by string URIs, not bare integers:
+  `tg:channel:<id>`, `tg:chat:<id>`, `tg:user:<id>`, and messages
+  `tg:msg:<channel_id>/<msg_id>`. This makes ids stable, self-describing, and
+  ready for graph/RDF export.
+- **Timestamps** are ISO-8601 UTC text (e.g. `2026-08-21T14:30:51.540418+00:00`).
+- **`*_json` columns** hold verbatim JSON projections of the corresponding
+  Telegram (TL) object or sub-object — kept so no field is lost even before the
+  normalized columns understand it.
+- **`source_raw_id`** on a projected row points back to the `raw_records` row it
+  was derived from (provenance; lets any projection be rebuilt from raw).
+- **`tier`** records the visibility level a fact was observed at:
+  `stranger` | `member` | `contact` | `admin` | `self`. The same field can look
+  different at different tiers, so the tier is part of the record.
+- **`first_seen` / `last_seen`** on entity tables bound when paperboy first and
+  most recently saw that row — `last_seen` advances on every re-observation even
+  when nothing changed.
+- **Raw first.** Every TL object is written to `raw_records` *before* it is
+  projected into the normalized tables. `raw_records` is the system of record; a
+  Telegram schema change can be re-parsed from it rather than re-scraped.
+- **History is append-only.** Edits, counter changes, and deletions are new rows
+  in `message_revisions` / `message_metrics` / `channel_snapshots` /
+  `message_tombstones`, never overwrites — so the timeline is preserved.
+
+---
+
+## `raw_records` — system of record
+
+Every Telegram object exactly as received, before any normalization.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `id` | INTEGER PK | Row id; referenced by every projection's `source_raw_id`. |
+| `kind` | TEXT | TL type name (e.g. `channelFull`, `message`, `user`). |
+| `observed_at` | TEXT | When paperboy received it (UTC). |
+| `tier` | TEXT | Visibility tier at capture (see conventions). |
+| `context_json` | TEXT | Optional capture context (e.g. resolve target, request params). |
+| `payload_json` | TEXT | The full TL object as JSON (`to_dict()`). |
+
+## Entities (current state)
+
+### `channels` — the channel/supergroup itself
+
+| Column | Type | Meaning |
+|---|---|---|
+| `id` | INTEGER PK | Telegram channel id (no `-100` prefix). |
+| `uri` | TEXT UNIQUE | `tg:channel:<id>`. |
+| `username` | TEXT | Public @username, or NULL if private/none. |
+| `title` | TEXT | Display title. |
+| `about` | TEXT | Description / bio text. |
+| `kind` | TEXT | `broadcast`, `megagroup`, `gigagroup`, or `forum`. |
+| `created_at` | TEXT | Channel creation date, when exposed. |
+| `linked_chat_id` | INTEGER | Linked discussion group id (0/NULL if none). |
+| `participants_count` | INTEGER | Subscriber/member count at last observation. |
+| `flags_json` | TEXT | Boolean flags (verified, scam, fake, restricted, `participants_hidden`, `join_to_send`, …). |
+| `restriction_json` | TEXT | `restriction_reason[]` (platform + reason: porno/terms/sensitive), if restricted. |
+| `source_raw_id` | INTEGER | Provenance → `raw_records`. |
+| `first_seen` / `last_seen` | TEXT | Bounds of observation. |
+
+### `peers` — any entity id encountered, with `min`-provenance
+
+Generic projection for **any** peer (`user`, `channel`, `chat`) seen anywhere —
+message authors, forwarders, mentions, etc. Channel-typed peers also get a
+richer row in `channels`.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `uri` | TEXT PK | `tg:user:<id>` / `tg:channel:<id>` / `tg:chat:<id>`. |
+| `kind` | TEXT | `user`, `channel`, or `chat`. |
+| `id` | INTEGER | Telegram id. |
+| `access_hash` | INTEGER | Per-session access hash (may be NULL/min). |
+| `is_min` | INTEGER | 1 if only a `min` constructor was seen (reduced fields; hash usable only for profile-photo fetch). |
+| `seen_in_chat` | INTEGER | Channel id this peer was seen in (min-provenance). |
+| `seen_in_msg` | INTEGER | Message id this peer was seen in — needed to build `inputUserFromMessage` for a min peer. |
+| `username` | TEXT | @username if known. |
+| `first_name` / `last_name` | TEXT | For user-typed peers. |
+| `title` | TEXT | For channel/chat-typed peers. |
+| `flags_json` | TEXT | Boolean flags (bot, verified, scam, fake, premium, …). |
+| `source_raw_id` | INTEGER | Provenance. |
+| `first_seen` / `last_seen` | TEXT | Bounds of observation. |
+
+### `messages` — current state of every message
+
+| Column | Type | Meaning |
+|---|---|---|
+| `uri` | TEXT PK | `tg:msg:<channel_id>/<msg_id>`. |
+| `channel_id` | INTEGER | Owning channel id. |
+| `msg_id` | INTEGER | Per-channel sequential message id. |
+| `date` | TEXT | Original post time (UTC). |
+| `edit_date` | TEXT | Last edit time, or NULL if never edited. |
+| `from_uri` | TEXT | Author peer URI (channel peer for anonymous admins; NULL for some). |
+| `post_author` | TEXT | Signature string, when the channel signs posts. |
+| `text` | TEXT | Message text (empty string for media-only/service messages). |
+| `entities_json` | TEXT | Formatting/entities (mentions, links, custom emoji). |
+| `media_kind` | TEXT | `photo`, `document`, `webpage`, `poll`, `geo`, … or NULL. |
+| `media_json` | TEXT | The media object as JSON. |
+| `fwd_json` | TEXT | Forward header (origin peer/name, channel_post, date) if forwarded. |
+| `reply_to_msg_id` | INTEGER | Message this replies to. |
+| `reply_to_top_id` | INTEGER | Thread root (comment threads / forum topics). |
+| `grouped_id` | INTEGER | Album group id (media groups share one). |
+| `via_bot_id` | INTEGER | Inline bot the message was sent via. |
+| `is_service` | INTEGER | 1 for service messages (joins, pins, title changes, …). |
+| `action_json` | TEXT | The service action object, when `is_service=1`. |
+| `content_hash` | TEXT | Hash of text+media; a change triggers a new `message_revisions` row. |
+| `deleted_at` | TEXT | Set when a deletion is observed via `update`/`empty` evidence (see `message_tombstones`); NULL otherwise. |
+| `source_raw_id` | INTEGER | Provenance. |
+| `first_seen` / `last_seen` | TEXT | Bounds of observation. |
+
+Unique index on `(channel_id, msg_id)`.
+
+### `media` — downloaded files (Phase 2)
+
+Content-addressed by SHA-256; deduped across messages.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `sha256` | TEXT PK | File hash (dedup key). |
+| `message_uri` | TEXT | Message the file came from. |
+| `kind` | TEXT | `photo` (server-re-encoded) or `document` (byte-exact). |
+| `mime_type` | TEXT | MIME type (documents). |
+| `size` | INTEGER | Byte size. |
+| `file_name` | TEXT | Original filename (documents). |
+| `attributes_json` | TEXT | Video/audio/sticker attributes. |
+| `path` | TEXT | Where the file was written on disk. |
+| `downloaded_at` | TEXT | Download time. |
+| `exif_json` | TEXT | Extracted EXIF/metadata (documents). |
+
+## History (append-only)
+
+### `channel_snapshots` — the channel over time
+
+One row per observation; diff them to see subscriber growth, renames, etc.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `id` | INTEGER PK | Row id. |
+| `channel_id` | INTEGER | Channel. |
+| `observed_at` | TEXT | Snapshot time. |
+| `participants_count` | INTEGER | Subscriber/member count then. |
+| `online_count` | INTEGER | Online count then, when available. |
+| `title` / `username` | TEXT | Title/username then (catches renames). |
+| `about_hash` | TEXT | Hash of the description (detects about-text changes cheaply). |
+| `source_raw_id` | INTEGER | Provenance. |
+
+### `message_revisions` — edit history
+
+Append-only; one row per observed version of a message (including the first).
+A new row is written whenever `content_hash` changes.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `id` | INTEGER PK | Row id. |
+| `message_uri` | TEXT | The message. |
+| `observed_at` | TEXT | When this version was seen. |
+| `edit_date` | TEXT | Telegram's edit timestamp for this version. |
+| `content_hash` | TEXT | Hash of this version. |
+| `text` | TEXT | Text of this version. |
+| `entities_json` / `media_json` | TEXT | Entities/media of this version. |
+| `source_raw_id` | INTEGER | Provenance. |
+
+> Telegram serves only the *current* version of a message; edit history exists
+> **only** because paperboy snapshots each version it observes. Versions posted
+> before you first collected are not recoverable.
+
+### `message_metrics` — counter time series
+
+Append-only; views/forwards/replies/reactions per observation. These counters
+carry no `pts`, so they can only be captured by snapshotting.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `id` | INTEGER PK | Row id. |
+| `message_uri` | TEXT | The message. |
+| `observed_at` | TEXT | Observation time. |
+| `views` | INTEGER | View count then. |
+| `forwards` | INTEGER | Forward count then. |
+| `replies` | INTEGER | Comment/reply count then. |
+| `reactions_json` | TEXT | Reaction tallies then. |
+
+### `message_tombstones` — deletions
+
+Records that a message id no longer exists, ranked by how sure we are. No FK to
+`messages`, because a deleted id may never have been observed as a stored
+message.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `id` | INTEGER PK | Row id. |
+| `message_uri` | TEXT | The (now-deleted) message URI. |
+| `observed_at` | TEXT | When the deletion was detected. |
+| `evidence` | TEXT | One of: **`update`** (a live delete event — unambiguous), **`empty`** (`messageEmpty` returned for an id inside a verified-complete range — strong), **`gap`** (id never seen; may be a hidden/service message — weak). `messages.deleted_at` is set only for `update`/`empty`. |
+
+## Graph
+
+### `edges` — triple-shaped relationships
+
+`(subject) —predicate→ (object)`, each with provenance. Ready for GraphML/RDF
+export.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `id` | INTEGER PK | Row id. |
+| `subject_uri` | TEXT | Source entity URI. |
+| `predicate` | TEXT | Relationship: `forwarded_from`, `linked_group`, `mentions`, `replied_to`, `member_of`, `admin_of`, `commented_on`, `recommended_with`, `invited_via`, `gifted_to`. |
+| `object_uri` | TEXT | Target entity URI. |
+| `observed_at` | TEXT | When the edge was observed. |
+| `tier` | TEXT | Visibility tier. |
+| `source_raw_id` | INTEGER | Provenance. |
+| `evidence_json` | TEXT | Optional supporting detail (e.g. the message the edge came from). |
+
+## Sync & operations
+
+### `sync_state` — resume cursors
+
+| Column | Type | Meaning |
+|---|---|---|
+| `scope` | TEXT | Namespace (e.g. `channel`, `history`). |
+| `key` | TEXT | Key within scope (usually a channel id). |
+| `value_json` | TEXT | Cursor value — notably the channel `pts` for incremental sync, and phase offsets. |
+
+Primary key `(scope, key)`.
+
+### `sync_ranges` — verified-complete message-id ranges
+
+Contiguous `[lo, hi]` id ranges known to be fully fetched for a channel. Gaps
+between ranges are candidates for deletion probing.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `id` | INTEGER PK | Row id. |
+| `channel_id` | INTEGER | Channel. |
+| `lo` / `hi` | INTEGER | Inclusive id bounds of a verified-complete run. |
+
+### `flood_log` — rate-limit cooldowns
+
+Persisted `FLOOD_WAIT` cooldowns so a restart doesn't immediately re-trip the
+same wall.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `id` | INTEGER PK | Row id. |
+| `method` | TEXT | The RPC method that was flooded. |
+| `until` | TEXT | Cooldown expiry (UTC). |
+| `seconds` | INTEGER | The wait Telegram asked for. |
+| `recorded_at` | TEXT | When recorded. |
+
+### `run_events` — per-phase bookkeeping
+
+One row per collector phase per run: completion, skip, phase-stop, hard-stop,
+with detail — the audit trail of what happened during a `collect`.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `id` | INTEGER PK | Row id. |
+| `observed_at` | TEXT | When. |
+| `channel_id` | INTEGER | Channel (NULL if the channel phase itself stopped early). |
+| `phase` | TEXT | Collector name (`channel`, `history`, …). |
+| `kind` | TEXT | `complete`, `skip`, `phase_stop`, `hard_stop`. |
+| `detail_json` | TEXT | Counts, or the error that stopped the phase. |
+
+### `custody_log` — chain of custody
+
+SHA-256 of every file paperboy writes to disk, for forensic integrity.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `id` | INTEGER PK | Row id. |
+| `path` | TEXT | File path. |
+| `sha256` | TEXT | Hash at write time. |
+| `recorded_at` | TEXT | When. |
+| `source_message_uri` | TEXT | Message the file came from, if any. |
+
+## Full-text search
+
+### `messages_fts` — FTS5 index over message text
+
+An external-content FTS5 virtual table over `messages.text`, kept in sync by
+triggers on insert/update/delete. Datasette auto-detects it and wires a search
+box onto `messages`. Query it directly:
+
+```sql
+SELECT m.msg_id, m.text
+FROM messages_fts f JOIN messages m ON m.rowid = f.rowid
+WHERE messages_fts MATCH 'your query';
+```
+
+The `messages_fts_data` / `messages_fts_idx` / `messages_fts_docsize` /
+`messages_fts_config` tables are FTS5's internal shadow tables — ignore them.
+
+## Meta
+
+### `schema_migrations`
+
+Tracks which migration files have been applied (`name` per applied migration),
+so `Store.open` only runs new ones. Internal; not for querying.

--- a/docs/features/collect-channel.md
+++ b/docs/features/collect-channel.md
@@ -271,3 +271,105 @@ All three are fixed in `fix: match Telethon's real PascalCase TL
 discriminators, not lowercase`; the full local suite (115 tests, ruff,
 pyright) stayed green throughout, and every scenario above was re-run
 against live Telegram after the fix to confirm it.
+
+## VALIDATE-phase findings (`feat/core-fixes`, second pass)
+
+Two more rounds of bugs surfaced after the transcript above, none of them
+caught by the (still-green) unit suite because every existing `collect`/
+`doctor` test monkeypatches `composition.build_gateway` — no test exercised
+the real credential-resolution or the real recipe-level exception handling.
+
+### Correctness-review fixes (`fix: correctness-review findings — SkipAndRecord, history guards, handler redaction`)
+
+1. **`SkipAndRecord` propagated uncaught out of `collect_channel`.**
+   `Budget.call` already classified `CHAT_ADMIN_REQUIRED`/`ChannelPrivateError`/
+   etc. into `SkipAndRecord` (confirmed live against `@durov` above via a
+   direct `Budget.call`, item 4) — but `recipes.collect_channel`'s `except`
+   clauses only listed `PhaseStop`/`HardStop`. Collecting any
+   private/inaccessible channel crashed the whole run instead of skipping
+   that phase and continuing. Fixed by adding a `except SkipAndRecord`
+   branch that records a `run_events(kind='skip')` row and marks the phase
+   `stopped="skip"`, matching spec §8.
+2. **`HistoryCollector.collect()`/`catch_up()` raised a bare
+   `AssertionError`** when `ctx.input_channel`/`channel_id` weren't set —
+   which happens whenever `channel` stops early (e.g. finding #1's
+   `SkipAndRecord`, or a long-`FLOOD_WAIT` `PhaseStop`) but `history` still
+   runs next in the same pass. Fixed by raising a handled `PhaseStop`
+   instead.
+3. **`RedactionFilter` was attached to the `paperboy` logger, not its
+   handlers.** The app logs exclusively through child loggers
+   (`paperboy.cli`, the `log` threaded into recipes/collectors);
+   `Logger.callHandlers` never re-checks an ancestor logger's own filters
+   for a record bubbling up from a child, so secrets logged through any
+   child logger reached the log file unmasked. Fixed by attaching one
+   shared `RedactionFilter` instance to each handler instead.
+4. **`Budget._record_flood` wrote spurious `flood_log` rows for transient
+   network errors.** `ConnectionError`/`TimeoutError`/`OSError` classify as
+   `Disposition.RETRY` too, but carry no `.seconds`; `getattr(exc,
+   "seconds", 0)` silently fell back to 0, writing a `(seconds=0)` row into
+   `flood_log` on every ordinary transient-network retry. Fixed by only
+   recording when `seconds > 0`.
+
+Re-validated without live Telegram (this session's sandbox denied
+keychain/credential access — see below): a script written independently of
+the implementer's own smoke test drives finding #1 end-to-end through the
+*real* `ChannelCollector`+`HistoryCollector` (not stub collectors), with a
+genuine `telethon.errors.ChatAdminRequiredError` routed through a real
+`Budget` instance — confirming `channel` is marked `stopped="skip"` and
+`history` (which runs next by default) hits guard #2 and is marked
+`stopped="phase_stop"`, never an uncaught exception. Findings #3 and #4 were
+re-confirmed directly: a secret registered via `register_secret` and logged
+through `logging.getLogger("paperboy.cli")` (and a grandchild logger) comes
+back masked in the file handler's JSON output; `ConnectionError`/
+`TimeoutError`/`OSError` retries leave `flood_log` empty while a genuine
+`telethon.errors.FloodWaitError` (not the `FakeFlood` test double) still
+records normally. Full transcript in the DoD report for this validation
+pass.
+
+Also included in `feat/core-fixes`: `fix: reject --phases history without
+channel instead of crashing` — `--phases history` alone now exits 1 with an
+actionable message from `cli.py`, before any RPC/doctor/store setup runs,
+instead of reaching `HistoryCollector`'s (now-fixed) guard. Re-confirmed via
+the real CLI in this validation pass (see the DoD report).
+
+### Missing-credentials failure mode (found and fixed during VALIDATE)
+
+`doctor`, `collect`, and `auth` all reach `composition.build_client`, which
+raises `app.ConfigError` — a deliberately actionable exception ("No api_id
+configured for profile ...: set PAPERBOY_API_ID or run ...") — when no
+`api_id`/`api_hash` is configured for the profile. Nothing in `cli.py`
+caught it: it reached the user as a raw Rich-rendered Python traceback
+instead of `ConfigError`'s own message. No test caught this either, for the
+same reason as the four findings above — every `collect`/`doctor` test
+monkeypatches `build_gateway` entirely, bypassing credential resolution.
+
+Fixed in `cli.py`: a `_run_async_or_exit` helper (used by `doctor`/
+`collect`) and a direct `try/except` in `auth` now catch `ConfigError` and
+exit 1 with its message, no traceback. Three new regression tests
+(`test_doctor_missing_credentials_exits_cleanly`,
+`test_collect_missing_credentials_exits_cleanly`,
+`test_auth_missing_credentials_exits_cleanly`) monkeypatch
+`build_gateway`/`build_client` to raise `ConfigError` and assert a clean
+exit + no `"Traceback"` in stdout. Re-confirmed live against the real CLI
+with a profile that genuinely has no stored credentials (`doctor`,
+`collect`, and `auth` each now print the actionable message and exit 1) —
+transcript in the DoD report.
+
+## Live-Telegram scenarios not re-run in this validation pass
+
+This VALIDATE session ran in a sandbox where keychain/credential access was
+denied by the harness's own permission policy (a deliberate safety boundary
+against an autonomous agent placing unsupervised live calls against a real
+Telegram account) — so the live-network portions of the DoD checklist
+(`CHAT_ADMIN_REQUIRED` skip via a real `paperboy collect` run against a
+genuinely inaccessible channel, a real `FLOOD_WAIT` sleep against Telegram,
+Ctrl-C-resume against live network, `doctor`-FAIL-blocks-`collect` against a
+real non-compliant account) were not re-executed here. They were already
+demonstrated live in the transcript above, prior to the fixes in this
+section; the specific defect finding #1 fixes (`SkipAndRecord` crashing
+`collect_channel`) was never actually exercised end-to-end live even in that
+earlier pass — the "CHAT_ADMIN_REQUIRED" item there drove `Budget.call`
+directly, not the full `collect_channel` recipe. A live confirmation of
+finding #1 (`paperboy collect <a private/no-admin channel> --unsafe` no
+longer crashing) is recommended as a follow-up by whoever next has
+interactive keychain access — see the DoD report for the exact command.

--- a/docs/features/collect-channel.md
+++ b/docs/features/collect-channel.md
@@ -1,0 +1,273 @@
+# Feature: `collect-channel`
+
+**Status:** shipped (Phase 1 / core, Tasks 1–17). **Spec:**
+`docs/superpowers/specs/2026-08-20-paperboy-design.md` §4–§10. **Plan:**
+`docs/superpowers/plans/2026-08-20-paperboy-core.md`.
+
+## Purpose
+
+`paperboy collect <target>` archives a Telegram channel or supergroup's
+metadata and full message history — with edit revisions, deletion
+tombstones, and counter time series — into one local SQLite database,
+read-only and passively (no join, no send/react/vote), behind a budget gate
+that paces every RPC and classifies every error per spec §8.
+
+## Inputs
+
+- `TARGET`: `@name`, `t.me/name`, `t.me/name/123`, or a bare handle
+  (`targets.py`). v1 acts on channel-like targets only (invite hashes and
+  numeric peer ids parse but aren't resolvable yet — see Known limitations).
+- `--profile`: selects the session/database compartment (`config.profile_dir`).
+- `--phases channel,history`: restricts which collectors run (default: both).
+- `--unsafe`: skips the `doctor` preflight gate.
+- `--profile-budget` / `--max-rpc`: override `Settings` for this run.
+- Credentials: `api_hash` + session from the OS keychain (`secrets.py`);
+  `api_id` from `PAPERBOY_API_ID` or the same keychain entry
+  `scripts/store_api.py` writes.
+
+## Outputs
+
+- `<data_dir>/<profile>/paperboy.sqlite`: `channels` (+ `channel_snapshots`),
+  `peers`, `messages` (+ `message_revisions`, `message_metrics`,
+  `message_tombstones`), `edges`, `sync_state`/`sync_ranges`, `raw_records`
+  (every TL object as received, before any projection).
+- `paperboy status [TARGET]`: row counts for one channel or the whole profile.
+- `paperboy export TARGET --format jsonl --out DIR`: `channel.jsonl`,
+  `messages.jsonl` (current state + inline `revisions` array), `edges.jsonl`
+  — scrubbed of the collecting account's own messages/edges.
+
+## How it works
+
+`cli.py` → `recipes.collect_channel` runs `ChannelCollector` (resolve →
+`getFullChannel` → upsert channel + snapshot + `linked_group` edge → seed
+`pts` → upsert peers → identify `self`), then `HistoryCollector`: pages
+`getHistory` newest→oldest into `sync_ranges`, probes every id in the swept
+span that `getHistory` didn't return via `getMessages` (chunks of ≤200),
+tombstones any `messageEmpty` result (`evidence="empty"`), then immediately
+runs `catch_up()` (`updates.getChannelDifference` from the stored `pts`) so
+the channel's sync state is current as of *now*. Every Telegram RPC goes
+through `Budget.call` (per-method pacing, persisted flood cooldowns, a
+per-run cap) — no collector or gateway method calls Telethon directly.
+
+## Edge cases handled
+
+- **Interrupted backfill**: a per-page `sync_state('history', ...)`
+  `offset_id` cursor means Ctrl-C mid-run loses at most one page; a re-run
+  resumes from the cursor rather than restarting (verified live, below).
+- **Deleted/never-existed messages**: an id inside the swept `[min, max]`
+  span that `getHistory` never returned is probed via `getMessages`; a
+  `messageEmpty` result gets a tombstone (`evidence="empty"`); a `pts`
+  catch-up delete event gets `evidence="update"` (spec §7's ranking).
+  `deleted_at` is set for both, never for a plain `gap`.
+- **Edited messages**: a changed `content_hash` appends a
+  `message_revisions` row and updates current state; identical content only
+  advances `last_seen`.
+- **Multi-username channels/peers** (Fragment-purchased extra handles):
+  Telegram reports the legacy `username` field as `null` and lists every
+  handle in `usernames[]` instead; `ids.primary_username` falls back to the
+  `editable: true` entry. Found live against `@durov` (6 usernames).
+- **`CHAT_ADMIN_REQUIRED`**: classified `SkipAndRecord`; confirmed live
+  against `@durov`'s admin list (below).
+- **Doctor-blocked account**: `collect` refuses to run (exit 1) unless
+  `--unsafe`; confirmed live (below).
+
+## Known limitations (v1 core scope)
+
+- `resolve()` only implements `contacts.resolveUsername` — invite-hash and
+  bare numeric-id targets parse (`Target.is_channel_like`) but aren't
+  resolvable yet; only `@name`/`t.me/name` targets work end to end.
+- A backfill resumed after an interruption only marks the *resumed* span
+  `[1, cursor_at_interruption]` as a verified `sync_range` — the portion
+  collected *before* the interruption isn't retroactively gap-probed by that
+  run. No data is lost or wrong; that upper span just isn't re-verified
+  until something (a future `watch`/audit pass) revisits it explicitly.
+- `--join` is accepted but inert — v1 core never joins anything (by design;
+  channel/history are passive-only per the Global Constraints).
+- A real `FLOOD_WAIT` sleep-and-retry is exercised only in `tests/test_budget.py`
+  (`FakeFlood`), not in the live smoke below — deliberately: inducing a real
+  one against Telegram means abusive request volume, which contradicts the
+  tool's own pacing/opsec purpose. `CHAT_ADMIN_REQUIRED` classification
+  *is* confirmed against a real Telegram error (below), exercising the same
+  `Budget.call` → `classify()` path.
+
+## Definition-of-Done smoke transcript (2026-08-21, profile `default`)
+
+Research account already in the macOS Keychain (`service=paperboy,
+profile=default`); read-only throughout, nothing joined, nothing sent.
+
+### 1. `doctor` — FAIL blocks `collect`
+
+```
+$ paperboy doctor --profile default
+                      paperboy doctor — profile 'default'
+┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ check            ┃ status ┃ detail                                           ┃
+┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ proxy            │ fail   │ require_proxy is set but no proxy is configured  │
+│ session_age      │ fail   │ session is 0.1 days old, below                   │
+│                  │        │ min_session_age_days=7                          │
+│ two_factor_auth  │ fail   │ no 2FA password set                              │
+│ privacy_phone    │ ok     │ phone privacy is restricted                      │
+│ privacy_lastseen │ fail   │ lastseen privacy is Everyone (AllowAll)          │
+│ privacy_photo    │ fail   │ photo privacy is Everyone (AllowAll)             │
+│ minimal_profile  │ ok     │ self profile is minimal                         │
+└──────────────────┴────────┴──────────────────────────────────────────────────┘
+BLOCKED: collect refuses to run without --unsafe.
+$ echo $?
+1
+```
+
+```
+$ paperboy collect @durov --profile default --phases channel
+doctor preflight failed — refusing to collect. Run `paperboy doctor` for
+details, or pass --unsafe to override.
+$ echo $?
+1
+```
+
+(Every check here is real: this is a genuinely fresh research account —
+0.1 days old, no proxy configured in this sandbox, no 2FA yet. A production
+investigation account should clear all of these before real use per
+`docs/opsec.md`; `--unsafe` below is a deliberate, scoped override for this
+smoke test only.)
+
+### 2. `collect` un-joined against a live public channel
+
+```
+$ paperboy collect @durov --profile default --phases channel,history --unsafe
+                                 collect @durov
+┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
+┃ phase   ┃ counts                                                   ┃ stopped ┃
+┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
+│ channel │ {'channels': 1, 'peers': 2}                              │ -       │
+│ history │ {'messages': 476, 'revisions': 476, 'tombstones': 67,    │ -       │
+│         │ 'edges': 1}                                              │         │
+└─────────┴──────────────────────────────────────────────────────────┴─────────┘
+
+$ paperboy status @durov --profile default
+  paperboy status — @durov
+┏━━━━━━━━━━━━┳━━━━━━━┓
+┃ metric     ┃ count ┃
+┡━━━━━━━━━━━━╇━━━━━━━┩
+│ messages   │ 476   │
+│ revisions  │ 476   │
+│ tombstones │ 67    │
+└────────────┴───────┘
+```
+
+`@durov`'s username resolved via `contacts.resolveUsername` un-joined
+(spec §13.2/.7 confirmed on a real account, not just the Phase-0 spike);
+476 messages backfilled with edit revisions and 67 gap-probed tombstones,
+1 `forwarded_from` edge.
+
+### 3. Interrupt mid-backfill (Ctrl-C) and resume
+
+Against `@nytimes` (a larger channel, for a wider interruption window):
+
+```
+$ paperboy collect @nytimes --profile default --phases channel,history --unsafe &
+[running...]
+$ # after ~5s, sent SIGINT (Ctrl-C) mid-backfill
+```
+
+State at the moment of interruption:
+
+```
+messages: 1500
+sync_state: history/1606432449 -> {"offset_id": 2087}
+min/max msg_id stored: 2087 .. 3616
+```
+
+Re-run, same command:
+
+```
+$ paperboy collect @nytimes --profile default --phases channel,history --unsafe
+                                collect @nytimes
+┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
+┃ phase   ┃ counts                                                   ┃ stopped ┃
+┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
+│ channel │ {'channels': 1, 'peers': 1}                              │ -       │
+│ history │ {'messages': 2043, 'revisions': 2043, 'tombstones': 43,  │ -       │
+│         │ 'edges': 0}                                              │         │
+└─────────┴──────────────────────────────────────────────────────────┴─────────┘
+```
+
+Resumed from `offset_id=2087` (not from 0): 1500 (pre-interrupt) + 2043
+(resumed) = 3543 total messages, confirmed via `select count(*) from
+messages` — no re-fetch of the already-collected span, no duplicates
+(upserts are idempotent by `uri`).
+
+### 4. `CHAT_ADMIN_REQUIRED` classified and skipped, not a crash
+
+A direct `Budget.call` around `channels.getParticipants(filter=Admins)` on
+`@durov` (a broadcast channel, and this account is not its admin):
+
+```
+CONFIRMED: Budget.call classified the real CHAT_ADMIN_REQUIRED error as
+SkipAndRecord: Chat admin privileges are required to do that in the
+specified chat [...] (caused by GetParticipantsRequest)
+```
+
+`classify()` mapped Telethon's real `ChatAdminRequiredError` to
+`Disposition.SKIP`, and `Budget.call` raised `SkipAndRecord` rather than
+propagating the raw RPC error — exactly spec §8's "skip-and-record" path,
+confirmed against a genuine Telegram response, not a test double.
+
+### 5. `export --format jsonl`
+
+```
+$ paperboy export @durov --format jsonl --out /tmp/paperboy_smoke_export --profile default
+    export @durov -> /tmp/paperboy_smoke_export
+┏━━━━━━━━━━━━━━━━┳━━━━━━┓
+┃ file           ┃ rows ┃
+┡━━━━━━━━━━━━━━━━╇━━━━━━┩
+│ channel.jsonl  │ 1    │
+│ messages.jsonl │ 476  │
+│ edges.jsonl    │ 1    │
+└────────────────┴──────┘
+$ wc -l /tmp/paperboy_smoke_export/*.jsonl
+       1 channel.jsonl
+       1 edges.jsonl
+     476 messages.jsonl
+```
+
+Row counts match `status` exactly. The first exported message (id 1, the
+channel-creation service message) correctly carries `"is_service": 1` and
+an `action_json` of `MessageActionChannelCreate` — confirming the
+PascalCase-discriminator fix (below) round-trips correctly end to end.
+
+## Bugs found and fixed by this smoke test (no-shed)
+
+The unit suite (115 tests, `FakeGateway` fixtures I authored myself) was
+green throughout implementation but never caught these — they only show up
+against real Telethon objects:
+
+1. **Wrong TL discriminator casing.** Telethon's `to_dict()` uses the
+   PascalCase Python class name (`"Channel"`, `"PeerUser"`,
+   `"MessageEmpty"`, `"ChannelDifferenceTooLong"`, ...) as the `"_"` key —
+   not the lowercase TL constructor name every fixture and discriminator
+   check in this codebase assumed. `@durov`'s channel object came back as
+   `{"_": "Channel", ...}`; `_pick_channel`'s `.startswith("channel")`
+   check never matched, and `ChannelCollector.collect` raised. Fixed by
+   matching case-insensitively everywhere a discriminator is checked
+   (`store/peers.py`, `store/messages.py`, `ids.peer_ref_uri`,
+   `collectors/channel.py`, `collectors/history.py`, `doctor.py`).
+2. **Multi-username accounts store a null username.** `@durov`'s channel
+   has six usernames (a Fragment-era feature); Telegram reports the legacy
+   `username` field as `null` for it and lists every handle in
+   `usernames[]` instead. `channels.username`/`peers.username` came back
+   `NULL`, breaking `status`/`export`'s lookup-by-username entirely. Fixed
+   via `ids.primary_username`, which falls back to the `editable: true`
+   entry in `usernames[]`.
+3. **`NameError` in `TelethonGateway.get_channel_difference`.** `cast(TLObject, ...)`
+   referenced a name only imported under `TYPE_CHECKING` — invisible to
+   pyright (annotations are lazy strings under `from __future__ import
+   annotations`, so it never actually resolves `TLObject` at check time)
+   but a real `NameError` the moment `cast()`'s first argument is
+   evaluated at runtime. Fixed with a real (non-guarded) local import,
+   matching every other method in the file.
+
+All three are fixed in `fix: match Telethon's real PascalCase TL
+discriminators, not lowercase`; the full local suite (115 tests, ruff,
+pyright) stayed green throughout, and every scenario above was re-run
+against live Telegram after the fix to confirm it.

--- a/docs/opsec.md
+++ b/docs/opsec.md
@@ -58,8 +58,8 @@ request. You **can** be:
 - **Never open collected documents on your working machine.** Office files,
   PDFs, and HTML can fetch remote resources **when opened**, leaking your IP and
   timing to whoever planted them (issue #1). Open them offline or in a sandbox
-  / air-gapped viewer with external content disabled. This is tapedeck
-  territory — keep the corpus offline.
+  / air-gapped viewer with external content disabled — keep the corpus
+  offline.
 - The tool stores URLs and Telegram's own server-side previews but **never
   fetches** a URL found inside a message.
 - If you encounter CSAM or other illegal material: do **not** download it;

--- a/docs/superpowers/specs/2026-08-20-paperboy-design.md
+++ b/docs/superpowers/specs/2026-08-20-paperboy-design.md
@@ -22,7 +22,7 @@ doctor; the remaining collectors are Phase 2.
 
 **vNext (designed for, not built):** `dossier-user`, `lookup phone`,
 hashtag/geo story search, multi-seed network maps, watchlists, third-party
-indexer enrichment, tapedeck import adapter.
+indexer enrichment.
 
 **Out of scope permanently:** anything that acts on Telegram (send, react,
 vote, invite, add members), `contacts.getLocated`, phone *enumeration*,
@@ -270,5 +270,5 @@ onset for sequential `getFullUser` at 1 req/s.
 - Canary URLs and phone-home documents: document the threat, enforce the
   allow-list, add a "open collected documents offline/sandboxed" note to
   `docs/opsec.md`, consider a `--strip-remote-content` pass for office files.
-- tapedeck import adapter.
+- Datasette/analytics export interop (generic).
 - Third-party indexer enrichment (tgstat/telemetr) — research not completed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "httpx>=0.27",
   "structlog>=24",
   "rich>=13",
+  "pysocks>=1.7",
 ]
 
 [project.scripts]

--- a/src/paperboy/app.py
+++ b/src/paperboy/app.py
@@ -1,0 +1,127 @@
+"""Composition root: wires `Settings` + `SecretStore` into a live client,
+`Gateway`, `Store`, and `Budget`. `cli.py` is a thin Typer layer over this —
+every real object gets built here so tests can monkeypatch one seam
+(`build_gateway`) instead of reaching into Telethon.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import keyring
+
+from paperboy.budget import Budget
+from paperboy.config import profile_dir
+from paperboy.gateway import TelethonGateway
+from paperboy.logging_setup import register_secret
+from paperboy.secrets import SERVICE, KeyringSecrets
+from paperboy.store.db import Store
+
+if TYPE_CHECKING:
+    from telethon import TelegramClient
+
+    from paperboy.config import Settings
+    from paperboy.gateway import Gateway
+    from paperboy.secrets import SecretStore
+
+
+class ConfigError(Exception):
+    """Missing credentials/config the operator must fix (not a bug to catch and hide)."""
+
+
+def resolve_api_id(settings: Settings, profile: str) -> int:
+    """`api_id` is not a secret (spec §9) — env/config is the documented
+    source (`PAPERBOY_API_ID`). As a convenience for operators who already
+    ran `scripts/store_api.py` (Task 0's bootstrap helper), fall back to the
+    same keychain entry that script wrote, so `--profile` alone is enough to
+    pick up a previously stored api_id without also exporting the env var.
+    """
+    if settings.api_id is not None:
+        return settings.api_id
+    stored = keyring.get_password(SERVICE, f"{profile}:api_id")
+    if stored is None:
+        raise ConfigError(
+            f"No api_id configured for profile {profile!r}: set PAPERBOY_API_ID or run "
+            f"`uv run python scripts/store_api.py --profile {profile}`."
+        )
+    return int(stored)
+
+
+def build_secrets(profile: str) -> SecretStore:
+    return KeyringSecrets(profile)
+
+
+def _parse_proxy(proxy: str) -> tuple:
+    """Parse `socks5://[user:pass@]host:port` into a PySocks-style tuple.
+
+    `mtproxy://` is recognized but not yet implemented — it needs a distinct
+    Telethon connection class, not just a `proxy=` tuple, and that wiring
+    hasn't been built/verified against the installed layer.
+    """
+    if proxy.startswith("mtproxy://"):
+        raise NotImplementedError(
+            "mtproxy:// proxies are not yet implemented; use socks5:// for now."
+        )
+    if not proxy.startswith("socks5://"):
+        raise ValueError(f"unsupported proxy scheme: {proxy!r}")
+    import socks
+
+    rest = proxy.removeprefix("socks5://")
+    auth, _, hostport = rest.rpartition("@") if "@" in rest else ("", "", rest)
+    host, _, port_s = hostport.partition(":")
+    port = int(port_s) if port_s else 1080
+    if auth:
+        user, _, password = auth.partition(":")
+        return (socks.SOCKS5, host, port, True, user, password)
+    return (socks.SOCKS5, host, port, True)
+
+
+def build_client(settings: Settings, secrets: SecretStore, profile: str) -> TelegramClient:
+    from telethon import TelegramClient
+    from telethon.sessions import StringSession
+
+    api_id = resolve_api_id(settings, profile)
+    api_hash = secrets.get_api_hash()
+    if api_hash is None:
+        raise ConfigError(
+            f"No api_hash stored for profile {profile!r}; run "
+            f"`uv run python scripts/store_api.py --profile {profile}`."
+        )
+    register_secret(api_hash)
+    session = secrets.get_session() or ""
+    if session:
+        register_secret(session)
+
+    client_kwargs: dict = {
+        "device_model": settings.device.device_model,
+        "system_version": settings.device.system_version,
+        "app_version": settings.device.app_version,
+        "lang_code": settings.device.lang_code,
+        # paperboy's own Budget owns all flood pacing/persistence (ADR-0003);
+        # a nonzero threshold here would let Telethon silently sleep through
+        # a FLOOD_WAIT before Budget.call ever sees the exception to record.
+        "flood_sleep_threshold": 0,
+    }
+    if settings.proxy:
+        client_kwargs["proxy"] = _parse_proxy(settings.proxy)
+
+    return TelegramClient(StringSession(session), api_id, api_hash, **client_kwargs)
+
+
+async def build_gateway(
+    settings: Settings, secrets: SecretStore, profile: str, store: Store
+) -> Gateway:
+    """Build a connected `TelethonGateway` — the one seam `cli.py` calls to
+    get "the thing that talks to Telegram", so tests substitute this single
+    async function with a stub returning a `FakeGateway` and never touch
+    Telethon, the keychain, or the network.
+    """
+    client = build_client(settings, secrets, profile)
+    budget = Budget(settings, store)
+    await client.connect()
+    return TelethonGateway(client, budget)
+
+
+def build_store(settings: Settings, profile: str) -> Store:
+    path = profile_dir(settings, profile) / "paperboy.sqlite"
+    return Store.open(path)

--- a/src/paperboy/budget.py
+++ b/src/paperboy/budget.py
@@ -1,0 +1,176 @@
+"""The `Budget` gate: every Telegram RPC passes through here (ADR-0003).
+
+Enforces, in order, on every call: a per-run RPC cap, a per-method minimum
+call interval, and any persisted flood cooldown for that method — then runs
+the call and classifies failures per spec §8. A short `FLOOD_WAIT` is slept
+through and retried once; everything else becomes one of `SkipAndRecord`,
+`PhaseStop`, or `HardStop` so the recipe layer can react without a collector
+ever having to know a Telethon error class.
+"""
+
+from __future__ import annotations
+
+import inspect
+import time as time_module
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import Protocol, TypeVar
+
+from paperboy.config import Settings
+from paperboy.errors import Disposition, classify
+from paperboy.ids import to_iso
+from paperboy.store.db import Store
+
+T = TypeVar("T")
+
+# Conservative default pacing between two calls to the *same* method, absent
+# any other guidance. Spec §13.10 (sequential `getFullUser` flood onset) is
+# unverified at the time of writing; 1 req/s is a safe starting point.
+DEFAULT_MIN_INTERVAL_SECONDS = 1.0
+
+
+class HardStop(Exception):
+    """The run must end now (spec §8: PEER_FLOOD, FROZEN_METHOD_INVALID, ...)."""
+
+
+class PhaseStop(Exception):
+    """The current phase must stop; other phases may still run (long FLOOD_WAIT)."""
+
+
+class SkipAndRecord(Exception):
+    """This one RPC is skipped (e.g. CHAT_ADMIN_REQUIRED); the phase continues."""
+
+
+class _Clock(Protocol):
+    def time(self) -> float: ...
+
+
+class _RealClock:
+    def time(self) -> float:
+        return time_module.time()
+
+
+async def _maybe_await(value: object) -> None:
+    if inspect.isawaitable(value):
+        await value
+
+
+class Budget:
+    """Paces, throttles, and classifies every RPC made through it.
+
+    `sleeper` is injectable so tests never actually block: it may be a plain
+    sync callable (called and ignored, for tests that just want to record
+    calls) or an async one like `asyncio.sleep` (awaited) — `Budget` detects
+    which by checking whether the call returns an awaitable.
+    """
+
+    def __init__(
+        self,
+        settings: Settings,
+        store: Store,
+        *,
+        clock: _Clock | None = None,
+        sleeper: Callable[[float], object] | None = None,
+        min_interval: float = DEFAULT_MIN_INTERVAL_SECONDS,
+    ) -> None:
+        self.settings = settings
+        self.store = store
+        self._clock: _Clock = clock or _RealClock()
+        self._sleeper: Callable[[float], object] = sleeper or self._default_sleep
+        self._min_interval = min_interval
+        self._count = 0
+        self._last_call: dict[str, float] = {}
+
+    @staticmethod
+    def _default_sleep(seconds: float) -> Awaitable[None]:
+        import asyncio
+
+        return asyncio.sleep(seconds)
+
+    def _now_iso(self) -> str:
+        return to_iso(datetime.fromtimestamp(self._clock.time(), tz=UTC))
+
+    async def _sleep(self, seconds: float) -> None:
+        if seconds > 0:
+            await _maybe_await(self._sleeper(seconds))
+
+    def _record_flood(self, method: str, seconds: int) -> None:
+        until = self._clock.time() + seconds
+        self.store.conn.execute(
+            "INSERT INTO flood_log(method, until, seconds, recorded_at) VALUES (?, ?, ?, ?)",
+            (method, to_iso(datetime.fromtimestamp(until, tz=UTC)), seconds, self._now_iso()),
+        )
+
+    def _active_cooldown_seconds(self, method: str) -> float:
+        row = self.store.conn.execute(
+            "SELECT until FROM flood_log WHERE method=? ORDER BY until DESC LIMIT 1",
+            (method,),
+        ).fetchone()
+        if row is None:
+            return 0.0
+        until_dt = datetime.fromisoformat(row["until"])
+        remaining = (until_dt - datetime.fromtimestamp(self._clock.time(), tz=UTC)).total_seconds()
+        return max(0.0, remaining)
+
+    @staticmethod
+    def _to_exception(disposition: Disposition, exc: BaseException) -> Exception:
+        if disposition is Disposition.SKIP:
+            return SkipAndRecord(str(exc))
+        if disposition is Disposition.PHASE_STOP:
+            return PhaseStop(str(exc))
+        if disposition is Disposition.HARD_STOP:
+            return HardStop(str(exc))
+        # RETRY should never reach here — call() handles it before this point.
+        raise AssertionError(f"unexpected disposition for re-raise: {disposition}")
+
+    async def call(self, method: str, factory: Callable[[], Awaitable[T]]) -> T:
+        if self._count >= self.settings.max_rpc_per_run:
+            raise HardStop(
+                f"max_rpc_per_run ({self.settings.max_rpc_per_run}) reached at {method!r}"
+            )
+        self._count += 1
+
+        last = self._last_call.get(method)
+        if last is not None:
+            delta = self._clock.time() - last
+            if delta < self._min_interval:
+                await self._sleep(self._min_interval - delta)
+
+        cooldown = self._active_cooldown_seconds(method)
+        if cooldown:
+            await self._sleep(cooldown)
+
+        self._last_call[method] = self._clock.time()
+
+        try:
+            return await factory()
+        except Exception as exc:
+            threshold = self.settings.flood_sleep_threshold
+            disposition = classify(exc, threshold=threshold)
+            if disposition is Disposition.PHASE_STOP:
+                # A FLOOD_WAIT over threshold: persist the cooldown (so a
+                # later call to this method — this run or the next — waits
+                # it out via `_active_cooldown_seconds`) and stop the phase.
+                self._record_flood(method, getattr(exc, "seconds", 0))
+                raise self._to_exception(disposition, exc) from exc
+            if disposition is not Disposition.RETRY:
+                raise self._to_exception(disposition, exc) from exc
+
+            seconds = getattr(exc, "seconds", 0)
+            self._record_flood(method, seconds)
+            await self._sleep(seconds)
+            self._last_call[method] = self._clock.time()
+            try:
+                return await factory()
+            except Exception as exc2:
+                d2 = classify(exc2, threshold=threshold)
+                if d2 is Disposition.RETRY:
+                    # A second consecutive flood wait is not retried again in
+                    # the same call — treat it as a phase stop so the caller
+                    # doesn't spin. The next run will see the persisted
+                    # cooldown via `_active_cooldown_seconds`.
+                    self._record_flood(method, getattr(exc2, "seconds", 0))
+                    raise PhaseStop(str(exc2)) from exc2
+                if d2 is Disposition.PHASE_STOP:
+                    self._record_flood(method, getattr(exc2, "seconds", 0))
+                raise self._to_exception(d2, exc2) from exc2

--- a/src/paperboy/budget.py
+++ b/src/paperboy/budget.py
@@ -156,8 +156,14 @@ class Budget:
             if disposition is not Disposition.RETRY:
                 raise self._to_exception(disposition, exc) from exc
 
+            # `seconds` is only meaningful for a genuine FloodWaitError/
+            # FakeFlood retry; a transient ConnectionError/TimeoutError/OSError
+            # also classifies as RETRY but has no `.seconds`, so `getattr`
+            # falls back to 0 — guard `_record_flood` so those don't pollute
+            # `flood_log` with spurious (until=now, seconds=0) rows.
             seconds = getattr(exc, "seconds", 0)
-            self._record_flood(method, seconds)
+            if seconds > 0:
+                self._record_flood(method, seconds)
             await self._sleep(seconds)
             self._last_call[method] = self._clock.time()
             try:
@@ -169,7 +175,9 @@ class Budget:
                     # the same call — treat it as a phase stop so the caller
                     # doesn't spin. The next run will see the persisted
                     # cooldown via `_active_cooldown_seconds`.
-                    self._record_flood(method, getattr(exc2, "seconds", 0))
+                    seconds2 = getattr(exc2, "seconds", 0)
+                    if seconds2 > 0:
+                        self._record_flood(method, seconds2)
                     raise PhaseStop(str(exc2)) from exc2
                 if d2 is Disposition.PHASE_STOP:
                     self._record_flood(method, getattr(exc2, "seconds", 0))

--- a/src/paperboy/cli.py
+++ b/src/paperboy/cli.py
@@ -138,6 +138,23 @@ def collect(
     parsed_target = parse_target(target)
     secrets = composition.build_secrets(profile)
     phase_list = phases.split(",") if phases else None
+    if phase_list is not None and "history" in phase_list and "channel" not in phase_list:
+        # `channel` populates `CollectContext.input_channel`/`channel_id` (the
+        # channel's numeric id + access_hash) for every later collector in
+        # *this run* — it is per-process context, not reloaded from
+        # `channels` even if a prior run already stored that channel, since
+        # `access_hash` can rotate and isn't persisted. Selecting `history`
+        # without `channel` in the same run leaves that context unset and
+        # `HistoryCollector.collect` would crash on its own assertion;
+        # reject it here instead, before any RPC (or even doctor/store setup)
+        # runs, with a clear, actionable message.
+        console.print(
+            "[red]--phases history requires channel in the same run[/] "
+            "(channel resolves the access hash history needs — it isn't "
+            "persisted between runs). Pass --phases channel,history, or "
+            "omit --phases to run both."
+        )
+        raise typer.Exit(code=1)
 
     with composition.build_store(settings, profile) as store:
         results = asyncio.run(

--- a/src/paperboy/cli.py
+++ b/src/paperboy/cli.py
@@ -36,6 +36,20 @@ def _settings_with_overrides(profile: str, **overrides: object) -> Settings:
     return load_settings(profile, clean)
 
 
+def _run_async_or_exit[T](coro: Coroutine[Any, Any, T]) -> T:
+    """`asyncio.run(coro)`, translating a missing-credentials `ConfigError`
+    (raised by `composition.build_client`/`build_gateway` when no `api_id`/
+    `api_hash` is configured for this profile) into a clean, actionable CLI
+    exit instead of a raw traceback. Every command that reaches Telethon
+    (`doctor`, `collect`) goes through here before ever touching the network.
+    """
+    try:
+        return asyncio.run(coro)
+    except composition.ConfigError as exc:
+        console.print(f"[red]{exc}[/]")
+        raise typer.Exit(code=1) from None
+
+
 def _find_channel_id(store, username: str) -> int | None:
     row = store.conn.execute(
         "SELECT id FROM channels WHERE username = ?", (username.lstrip("@"),)
@@ -48,7 +62,11 @@ def auth(profile: str = typer.Option("default", "--profile")) -> None:
     """Interactive login: prompts for phone + code on stdin, saves the session to the Keychain."""
     settings = _settings_with_overrides(profile)
     secrets = composition.build_secrets(profile)
-    client = composition.build_client(settings, secrets, profile)
+    try:
+        client = composition.build_client(settings, secrets, profile)
+    except composition.ConfigError as exc:
+        console.print(f"[red]{exc}[/]")
+        raise typer.Exit(code=1) from None
 
     async def _run() -> None:
         # Telethon ships no return-type stubs for these — `start`/`disconnect`
@@ -78,7 +96,7 @@ def doctor(
     secrets = composition.build_secrets(profile)
 
     with composition.build_store(settings, profile) as store:
-        checks = asyncio.run(_run_doctor(settings, secrets, profile, store))
+        checks = _run_async_or_exit(_run_doctor(settings, secrets, profile, store))
 
     table = Table(title=f"paperboy doctor — profile {profile!r}")
     table.add_column("check")
@@ -157,7 +175,7 @@ def collect(
         raise typer.Exit(code=1)
 
     with composition.build_store(settings, profile) as store:
-        results = asyncio.run(
+        results = _run_async_or_exit(
             _run_collect(settings, secrets, profile, store, parsed_target, phase_list, log, unsafe)
         )
 

--- a/src/paperboy/cli.py
+++ b/src/paperboy/cli.py
@@ -1,0 +1,273 @@
+"""The `paperboy` Typer CLI — thin wrappers over `app.py` (composition root),
+`recipes.collect_channel`, `export.jsonl.export_jsonl`, and `doctor.run_doctor`.
+Every command is `asyncio.run`-based since everything underneath is async.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Coroutine
+from pathlib import Path
+from typing import Any, cast
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from paperboy import app as composition
+from paperboy.config import Settings, load_settings, profile_dir
+from paperboy.doctor import doctor_blocks, run_doctor
+from paperboy.export.jsonl import export_jsonl
+from paperboy.ids import channel_uri
+from paperboy.logging_setup import configure_logging
+from paperboy.recipes import collect_channel
+from paperboy.targets import parse_target
+
+app = typer.Typer(
+    add_completion=False,
+    help="Local, read-only Telegram channel OSINT collector. See docs/opsec.md first.",
+)
+console = Console()
+
+
+def _settings_with_overrides(profile: str, **overrides: object) -> Settings:
+    clean = {k: v for k, v in overrides.items() if v is not None}
+    return load_settings(profile, clean)
+
+
+def _find_channel_id(store, username: str) -> int | None:
+    row = store.conn.execute(
+        "SELECT id FROM channels WHERE username = ?", (username.lstrip("@"),)
+    ).fetchone()
+    return row["id"] if row else None
+
+
+@app.command()
+def auth(profile: str = typer.Option("default", "--profile")) -> None:
+    """Interactive login: prompts for phone + code on stdin, saves the session to the Keychain."""
+    settings = _settings_with_overrides(profile)
+    secrets = composition.build_secrets(profile)
+    client = composition.build_client(settings, secrets, profile)
+
+    async def _run() -> None:
+        # Telethon ships no return-type stubs for these — `start`/`disconnect`
+        # are plain `def`s that return a coroutine when (as here) an event
+        # loop is already running; verified against the installed version,
+        # not guessed. See the same rationale in gateway.py.
+        await cast(Coroutine[Any, Any, Any], client.start())  # phone + code (+ 2FA) on stdin
+        me = await client.get_me()
+        session = client.session
+        assert session is not None
+        secrets.set_session(session.save())
+        await cast(Coroutine[Any, Any, Any], client.disconnect())
+        me_id = getattr(me, "id", "unknown")
+        console.print(f"[green]Logged in[/] as id={me_id} — session saved to the Keychain.")
+
+    asyncio.run(_run())
+
+
+@app.command()
+def doctor(
+    profile: str = typer.Option("default", "--profile"),
+    strict: bool = typer.Option(False, "--strict"),
+) -> None:
+    """Opsec preflight: proxy, session age, 2FA, privacy keys, profile minimalism."""
+    settings = _settings_with_overrides(profile)
+    configure_logging(profile_dir(settings, profile) / "paperboy.log", console=False)
+    secrets = composition.build_secrets(profile)
+
+    with composition.build_store(settings, profile) as store:
+        checks = asyncio.run(_run_doctor(settings, secrets, profile, store))
+
+    table = Table(title=f"paperboy doctor — profile {profile!r}")
+    table.add_column("check")
+    table.add_column("status")
+    table.add_column("detail")
+    for c in checks:
+        if c.ok:
+            status = "[green]ok[/]"
+        elif c.severity == "fail":
+            status = "[red]fail[/]"
+        else:
+            status = "[yellow]warn[/]"
+        table.add_row(c.name, status, c.detail)
+    console.print(table)
+
+    blocked = doctor_blocks(checks)
+    if blocked:
+        console.print("[red]BLOCKED[/]: collect refuses to run without --unsafe.")
+        raise typer.Exit(code=1)
+    if strict and any(not c.ok for c in checks):
+        console.print("[yellow]--strict: a warning is present.[/]")
+        raise typer.Exit(code=1)
+    console.print("[green]PASS[/]")
+
+
+async def _run_doctor(settings, secrets, profile: str, store):
+    gateway = await composition.build_gateway(settings, secrets, profile, store)
+    return await run_doctor(gateway, settings)
+
+
+@app.command()
+def collect(
+    target: str,
+    profile: str = typer.Option("default", "--profile"),
+    phases: str = typer.Option(None, "--phases", help="Comma-separated: channel,history"),
+    join: bool = typer.Option(False, "--join", help="Not implemented in core v1 (Phase 2)."),
+    profile_budget: int = typer.Option(None, "--profile-budget"),
+    max_rpc: int = typer.Option(None, "--max-rpc"),
+    unsafe: bool = typer.Option(False, "--unsafe", help="Skip the doctor preflight gate."),
+) -> None:
+    """Collect channel metadata + full message history for TARGET."""
+    if join:
+        console.print(
+            "[yellow]--join is accepted but not implemented in core v1 — "
+            "paperboy never joins.[/]"
+        )
+
+    overrides: dict[str, object] = {}
+    if profile_budget is not None:
+        overrides["profile_budget"] = profile_budget
+    if max_rpc is not None:
+        overrides["max_rpc_per_run"] = max_rpc
+    settings = load_settings(profile, overrides)
+
+    configure_logging(profile_dir(settings, profile) / "paperboy.log", console=True)
+    log = logging.getLogger("paperboy.cli")
+    parsed_target = parse_target(target)
+    secrets = composition.build_secrets(profile)
+    phase_list = phases.split(",") if phases else None
+
+    with composition.build_store(settings, profile) as store:
+        results = asyncio.run(
+            _run_collect(settings, secrets, profile, store, parsed_target, phase_list, log, unsafe)
+        )
+
+    table = Table(title=f"collect {target}")
+    table.add_column("phase")
+    table.add_column("counts")
+    table.add_column("stopped")
+    for r in results:
+        table.add_row(r.name, str(r.counts), r.stopped or "-")
+    console.print(table)
+
+
+async def _run_collect(settings, secrets, profile, store, target, phase_list, log, unsafe):
+    gateway = await composition.build_gateway(settings, secrets, profile, store)
+    if not unsafe:
+        checks = await run_doctor(gateway, settings)
+        if doctor_blocks(checks):
+            console.print(
+                "[red]doctor preflight failed[/] — refusing to collect. "
+                "Run `paperboy doctor` for details, or pass --unsafe to override."
+            )
+            raise typer.Exit(code=1)
+    return await collect_channel(gateway, store, settings, target, phase_list, log)
+
+
+@app.command()
+def status(
+    target: str = typer.Argument(None),
+    profile: str = typer.Option("default", "--profile"),
+) -> None:
+    """Summarize what's stored for TARGET, or the whole profile if TARGET is omitted."""
+    settings = _settings_with_overrides(profile)
+    with composition.build_store(settings, profile) as store:
+
+        def count(sql: str, params: tuple = ()) -> int:
+            return store.conn.execute(sql, params).fetchone()[0]
+
+        channel_id = None
+        if target:
+            parsed = parse_target(target)
+            channel_id = _find_channel_id(store, parsed.value)
+            if channel_id is None:
+                console.print(f"[yellow]No local data for {target!r} yet — run `collect` first.[/]")
+                raise typer.Exit(code=1)
+
+        title = (
+            f"paperboy status — {target}" if target else f"paperboy status — profile {profile!r}"
+        )
+        table = Table(title=title)
+        table.add_column("metric")
+        table.add_column("count")
+        if channel_id is not None:
+            pattern = f"tg:msg:{channel_id}/%"
+            messages_n = count("SELECT count(*) FROM messages WHERE channel_id=?", (channel_id,))
+            revisions_n = count(
+                "SELECT count(*) FROM message_revisions WHERE message_uri LIKE ?", (pattern,)
+            )
+            tombstones_n = count(
+                "SELECT count(*) FROM message_tombstones WHERE message_uri LIKE ?", (pattern,)
+            )
+            table.add_row("messages", str(messages_n))
+            table.add_row("revisions", str(revisions_n))
+            table.add_row("tombstones", str(tombstones_n))
+        else:
+            table.add_row("channels", str(count("SELECT count(*) FROM channels")))
+            table.add_row("messages", str(count("SELECT count(*) FROM messages")))
+            table.add_row("peers", str(count("SELECT count(*) FROM peers")))
+            table.add_row("edges", str(count("SELECT count(*) FROM edges")))
+        console.print(table)
+
+
+@app.command(name="export")
+def export_cmd(
+    target: str,
+    format: str = typer.Option("jsonl", "--format"),
+    out: str = typer.Option(None, "--out"),
+    profile: str = typer.Option("default", "--profile"),
+) -> None:
+    """Export TARGET's stored data. Only --format jsonl exists in core v1."""
+    if format != "jsonl":
+        console.print(
+            f"[red]--format {format!r} is Phase 2 (csv/rdf/datasette); only jsonl exists.[/]"
+        )
+        raise typer.Exit(code=1)
+
+    settings = _settings_with_overrides(profile)
+    parsed = parse_target(target)
+    with composition.build_store(settings, profile) as store:
+        channel_id = _find_channel_id(store, parsed.value)
+        if channel_id is None:
+            console.print(f"[red]No local data for {target!r}. Run `collect` first.[/]")
+            raise typer.Exit(code=1)
+        out_dir = Path(out) if out else profile_dir(settings, profile) / "export"
+        counts = export_jsonl(store, channel_uri(channel_id), out_dir)
+
+    table = Table(title=f"export {target} -> {out_dir}")
+    table.add_column("file")
+    table.add_column("rows")
+    for name, n in counts.items():
+        table.add_row(f"{name}.jsonl", str(n))
+    console.print(table)
+
+
+@app.command()
+def watch(
+    target: str,
+    profile: str = typer.Option("default", "--profile"),
+    interval: int = typer.Option(60, "--interval"),
+) -> None:
+    """Not in core v1 — Phase 2."""
+    del target, profile, interval
+    console.print("[yellow]`watch` is not implemented in core v1 (Phase 2).[/]")
+    raise typer.Exit(code=1)
+
+
+@app.command()
+def lookup(
+    kind: str = typer.Argument(..., help="Only 'phone' is planned, and it's Phase 2."),
+    value: str = typer.Argument(None),
+    profile: str = typer.Option("default", "--profile"),
+    i_understand_the_risk: bool = typer.Option(False, "--i-understand-the-risk"),
+) -> None:
+    """Not in core v1 — Phase 2, flag-gated."""
+    del kind, value, profile, i_understand_the_risk
+    console.print("[yellow]`lookup` is not implemented in core v1 (Phase 2, flag-gated).[/]")
+    raise typer.Exit(code=1)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/paperboy/collectors/__init__.py
+++ b/src/paperboy/collectors/__init__.py
@@ -1,0 +1,1 @@
+"""Collectors: `Collector.collect(ctx)` implementations run by a recipe (`recipes.py`)."""

--- a/src/paperboy/collectors/base.py
+++ b/src/paperboy/collectors/base.py
@@ -1,0 +1,45 @@
+"""The `Collector` Protocol and the mutable context every collector shares.
+
+A recipe (`recipes.py`) builds one `CollectContext` per target and threads it
+through an ordered list of collectors: `channel` populates `input_channel`/
+`channel_id`/`tier` for `history` (and later Phase 2 collectors) to consume.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from logging import Logger
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from paperboy.config import Settings
+    from paperboy.gateway import Gateway
+    from paperboy.store.db import Store
+    from paperboy.targets import Target
+
+
+@dataclass
+class CollectContext:
+    gateway: Gateway
+    store: Store
+    settings: Settings
+    target: Target
+    input_channel: dict | None
+    channel_id: int | None
+    tier: str
+    log: Logger
+
+
+@dataclass
+class CollectResult:
+    name: str
+    counts: dict[str, int] = field(default_factory=dict)
+    stopped: str | None = None
+
+
+class Collector(Protocol):
+    name: str
+
+    def applies_to(self, target: Target) -> bool: ...
+
+    async def collect(self, ctx: CollectContext) -> CollectResult: ...

--- a/src/paperboy/collectors/channel.py
+++ b/src/paperboy/collectors/channel.py
@@ -1,0 +1,88 @@
+"""The `channel` collector: resolve a target, fetch full channel metadata,
+project it, and prime `ctx` for `history` (and later Phase 2 collectors).
+"""
+
+from __future__ import annotations
+
+from paperboy.collectors.base import CollectContext, CollectResult
+from paperboy.ids import channel_uri, utc_now_iso
+from paperboy.store.channels import upsert_channel
+from paperboy.store.edges import add_edge
+from paperboy.store.peers import upsert_peer
+from paperboy.store.sync import set_state
+from paperboy.targets import Target
+
+
+def _pick_channel(chats: list[dict]) -> dict:
+    for chat in chats:
+        if chat.get("_", "").startswith("channel"):
+            return chat
+    raise ValueError("resolve() returned no channel-typed chat for a channel-like target")
+
+
+class ChannelCollector:
+    name = "channel"
+
+    def applies_to(self, target: Target) -> bool:
+        return target.is_channel_like
+
+    async def collect(self, ctx: CollectContext) -> CollectResult:
+        observed_at = utc_now_iso()
+        peer_uris: set[str] = set()
+
+        resolved = await ctx.gateway.resolve(ctx.target.value)
+        resolve_raw_id = ctx.store.add_raw(
+            resolved.get("_", "resolvedPeer"), resolved, ctx.tier, {"target": ctx.target.raw}
+        )
+        chan = _pick_channel(resolved.get("chats", []))
+        input_channel = {"channel_id": chan["id"], "access_hash": chan["access_hash"]}
+
+        full = await ctx.gateway.get_full_channel(input_channel)
+        full_raw_id = ctx.store.add_raw(
+            full.get("_", "messages.chatFull"), full, ctx.tier, {"channel_id": chan["id"]}
+        )
+        full_chat = full["full_chat"]
+        # Prefer the richer `chat` object returned alongside getFullChannel
+        # (may carry admin_rights/creator not present on the resolve() one).
+        full_chats = full.get("chats", [])
+        chan_for_channel = _pick_channel(full_chats) if full_chats else chan
+
+        channel_id = chan_for_channel["id"]
+        channel_uri_ = upsert_channel(
+            ctx.store, full_chat, chan_for_channel, full_raw_id, observed_at
+        )
+
+        set_state(ctx.store, "channel", str(channel_id), {"pts": full_chat["pts"]})
+
+        linked_chat_id = full_chat.get("linked_chat_id") or None
+        if linked_chat_id:
+            add_edge(
+                ctx.store, channel_uri_, "linked_group", channel_uri(linked_chat_id),
+                observed_at, ctx.tier, full_raw_id,
+                {"field": "linked_chat_id"},
+            )
+
+        for source_raw_id, payload in ((resolve_raw_id, resolved), (full_raw_id, full)):
+            for obj in (*payload.get("chats", []), *payload.get("users", [])):
+                uri = upsert_peer(
+                    ctx.store, obj, source_raw_id, observed_at,
+                    seen_in_chat=None, seen_in_msg=None,
+                )
+                peer_uris.add(uri)
+
+        if chan_for_channel.get("creator"):
+            ctx.tier = "self"
+        elif chan_for_channel.get("admin_rights"):
+            ctx.tier = "admin"
+
+        self_user = await ctx.gateway.get_self()
+        self_raw_id = ctx.store.add_raw(self_user.get("_", "user"), self_user, "self", None)
+        self_uri = upsert_peer(
+            ctx.store, self_user, self_raw_id, observed_at, seen_in_chat=None, seen_in_msg=None
+        )
+        set_state(ctx.store, "account", "self", {"uri": self_uri, "id": self_user.get("id")})
+
+        ctx.input_channel = input_channel
+        ctx.channel_id = channel_id
+
+        return CollectResult(name=self.name, counts={"channels": 1, "peers": len(peer_uris)})

--- a/src/paperboy/collectors/channel.py
+++ b/src/paperboy/collectors/channel.py
@@ -14,8 +14,10 @@ from paperboy.targets import Target
 
 
 def _pick_channel(chats: list[dict]) -> dict:
+    # Telethon's to_dict() uses the PascalCase class name ("Channel",
+    # "ChannelForbidden"), not the lowercase TL constructor name.
     for chat in chats:
-        if chat.get("_", "").startswith("channel"):
+        if chat.get("_", "").lower().startswith("channel"):
             return chat
     raise ValueError("resolve() returned no channel-typed chat for a channel-like target")
 
@@ -32,14 +34,14 @@ class ChannelCollector:
 
         resolved = await ctx.gateway.resolve(ctx.target.value)
         resolve_raw_id = ctx.store.add_raw(
-            resolved.get("_", "resolvedPeer"), resolved, ctx.tier, {"target": ctx.target.raw}
+            resolved.get("_", "ResolvedPeer"), resolved, ctx.tier, {"target": ctx.target.raw}
         )
         chan = _pick_channel(resolved.get("chats", []))
         input_channel = {"channel_id": chan["id"], "access_hash": chan["access_hash"]}
 
         full = await ctx.gateway.get_full_channel(input_channel)
         full_raw_id = ctx.store.add_raw(
-            full.get("_", "messages.chatFull"), full, ctx.tier, {"channel_id": chan["id"]}
+            full.get("_", "ChatFull"), full, ctx.tier, {"channel_id": chan["id"]}
         )
         full_chat = full["full_chat"]
         # Prefer the richer `chat` object returned alongside getFullChannel
@@ -76,7 +78,7 @@ class ChannelCollector:
             ctx.tier = "admin"
 
         self_user = await ctx.gateway.get_self()
-        self_raw_id = ctx.store.add_raw(self_user.get("_", "user"), self_user, "self", None)
+        self_raw_id = ctx.store.add_raw(self_user.get("_", "User"), self_user, "self", None)
         self_uri = upsert_peer(
             ctx.store, self_user, self_raw_id, observed_at, seen_in_chat=None, seen_in_msg=None
         )

--- a/src/paperboy/collectors/history.py
+++ b/src/paperboy/collectors/history.py
@@ -1,0 +1,142 @@
+"""The `history` collector: newest->oldest backfill with gap-based deletion
+tombstones (this file), and `pts` catch-up (`catch_up`, added in the next
+change).
+
+Resumability has two independent layers: a per-run `offset_id` cursor in
+`sync_state('history', ...)` lets a killed/Ctrl-C'd backfill continue paging
+from where it stopped, while `sync_ranges` records which numeric message-id
+spans have been fully swept *and* gap-probed — the two are deliberately not
+conflated (see the module-level note on `_gap_candidates`).
+"""
+
+from __future__ import annotations
+
+from paperboy.collectors.base import CollectContext, CollectResult
+from paperboy.ids import msg_uri, peer_ref_uri, utc_now_iso
+from paperboy.store.edges import add_edge
+from paperboy.store.messages import mark_deleted, upsert_message
+from paperboy.store.peers import upsert_peer
+from paperboy.store.sync import add_range, get_state, set_state
+from paperboy.targets import Target
+
+_HISTORY_PAGE_SIZE = 100
+_GET_MESSAGES_CHUNK = 200
+
+
+def _latest_revision_hash(ctx: CollectContext, uri: str) -> str | None:
+    row = ctx.store.conn.execute(
+        "SELECT content_hash FROM message_revisions WHERE message_uri=? "
+        "ORDER BY observed_at DESC, id DESC LIMIT 1",
+        (uri,),
+    ).fetchone()
+    return row["content_hash"] if row else None
+
+
+class HistoryCollector:
+    name = "history"
+
+    def applies_to(self, target: Target) -> bool:
+        return target.is_channel_like
+
+    async def collect(self, ctx: CollectContext) -> CollectResult:
+        assert ctx.input_channel is not None
+        assert ctx.channel_id is not None
+        channel_id = ctx.channel_id
+        counts = {"messages": 0, "revisions": 0, "tombstones": 0, "edges": 0}
+
+        resume = get_state(ctx.store, "history", str(channel_id)) or {}
+        cursor: int = resume.get("offset_id", 0)
+
+        ids_seen: set[int] = set()
+        min_id: int | None = None
+        max_id: int | None = None
+
+        while True:
+            page = [
+                m
+                async for m in ctx.gateway.iter_history(
+                    ctx.input_channel, offset_id=cursor, limit=_HISTORY_PAGE_SIZE
+                )
+            ]
+            if not page:
+                break
+
+            for m in page:
+                self._observe_message(ctx, channel_id, m, counts)
+                mid = m["id"]
+                ids_seen.add(mid)
+                min_id = mid if min_id is None else min(min_id, mid)
+                max_id = mid if max_id is None else max(max_id, mid)
+
+            cursor = min(m["id"] for m in page)
+            set_state(ctx.store, "history", str(channel_id), {"offset_id": cursor})
+
+        if min_id is not None and max_id is not None:
+            await self._probe_gaps(ctx, channel_id, min_id, max_id, ids_seen, counts)
+            add_range(ctx.store, channel_id, min_id, max_id)
+
+        return CollectResult(name=self.name, counts=counts)
+
+    def _observe_message(
+        self, ctx: CollectContext, channel_id: int, m: dict, counts: dict[str, int]
+    ) -> None:
+        observed_at = utc_now_iso()
+        raw_id = ctx.store.add_raw(
+            m.get("_", "message"), m, ctx.tier, {"channel_id": channel_id}
+        )
+        uri = msg_uri(channel_id, m["id"])
+        before = _latest_revision_hash(ctx, uri)
+        upsert_message(ctx.store, channel_id, m, raw_id, observed_at, ctx.tier)
+        after = _latest_revision_hash(ctx, uri)
+        counts["messages"] += 1
+        if after != before:
+            counts["revisions"] += 1
+
+        from_id = m.get("from_id")
+        if from_id and from_id.get("_") == "peerUser":
+            # We only have the bare peer reference here (no username/name) —
+            # record it as `min`, honestly reflecting how little we know; a
+            # Phase 2 `profiles` collector fills in the rest.
+            stub = {"_": "user", "id": from_id["user_id"], "min": True}
+            upsert_peer(
+                ctx.store, stub, raw_id, observed_at,
+                seen_in_chat=channel_id, seen_in_msg=m["id"],
+            )
+
+        fwd_from = m.get("fwd_from")
+        object_uri = peer_ref_uri(fwd_from.get("from_id")) if fwd_from else None
+        if object_uri:
+            add_edge(
+                ctx.store, uri, "forwarded_from", object_uri, observed_at, ctx.tier, raw_id,
+                {"fwd_from": fwd_from},
+            )
+            counts["edges"] += 1
+
+    async def _probe_gaps(
+        self,
+        ctx: CollectContext,
+        channel_id: int,
+        min_id: int,
+        max_id: int,
+        ids_seen: set[int],
+        counts: dict[str, int],
+    ) -> None:
+        """Probe every id in `[min_id, max_id]` that `iter_history` never
+        returned. This is *this sweep's* candidate-gap set — the numeric
+        complement of what we actually saw, not `sync.missing_ids()` (which
+        answers a different question: what isn't yet covered by any
+        previously verified-complete range at all, useful across separate
+        runs, not within one).
+        """
+        assert ctx.input_channel is not None
+        candidates = sorted(set(range(min_id, max_id + 1)) - ids_seen)
+        for start in range(0, len(candidates), _GET_MESSAGES_CHUNK):
+            chunk = candidates[start : start + _GET_MESSAGES_CHUNK]
+            results = await ctx.gateway.get_messages(ctx.input_channel, chunk)
+            for r in results:
+                if r.get("_") != "messageEmpty":
+                    continue
+                observed_at = utc_now_iso()
+                ctx.store.add_raw("messageEmpty", r, ctx.tier, {"channel_id": channel_id})
+                mark_deleted(ctx.store, channel_id, r["id"], "empty", observed_at)
+                counts["tombstones"] += 1

--- a/src/paperboy/collectors/history.py
+++ b/src/paperboy/collectors/history.py
@@ -13,6 +13,7 @@ collector from `channelFull.pts`.
 
 from __future__ import annotations
 
+from paperboy.budget import PhaseStop
 from paperboy.collectors.base import CollectContext, CollectResult
 from paperboy.ids import msg_uri, peer_ref_uri, utc_now_iso
 from paperboy.store.edges import add_edge
@@ -42,8 +43,15 @@ class HistoryCollector:
         return target.is_channel_like
 
     async def collect(self, ctx: CollectContext) -> CollectResult:
-        assert ctx.input_channel is not None
-        assert ctx.channel_id is not None
+        if ctx.input_channel is None or ctx.channel_id is None:
+            # The `channel` phase didn't complete (e.g. it raised `PhaseStop`
+            # on a FLOOD_WAIT during resolve()/getFullChannel before setting
+            # these) — a handled disposition the recipe layer records and
+            # continues past, never a bare `AssertionError` crash.
+            raise PhaseStop(
+                "history skipped: channel context not established "
+                "(channel phase did not complete)"
+            )
         channel_id = ctx.channel_id
         counts = {"messages": 0, "revisions": 0, "tombstones": 0, "edges": 0}
 
@@ -156,8 +164,11 @@ class HistoryCollector:
         gap probe for this channel is the caller's job (a future `watch`
         loop iteration or a plain re-run of `history`).
         """
-        assert ctx.input_channel is not None
-        assert ctx.channel_id is not None
+        if ctx.input_channel is None or ctx.channel_id is None:
+            raise PhaseStop(
+                "history skipped: channel context not established "
+                "(channel phase did not complete)"
+            )
         channel_id = ctx.channel_id
         counts = {"messages": 0, "revisions": 0, "tombstones": 0, "edges": 0}
 

--- a/src/paperboy/collectors/history.py
+++ b/src/paperboy/collectors/history.py
@@ -1,12 +1,14 @@
 """The `history` collector: newest->oldest backfill with gap-based deletion
-tombstones (this file), and `pts` catch-up (`catch_up`, added in the next
-change).
+tombstones, plus `pts`-based catch-up (`catch_up`) applying edits and
+deletions delivered via `updates.getChannelDifference` (ADR-0004).
 
 Resumability has two independent layers: a per-run `offset_id` cursor in
 `sync_state('history', ...)` lets a killed/Ctrl-C'd backfill continue paging
 from where it stopped, while `sync_ranges` records which numeric message-id
 spans have been fully swept *and* gap-probed — the two are deliberately not
-conflated (see the module-level note on `_gap_candidates`).
+conflated (see the note on `_probe_gaps`). `catch_up` uses a third, separate
+cursor: `sync_state('channel', ...)`'s `pts`, seeded by the `channel`
+collector from `channelFull.pts`.
 """
 
 from __future__ import annotations
@@ -21,6 +23,7 @@ from paperboy.targets import Target
 
 _HISTORY_PAGE_SIZE = 100
 _GET_MESSAGES_CHUNK = 200
+_CHANNEL_DIFFERENCE_LIMIT = 100
 
 
 def _latest_revision_hash(ctx: CollectContext, uri: str) -> str | None:
@@ -140,3 +143,50 @@ class HistoryCollector:
                 ctx.store.add_raw("messageEmpty", r, ctx.tier, {"channel_id": channel_id})
                 mark_deleted(ctx.store, channel_id, r["id"], "empty", observed_at)
                 counts["tombstones"] += 1
+
+    async def catch_up(self, ctx: CollectContext) -> CollectResult:
+        """Apply everything since the last stored `pts` via `getChannelDifference`.
+
+        `new_messages` are upserted; `other_updates` are applied by kind —
+        `updateEditChannelMessage` appends a revision (via `upsert_message`'s
+        own content-hash check), `updateDeleteChannelMessages` tombstones
+        with `evidence="update"` (spec §7's highest-confidence deletion
+        evidence). A `channelDifferenceTooLong` re-seeds `pts` from the
+        payload's `dialog` and returns with `stopped="resynced"` — a full
+        gap probe for this channel is the caller's job (a future `watch`
+        loop iteration or a plain re-run of `history`).
+        """
+        assert ctx.input_channel is not None
+        assert ctx.channel_id is not None
+        channel_id = ctx.channel_id
+        counts = {"messages": 0, "revisions": 0, "tombstones": 0, "edges": 0}
+
+        state = get_state(ctx.store, "channel", str(channel_id)) or {}
+        pts = state.get("pts", 0)
+
+        diff = await ctx.gateway.get_channel_difference(
+            ctx.input_channel, pts, _CHANNEL_DIFFERENCE_LIMIT
+        )
+        ctx.store.add_raw(
+            diff.get("_", "updates.channelDifference"), diff, ctx.tier, {"channel_id": channel_id}
+        )
+
+        if diff.get("_") == "updates.channelDifferenceTooLong":
+            resynced_pts = diff.get("dialog", {}).get("pts", pts)
+            set_state(ctx.store, "channel", str(channel_id), {"pts": resynced_pts})
+            return CollectResult(name=self.name, counts=counts, stopped="resynced")
+
+        for m in diff.get("new_messages", []):
+            self._observe_message(ctx, channel_id, m, counts)
+
+        for update in diff.get("other_updates", []):
+            kind = update.get("_")
+            if kind == "updateEditChannelMessage":
+                self._observe_message(ctx, channel_id, update["message"], counts)
+            elif kind == "updateDeleteChannelMessages":
+                for mid in update.get("messages", []):
+                    mark_deleted(ctx.store, channel_id, mid, "update", utc_now_iso())
+                    counts["tombstones"] += 1
+
+        set_state(ctx.store, "channel", str(channel_id), {"pts": diff.get("pts", pts)})
+        return CollectResult(name=self.name, counts=counts)

--- a/src/paperboy/collectors/history.py
+++ b/src/paperboy/collectors/history.py
@@ -85,7 +85,7 @@ class HistoryCollector:
     ) -> None:
         observed_at = utc_now_iso()
         raw_id = ctx.store.add_raw(
-            m.get("_", "message"), m, ctx.tier, {"channel_id": channel_id}
+            m.get("_", "Message"), m, ctx.tier, {"channel_id": channel_id}
         )
         uri = msg_uri(channel_id, m["id"])
         before = _latest_revision_hash(ctx, uri)
@@ -96,11 +96,11 @@ class HistoryCollector:
             counts["revisions"] += 1
 
         from_id = m.get("from_id")
-        if from_id and from_id.get("_") == "peerUser":
+        if from_id and from_id.get("_", "").lower() == "peeruser":
             # We only have the bare peer reference here (no username/name) —
             # record it as `min`, honestly reflecting how little we know; a
             # Phase 2 `profiles` collector fills in the rest.
-            stub = {"_": "user", "id": from_id["user_id"], "min": True}
+            stub = {"_": "User", "id": from_id["user_id"], "min": True}
             upsert_peer(
                 ctx.store, stub, raw_id, observed_at,
                 seen_in_chat=channel_id, seen_in_msg=m["id"],
@@ -137,10 +137,10 @@ class HistoryCollector:
             chunk = candidates[start : start + _GET_MESSAGES_CHUNK]
             results = await ctx.gateway.get_messages(ctx.input_channel, chunk)
             for r in results:
-                if r.get("_") != "messageEmpty":
+                if r.get("_", "").lower() != "messageempty":
                     continue
                 observed_at = utc_now_iso()
-                ctx.store.add_raw("messageEmpty", r, ctx.tier, {"channel_id": channel_id})
+                ctx.store.add_raw("MessageEmpty", r, ctx.tier, {"channel_id": channel_id})
                 mark_deleted(ctx.store, channel_id, r["id"], "empty", observed_at)
                 counts["tombstones"] += 1
 
@@ -168,10 +168,10 @@ class HistoryCollector:
             ctx.input_channel, pts, _CHANNEL_DIFFERENCE_LIMIT
         )
         ctx.store.add_raw(
-            diff.get("_", "updates.channelDifference"), diff, ctx.tier, {"channel_id": channel_id}
+            diff.get("_", "ChannelDifference"), diff, ctx.tier, {"channel_id": channel_id}
         )
 
-        if diff.get("_") == "updates.channelDifferenceTooLong":
+        if diff.get("_", "").lower() == "channeldifferencetoolong":
             resynced_pts = diff.get("dialog", {}).get("pts", pts)
             set_state(ctx.store, "channel", str(channel_id), {"pts": resynced_pts})
             return CollectResult(name=self.name, counts=counts, stopped="resynced")
@@ -180,10 +180,10 @@ class HistoryCollector:
             self._observe_message(ctx, channel_id, m, counts)
 
         for update in diff.get("other_updates", []):
-            kind = update.get("_")
-            if kind == "updateEditChannelMessage":
+            kind = update.get("_", "").lower()
+            if kind == "updateeditchannelmessage":
                 self._observe_message(ctx, channel_id, update["message"], counts)
-            elif kind == "updateDeleteChannelMessages":
+            elif kind == "updatedeletechannelmessages":
                 for mid in update.get("messages", []):
                     mark_deleted(ctx.store, channel_id, mid, "update", utc_now_iso())
                     counts["tombstones"] += 1

--- a/src/paperboy/config.py
+++ b/src/paperboy/config.py
@@ -14,7 +14,11 @@ from pathlib import Path
 from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-DEFAULT_DATA_DIR = Path("~/.local/share/paperboy")
+# Repo-relative by default so collected data lands in `./data/` next to the
+# code, not somewhere on the filesystem you have to hunt for. `./data` is
+# gitignored. Override with `PAPERBOY_DATA_DIR` (absolute or `~`-relative) to
+# put it elsewhere.
+DEFAULT_DATA_DIR = Path("data")
 
 
 class DeviceIdentity(BaseModel):

--- a/src/paperboy/config.py
+++ b/src/paperboy/config.py
@@ -1,0 +1,70 @@
+"""Runtime configuration.
+
+`Settings` is a `pydantic-settings` model, `PAPERBOY_*`-env-prefixed, with the
+defaults from spec §9. Precedence is CLI > env > `config.toml` > defaults;
+`pydantic-settings` already prioritises constructor keyword arguments over
+environment variables (its default source order), so `load_settings` gets the
+right precedence for free by passing CLI overrides as kwargs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+DEFAULT_DATA_DIR = Path("~/.local/share/paperboy")
+
+
+class DeviceIdentity(BaseModel):
+    """A stable, generic device fingerprint.
+
+    Deliberately does NOT resemble an official Telegram client string (see
+    docs/opsec.md: "we do not impersonate an official client") — a consistent,
+    generic identity across runs is the goal, not blending in as a specific
+    real client.
+    """
+
+    device_model: str = "PC"
+    system_version: str = "Linux"
+    app_version: str = "paperboy"
+    lang_code: str = "en"
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="PAPERBOY_", extra="ignore")
+
+    api_id: int | None = None
+    data_dir: Path = DEFAULT_DATA_DIR
+    proxy: str | None = None
+    require_proxy: bool = True
+    device: DeviceIdentity = Field(default_factory=DeviceIdentity)
+    min_session_age_days: int = 7
+    flood_sleep_threshold: int = 60
+    max_rpc_per_run: int = 20000
+    profile_budget: int = 2000
+    allow_join: bool = False
+    allow_phone_lookup: bool = False
+
+    @field_validator("data_dir", mode="after")
+    @classmethod
+    def _expand_data_dir(cls, v: Path) -> Path:
+        return v.expanduser()
+
+
+def load_settings(profile: str, overrides: dict) -> Settings:
+    """Build `Settings` for one profile.
+
+    `profile` selects *where* data lives (see `profile_dir`) — it is not a
+    `Settings` field, so it is not threaded into the model. `overrides`
+    (typically parsed CLI flags) are passed as constructor kwargs, which
+    `pydantic-settings` prioritises over environment variables.
+    """
+    del profile
+    return Settings(**overrides)
+
+
+def profile_dir(settings: Settings, profile: str) -> Path:
+    """The per-profile data directory: `<data_dir>/<profile>/`."""
+    return settings.data_dir / profile

--- a/src/paperboy/doctor.py
+++ b/src/paperboy/doctor.py
@@ -25,7 +25,9 @@ _PRIVACY_KEYS = ("phone", "lastseen", "photo")
 # rules at all is *not* actually possible from a real getPrivacy response,
 # but an empty list is treated the same as AllowAll — Telegram's own default)
 # counts as restrictive.
-_PERMISSIVE_RULE = "privacyValueAllowAll"
+# Telethon's to_dict() uses the PascalCase class name, not the lowercase TL
+# constructor name — compared case-insensitively below.
+_PERMISSIVE_RULE = "privacyvalueallowall"
 
 
 @dataclass(frozen=True)
@@ -81,7 +83,7 @@ def _check_two_factor(password_state: dict) -> Check:
 
 def _check_privacy(key: str, rules: dict) -> Check:
     rule_list = rules.get("rules", [])
-    permissive = not rule_list or rule_list[0].get("_") == _PERMISSIVE_RULE
+    permissive = not rule_list or rule_list[0].get("_", "").lower() == _PERMISSIVE_RULE
     if permissive:
         return Check(f"privacy_{key}", False, f"{key} privacy is Everyone (AllowAll)", "fail")
     return Check(f"privacy_{key}", True, f"{key} privacy is restricted", "fail")

--- a/src/paperboy/doctor.py
+++ b/src/paperboy/doctor.py
@@ -1,0 +1,122 @@
+"""`paperboy doctor`: the operational-security preflight (spec §3).
+
+Checks the account's controllable opsec posture — proxy presence, session
+age, 2FA, restrictive privacy keys, a minimal profile — before `collect` is
+allowed to run. A `fail` blocks `collect` unless the operator passes
+`--unsafe`; a `warn` (currently only the minimal-profile check) never blocks
+— a non-minimal profile is a hygiene issue for the *account*, not a risk to
+the current run the way a missing proxy or a fresh session is.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from paperboy.config import Settings
+    from paperboy.gateway import Gateway
+
+Severity = Literal["fail", "warn"]
+
+_PRIVACY_KEYS = ("phone", "lastseen", "photo")
+# A privacy rule of AllowAll is the permissive default; anything else (and no
+# rules at all is *not* actually possible from a real getPrivacy response,
+# but an empty list is treated the same as AllowAll — Telegram's own default)
+# counts as restrictive.
+_PERMISSIVE_RULE = "privacyValueAllowAll"
+
+
+@dataclass(frozen=True)
+class Check:
+    name: str
+    ok: bool
+    detail: str
+    severity: Severity
+
+
+def _session_age_days(authorizations: dict) -> float | None:
+    for auth in authorizations.get("authorizations", []):
+        if not auth.get("current"):
+            continue
+        created = auth.get("date_created")
+        if created is None:
+            return None
+        if not isinstance(created, datetime):
+            raise TypeError(
+                f"expected an aware datetime for date_created, got {type(created).__name__}"
+            )
+        return (datetime.now(UTC) - created).total_seconds() / 86400
+    return None
+
+
+def _check_proxy(settings: Settings) -> Check:
+    if not settings.require_proxy:
+        return Check("proxy", True, "require_proxy is disabled", "fail")
+    if settings.proxy:
+        return Check("proxy", True, f"proxy configured ({settings.proxy})", "fail")
+    return Check("proxy", False, "require_proxy is set but no proxy is configured", "fail")
+
+
+def _check_session_age(authorizations: dict, settings: Settings) -> Check:
+    age = _session_age_days(authorizations)
+    if age is None:
+        return Check("session_age", False, "no current session found", "fail")
+    if age < settings.min_session_age_days:
+        return Check(
+            "session_age", False,
+            f"session is {age:.1f} days old, below min_session_age_days="
+            f"{settings.min_session_age_days}",
+            "fail",
+        )
+    return Check("session_age", True, f"session is {age:.1f} days old", "fail")
+
+
+def _check_two_factor(password_state: dict) -> Check:
+    if password_state.get("has_password"):
+        return Check("two_factor_auth", True, "2FA password is set", "fail")
+    return Check("two_factor_auth", False, "no 2FA password set", "fail")
+
+
+def _check_privacy(key: str, rules: dict) -> Check:
+    rule_list = rules.get("rules", [])
+    permissive = not rule_list or rule_list[0].get("_") == _PERMISSIVE_RULE
+    if permissive:
+        return Check(f"privacy_{key}", False, f"{key} privacy is Everyone (AllowAll)", "fail")
+    return Check(f"privacy_{key}", True, f"{key} privacy is restricted", "fail")
+
+
+def _check_minimal_profile(self_user: dict) -> Check:
+    exposed = [
+        field for field in ("username", "photo", "about") if self_user.get(field)
+    ]
+    if exposed:
+        return Check(
+            "minimal_profile", False,
+            f"self profile exposes: {', '.join(exposed)}",
+            "warn",
+        )
+    return Check("minimal_profile", True, "self profile is minimal", "warn")
+
+
+async def run_doctor(gateway: Gateway, settings: Settings) -> list[Check]:
+    self_user = await gateway.get_self()
+    authorizations = await gateway.get_authorizations()
+    password_state = await gateway.get_password_state()
+
+    checks = [
+        _check_proxy(settings),
+        _check_session_age(authorizations, settings),
+        _check_two_factor(password_state),
+    ]
+    for key in _PRIVACY_KEYS:
+        rules = await gateway.get_privacy(key)
+        checks.append(_check_privacy(key, rules))
+    checks.append(_check_minimal_profile(self_user))
+    return checks
+
+
+def doctor_blocks(checks: list[Check]) -> bool:
+    """True if any `fail`-severity check did not pass. `warn`s never block."""
+    return any(not c.ok and c.severity == "fail" for c in checks)

--- a/src/paperboy/errors.py
+++ b/src/paperboy/errors.py
@@ -1,0 +1,92 @@
+"""RPC error → `Disposition` classification (spec §8).
+
+Telethon error classes are imported lazily inside `classify` so nothing that
+merely wants to reason about dispositions (e.g. a unit test) needs Telethon
+importable. `classify` duck-types on Telethon's `FloodWaitError.seconds`
+attribute for `FakeFlood`/`FakePeerFlood` (thin test doubles below) as well
+as the real thing.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Disposition(Enum):
+    RETRY = "retry"
+    SKIP = "skip"
+    PHASE_STOP = "phase_stop"
+    HARD_STOP = "hard_stop"
+
+
+DEFAULT_FLOOD_SLEEP_THRESHOLD = 60
+
+
+class FakeFlood(Exception):
+    """Test double mirroring `telethon.errors.FloodWaitError`'s `.seconds`."""
+
+    def __init__(self, seconds: int) -> None:
+        super().__init__(f"flood wait {seconds}s")
+        self.seconds = seconds
+
+
+class FakePeerFlood(Exception):
+    """Test double mirroring `telethon.errors.PeerFloodError` (hard stop, no payload)."""
+
+
+def _skip_error_classes() -> tuple[type[Exception], ...]:
+    from telethon.errors import (
+        BroadcastForbiddenError,
+        ChannelPrivateError,
+        ChatAdminRequiredError,
+        MsgIdInvalidError,
+        PremiumAccountRequiredError,
+    )
+
+    return (
+        ChatAdminRequiredError,
+        ChannelPrivateError,
+        MsgIdInvalidError,
+        BroadcastForbiddenError,
+        PremiumAccountRequiredError,
+    )
+
+
+def _hard_stop_error_classes() -> tuple[type[Exception], ...]:
+    from telethon.errors import (
+        AuthKeyDuplicatedError,
+        FrozenMethodInvalidError,
+        PeerFloodError,
+        SessionRevokedError,
+    )
+
+    return (
+        PeerFloodError,
+        FrozenMethodInvalidError,
+        AuthKeyDuplicatedError,
+        SessionRevokedError,
+        FakePeerFlood,
+    )
+
+
+def classify(exc: BaseException, threshold: int = DEFAULT_FLOOD_SLEEP_THRESHOLD) -> Disposition:
+    """Map one RPC exception to a `Disposition` per spec §8.
+
+    Order matters: a flood-wait check comes first (it duck-types on
+    `.seconds`, which only `FloodWaitError`/`FakeFlood` carry), then the
+    explicit skip/hard-stop class lists, then transient network errors
+    (retryable), and finally — since "no exception is swallowed" — anything
+    unrecognized is re-raised as itself rather than mapped to a made-up
+    disposition.
+    """
+    from telethon.errors import FloodWaitError
+
+    if isinstance(exc, FloodWaitError | FakeFlood):
+        return Disposition.RETRY if exc.seconds <= threshold else Disposition.PHASE_STOP
+    if isinstance(exc, _skip_error_classes()):
+        return Disposition.SKIP
+    if isinstance(exc, _hard_stop_error_classes()):
+        return Disposition.HARD_STOP
+    if isinstance(exc, ConnectionError | TimeoutError | OSError):
+        return Disposition.RETRY
+    raise exc

--- a/src/paperboy/export/__init__.py
+++ b/src/paperboy/export/__init__.py
@@ -1,0 +1,1 @@
+"""Export views over the `Store` — never a primary store (ADR-0002)."""

--- a/src/paperboy/export/jsonl.py
+++ b/src/paperboy/export/jsonl.py
@@ -1,0 +1,84 @@
+"""JSONL export view: `channel.jsonl` / `messages.jsonl` / `edges.jsonl`.
+
+A read view over the `Store`, never the primary record (ADR-0002) — it can
+always be regenerated. Messages carry their full `message_revisions` history
+inline (so an edited message's prior text isn't lost to "current state
+only"), and both messages and edges scrub anything traceable to the
+collecting account's own identity (spec §2/§3: "exports scrub the collecting
+account") — looked up via the `account`/`self` cursor the `channel` collector
+seeds from `gateway.get_self()`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from paperboy.ids import parse_uri
+from paperboy.store.sync import get_state
+
+if TYPE_CHECKING:
+    from paperboy.store.db import Store
+
+
+def _self_uri(store: Store) -> str | None:
+    state = get_state(store, "account", "self")
+    return state.get("uri") if state else None
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> int:
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False, sort_keys=True, default=str))
+            f.write("\n")
+    return len(rows)
+
+
+def export_jsonl(store: Store, channel_uri: str, out_dir: Path) -> dict[str, int]:
+    kind, ids = parse_uri(channel_uri)
+    if kind != "channel":
+        raise ValueError(f"export_jsonl expects a channel URI, got {channel_uri!r}")
+    channel_id = ids[0]
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    self_uri = _self_uri(store)
+
+    channel_rows = [
+        dict(r) for r in store.conn.execute("SELECT * FROM channels WHERE id=?", (channel_id,))
+    ]
+    channel_count = _write_jsonl(out_dir / "channel.jsonl", channel_rows)
+
+    message_rows: list[dict] = []
+    messages = store.conn.execute(
+        "SELECT * FROM messages WHERE channel_id=? ORDER BY msg_id", (channel_id,)
+    )
+    for row in messages:
+        message = dict(row)
+        if self_uri and message.get("from_uri") == self_uri:
+            continue  # scrub the collecting account's own messages
+        revisions = store.conn.execute(
+            "SELECT observed_at, edit_date, content_hash, text, entities_json, media_json "
+            "FROM message_revisions WHERE message_uri=? ORDER BY observed_at",
+            (message["uri"],),
+        )
+        message["revisions"] = [dict(r) for r in revisions]
+        message_rows.append(message)
+    message_count = _write_jsonl(out_dir / "messages.jsonl", message_rows)
+
+    edge_rows: list[dict] = []
+    message_uri_pattern = f"tg:msg:{channel_id}/%"
+    edges = store.conn.execute(
+        "SELECT * FROM edges WHERE subject_uri=? OR subject_uri LIKE ? OR object_uri=? "
+        "ORDER BY id",
+        (channel_uri, message_uri_pattern, channel_uri),
+    )
+    for row in edges:
+        edge = dict(row)
+        if self_uri and self_uri in (edge.get("subject_uri"), edge.get("object_uri")):
+            continue
+        edge_rows.append(edge)
+    edge_count = _write_jsonl(out_dir / "edges.jsonl", edge_rows)
+
+    return {"channel": channel_count, "messages": message_count, "edges": edge_count}

--- a/src/paperboy/gateway.py
+++ b/src/paperboy/gateway.py
@@ -1,0 +1,233 @@
+"""The `Gateway` seam (ADR-0001): every Telegram-shaped operation a collector needs.
+
+`Gateway` is a `typing.Protocol` so collectors depend on a shape, not on
+Telethon. Every method returns plain dicts (`TLObject.to_dict()`), never
+Telethon types — that's what makes `FakeGateway` (fixture replay, no
+network) a drop-in test double for `TelethonGateway` (the real thing, every
+call routed through `Budget.call`).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Protocol, cast
+
+if TYPE_CHECKING:
+    from telethon import TelegramClient
+    from telethon.tl.tlobject import TLObject
+    from telethon.tl.types import InputChannel, InputPeerChannel
+
+    from paperboy.budget import Budget
+
+
+class Gateway(Protocol):
+    async def resolve(self, target_value: str) -> dict:
+        """`contacts.resolveUsername` — returns `{"chats": [...], "users": [...]}`."""
+        ...
+
+    async def get_full_channel(self, input_channel: dict) -> dict:
+        """`channels.getFullChannel` — `{"full_chat": {...}, "chats": [...], "users": [...]}`."""
+        ...
+
+    def iter_history(
+        self, input_channel: dict, *, offset_id: int, limit: int
+    ) -> AsyncIterator[dict]:
+        """One page of `messages.getHistory`, newest-first, as an async stream of message dicts."""
+        ...
+
+    async def get_messages(self, input_channel: dict, ids: list[int]) -> list[dict]:
+        """`channels.getMessages` — missing ids come back as `messageEmpty` dicts."""
+        ...
+
+    async def get_channel_difference(self, input_channel: dict, pts: int, limit: int) -> dict:
+        """`updates.getChannelDifference` — the `pts`-based incremental sync primitive."""
+        ...
+
+    async def get_self(self) -> dict:
+        """The collecting account's own basic user dict."""
+        ...
+
+
+class FakeGateway:
+    """Replays recorded fixture dicts — no network, no `Budget` involved.
+
+    `fixtures` keys: `resolve`, `full_channel`, `self`, `history` (a flat
+    list, newest-first), `get_messages` (a `{id: message_dict}` lookup),
+    `channel_difference`.
+    """
+
+    def __init__(self, fixtures: dict) -> None:
+        self._fx = fixtures
+
+    async def resolve(self, target_value: str) -> dict:
+        del target_value
+        return self._fx["resolve"]
+
+    async def get_full_channel(self, input_channel: dict) -> dict:
+        del input_channel
+        return self._fx["full_channel"]
+
+    async def get_self(self) -> dict:
+        return self._fx["self"]
+
+    async def iter_history(
+        self, input_channel: dict, *, offset_id: int, limit: int
+    ) -> AsyncIterator[dict]:
+        del input_channel
+        history = self._fx.get("history", [])
+        # Mirrors real getHistory semantics: offset_id=0 means "from the
+        # top"; otherwise only ids strictly below it (paging older).
+        page = [m for m in history if offset_id == 0 or m["id"] < offset_id]
+        for m in page[:limit]:
+            yield m
+
+    async def get_messages(self, input_channel: dict, ids: list[int]) -> list[dict]:
+        del input_channel
+        table: dict[int, dict] = self._fx.get("get_messages", {})
+        return [table.get(i, {"_": "messageEmpty", "id": i}) for i in ids]
+
+    async def get_channel_difference(self, input_channel: dict, pts: int, limit: int) -> dict:
+        del input_channel, pts, limit
+        return self._fx["channel_difference"]
+
+
+def _input_channel(input_channel: dict) -> InputChannel:
+    from telethon.tl.types import InputChannel as _InputChannel
+
+    return _InputChannel(
+        channel_id=input_channel["channel_id"], access_hash=input_channel["access_hash"]
+    )
+
+
+def _input_peer_channel(input_channel: dict) -> InputPeerChannel:
+    from telethon.tl.types import InputPeerChannel as _InputPeerChannel
+
+    return _InputPeerChannel(
+        channel_id=input_channel["channel_id"], access_hash=input_channel["access_hash"]
+    )
+
+
+class TelethonGateway:
+    """The real `Gateway`: builds raw `telethon.tl.functions.*` requests, every
+    one routed through `Budget.call` — no collector or gateway consumer talks
+    to Telethon directly (ADR-0003).
+
+    Telethon ships no return-type stubs for `TelegramClient.__call__` (it's
+    dynamically typed on the request instance), so each response is `cast`
+    to the TL response shape that request actually returns — a typing aid
+    only; every cast target is a real `TLObject` verified against the
+    installed layer (ADR-0001), never a runtime behavior change.
+    """
+
+    def __init__(self, client: TelegramClient, budget: Budget) -> None:
+        self.client = client
+        self.budget = budget
+
+    async def resolve(self, target_value: str) -> dict:
+        from telethon.tl.functions.contacts import ResolveUsernameRequest
+        from telethon.tl.types.contacts import ResolvedPeer
+
+        result = cast(
+            ResolvedPeer,
+            await self.budget.call(
+                "contacts.resolveUsername",
+                lambda: self.client(ResolveUsernameRequest(username=target_value)),
+            ),
+        )
+        return result.to_dict()
+
+    async def get_full_channel(self, input_channel: dict) -> dict:
+        from telethon.tl.functions.channels import GetFullChannelRequest
+        from telethon.tl.types.messages import ChatFull
+
+        channel = _input_channel(input_channel)
+        result = cast(
+            ChatFull,
+            await self.budget.call(
+                "channels.getFullChannel",
+                lambda: self.client(GetFullChannelRequest(channel=channel)),
+            ),
+        )
+        return result.to_dict()
+
+    async def iter_history(
+        self, input_channel: dict, *, offset_id: int, limit: int
+    ) -> AsyncIterator[dict]:
+        from telethon.tl.functions.messages import GetHistoryRequest
+        from telethon.tl.types.messages import Messages
+
+        peer = _input_peer_channel(input_channel)
+        result = cast(
+            Messages,
+            await self.budget.call(
+                "messages.getHistory",
+                lambda: self.client(
+                    GetHistoryRequest(
+                        peer=peer,
+                        offset_id=offset_id,
+                        offset_date=None,
+                        add_offset=0,
+                        limit=limit,
+                        max_id=0,
+                        min_id=0,
+                        hash=0,
+                    )
+                ),
+            ),
+        )
+        for m in result.messages:
+            yield m.to_dict()
+
+    async def get_messages(self, input_channel: dict, ids: list[int]) -> list[dict]:
+        from telethon.tl.functions.channels import GetMessagesRequest
+        from telethon.tl.types import InputMessageID, TypeInputMessage
+        from telethon.tl.types.messages import Messages
+
+        channel = _input_channel(input_channel)
+        message_ids: list[TypeInputMessage] = [InputMessageID(id=i) for i in ids]
+        result = cast(
+            Messages,
+            await self.budget.call(
+                "channels.getMessages",
+                lambda: self.client(GetMessagesRequest(channel=channel, id=message_ids)),
+            ),
+        )
+        return [m.to_dict() for m in result.messages]
+
+    async def get_channel_difference(self, input_channel: dict, pts: int, limit: int) -> dict:
+        from telethon.tl.functions.updates import GetChannelDifferenceRequest
+        from telethon.tl.types import ChannelMessagesFilterEmpty
+
+        channel = _input_channel(input_channel)
+        result = cast(
+            TLObject,
+            await self.budget.call(
+                "updates.getChannelDifference",
+                lambda: self.client(
+                    GetChannelDifferenceRequest(
+                        channel=channel,
+                        filter=ChannelMessagesFilterEmpty(),
+                        pts=pts,
+                        limit=limit,
+                        force=False,
+                    )
+                ),
+            ),
+        )
+        return result.to_dict()
+
+    async def get_self(self) -> dict:
+        from telethon.tl.functions.users import GetFullUserRequest
+        from telethon.tl.types import InputUserSelf
+        from telethon.tl.types.users import UserFull
+
+        result = cast(
+            UserFull,
+            await self.budget.call(
+                "users.getFullUser",
+                lambda: self.client(GetFullUserRequest(id=InputUserSelf())),
+            ),
+        )
+        # UserFull wraps the actual User under `.users[0]`; expose the user,
+        # not the full-profile wrapper, matching `resolve`/history peers.
+        return result.users[0].to_dict()

--- a/src/paperboy/gateway.py
+++ b/src/paperboy/gateway.py
@@ -44,7 +44,20 @@ class Gateway(Protocol):
         ...
 
     async def get_self(self) -> dict:
-        """The collecting account's own basic user dict."""
+        """The collecting account's own user dict, `about` merged in from `getFullUser`."""
+        ...
+
+    async def get_authorizations(self) -> dict:
+        """`account.getAuthorizations` — `{"authorizations": [...]}`, used by `doctor` for
+        session age (the entry with `current: True`)."""
+        ...
+
+    async def get_password_state(self) -> dict:
+        """`account.getPassword` — includes `has_password` (2FA presence), used by `doctor`."""
+        ...
+
+    async def get_privacy(self, key: str) -> dict:
+        """`account.getPrivacy` for one key (`phone`/`lastseen`/`photo`) — `{"rules": [...]}`."""
         ...
 
 
@@ -53,7 +66,8 @@ class FakeGateway:
 
     `fixtures` keys: `resolve`, `full_channel`, `self`, `history` (a flat
     list, newest-first), `get_messages` (a `{id: message_dict}` lookup),
-    `channel_difference`.
+    `channel_difference`, `authorizations`, `password_state`, `privacy` (a
+    `{key: rules_dict}` lookup keyed by `"phone"`/`"lastseen"`/`"photo"`).
     """
 
     def __init__(self, fixtures: dict) -> None:
@@ -89,6 +103,15 @@ class FakeGateway:
     async def get_channel_difference(self, input_channel: dict, pts: int, limit: int) -> dict:
         del input_channel, pts, limit
         return self._fx["channel_difference"]
+
+    async def get_authorizations(self) -> dict:
+        return self._fx["authorizations"]
+
+    async def get_password_state(self) -> dict:
+        return self._fx["password_state"]
+
+    async def get_privacy(self, key: str) -> dict:
+        return self._fx["privacy"][key]
 
 
 def _input_channel(input_channel: dict) -> InputChannel:
@@ -229,5 +252,59 @@ class TelethonGateway:
             ),
         )
         # UserFull wraps the actual User under `.users[0]`; expose the user,
-        # not the full-profile wrapper, matching `resolve`/history peers.
-        return result.users[0].to_dict()
+        # not the full-profile wrapper, matching `resolve`/history peers —
+        # but merge in `about` (bio), which only `full_user` carries and
+        # `doctor`'s minimal-profile check needs.
+        user_dict = result.users[0].to_dict()
+        user_dict["about"] = getattr(result.full_user, "about", None)
+        return user_dict
+
+    async def get_authorizations(self) -> dict:
+        from telethon.tl.functions.account import GetAuthorizationsRequest
+        from telethon.tl.types.account import Authorizations
+
+        result = cast(
+            Authorizations,
+            await self.budget.call(
+                "account.getAuthorizations", lambda: self.client(GetAuthorizationsRequest())
+            ),
+        )
+        return result.to_dict()
+
+    async def get_password_state(self) -> dict:
+        from telethon.tl.functions.account import GetPasswordRequest
+        from telethon.tl.types.account import Password
+
+        result = cast(
+            Password,
+            await self.budget.call(
+                "account.getPassword", lambda: self.client(GetPasswordRequest())
+            ),
+        )
+        return result.to_dict()
+
+    async def get_privacy(self, key: str) -> dict:
+        from telethon.tl.functions.account import GetPrivacyRequest
+        from telethon.tl.types import (
+            InputPrivacyKeyPhoneNumber,
+            InputPrivacyKeyProfilePhoto,
+            InputPrivacyKeyStatusTimestamp,
+        )
+        from telethon.tl.types.account import PrivacyRules
+
+        input_keys = {
+            "phone": InputPrivacyKeyPhoneNumber,
+            "lastseen": InputPrivacyKeyStatusTimestamp,
+            "photo": InputPrivacyKeyProfilePhoto,
+        }
+        if key not in input_keys:
+            raise ValueError(f"unknown privacy key: {key!r}")
+        input_key = input_keys[key]()
+        result = cast(
+            PrivacyRules,
+            await self.budget.call(
+                f"account.getPrivacy:{key}",
+                lambda: self.client(GetPrivacyRequest(key=input_key)),
+            ),
+        )
+        return result.to_dict()

--- a/src/paperboy/gateway.py
+++ b/src/paperboy/gateway.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, Protocol, cast
 
 if TYPE_CHECKING:
     from telethon import TelegramClient
-    from telethon.tl.tlobject import TLObject
     from telethon.tl.types import InputChannel, InputPeerChannel
 
     from paperboy.budget import Budget
@@ -98,7 +97,7 @@ class FakeGateway:
     async def get_messages(self, input_channel: dict, ids: list[int]) -> list[dict]:
         del input_channel
         table: dict[int, dict] = self._fx.get("get_messages", {})
-        return [table.get(i, {"_": "messageEmpty", "id": i}) for i in ids]
+        return [table.get(i, {"_": "MessageEmpty", "id": i}) for i in ids]
 
     async def get_channel_difference(self, input_channel: dict, pts: int, limit: int) -> dict:
         del input_channel, pts, limit
@@ -219,6 +218,7 @@ class TelethonGateway:
 
     async def get_channel_difference(self, input_channel: dict, pts: int, limit: int) -> dict:
         from telethon.tl.functions.updates import GetChannelDifferenceRequest
+        from telethon.tl.tlobject import TLObject
         from telethon.tl.types import ChannelMessagesFilterEmpty
 
         channel = _input_channel(input_channel)

--- a/src/paperboy/ids.py
+++ b/src/paperboy/ids.py
@@ -1,0 +1,66 @@
+"""URI-style entity ids and UTC time helpers.
+
+Entity ids are URI strings of the shape ``tg:<kind>:<id>`` (or
+``tg:msg:<channel_id>/<msg_id>`` for messages) so that projections, edges,
+and exports can all reference entities by one stable, human-legible key
+regardless of storage backend. All timestamps in the store are ISO-8601 UTC
+text produced by :func:`to_iso` / :func:`utc_now_iso`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+_SCHEME = "tg"
+_KINDS = {"channel", "chat", "user", "msg"}
+
+
+def channel_uri(id: int) -> str:
+    return f"{_SCHEME}:channel:{id}"
+
+
+def chat_uri(id: int) -> str:
+    return f"{_SCHEME}:chat:{id}"
+
+
+def user_uri(id: int) -> str:
+    return f"{_SCHEME}:user:{id}"
+
+
+def msg_uri(channel_id: int, msg_id: int) -> str:
+    return f"{_SCHEME}:msg:{channel_id}/{msg_id}"
+
+
+def parse_uri(uri: str) -> tuple[str, tuple[int, ...]]:
+    """Parse a ``tg:<kind>:<ids>`` URI back into (kind, ids).
+
+    Raises ``ValueError`` for anything that isn't a well-formed paperboy URI.
+    """
+    parts = uri.split(":")
+    if len(parts) != 3 or parts[0] != _SCHEME:
+        raise ValueError(f"malformed paperboy URI: {uri!r}")
+    _, kind, rest = parts
+    if kind not in _KINDS:
+        raise ValueError(f"unknown URI kind: {kind!r}")
+    try:
+        if kind == "msg":
+            channel_id_s, msg_id_s = rest.split("/")
+            ids = (int(channel_id_s), int(msg_id_s))
+        else:
+            ids = (int(rest),)
+    except ValueError as e:
+        raise ValueError(f"malformed paperboy URI: {uri!r}") from e
+    return kind, ids
+
+
+def to_iso(dt: datetime | int) -> str:
+    """Normalize a timezone-aware datetime or an epoch-seconds int to UTC ISO-8601 text."""
+    if isinstance(dt, datetime):
+        if dt.tzinfo is None:
+            raise ValueError("to_iso requires a timezone-aware datetime")
+        return dt.astimezone(UTC).isoformat()
+    return datetime.fromtimestamp(dt, tz=UTC).isoformat()
+
+
+def utc_now_iso() -> str:
+    return to_iso(datetime.now(UTC))

--- a/src/paperboy/ids.py
+++ b/src/paperboy/ids.py
@@ -31,6 +31,24 @@ def msg_uri(channel_id: int, msg_id: int) -> str:
     return f"{_SCHEME}:msg:{channel_id}/{msg_id}"
 
 
+def peer_ref_uri(peer: dict | None) -> str | None:
+    """Convert a TL `Peer*`/`InputPeer*` reference dict (e.g. a message's
+    `from_id` or a forward header's `from_id`) to a paperboy URI, or None if
+    absent/unrecognized. Shared by the message projection and the history
+    collector's forward-edge extraction so both agree on one mapping.
+    """
+    if not peer:
+        return None
+    kind = peer.get("_", "")
+    if kind in ("peerUser", "inputPeerUser"):
+        return user_uri(peer["user_id"])
+    if kind in ("peerChannel", "inputPeerChannel"):
+        return channel_uri(peer["channel_id"])
+    if kind in ("peerChat", "inputPeerChat"):
+        return chat_uri(peer["chat_id"])
+    return None
+
+
 def parse_uri(uri: str) -> tuple[str, tuple[int, ...]]:
     """Parse a ``tg:<kind>:<ids>`` URI back into (kind, ids).
 

--- a/src/paperboy/ids.py
+++ b/src/paperboy/ids.py
@@ -31,20 +31,46 @@ def msg_uri(channel_id: int, msg_id: int) -> str:
     return f"{_SCHEME}:msg:{channel_id}/{msg_id}"
 
 
+def primary_username(obj: dict) -> str | None:
+    """Extract the canonical username from a TL `Channel`/`Chat`/`User` dict.
+
+    Accounts/channels enrolled in Telegram's multi-username feature (extra
+    handles bought via Fragment, or just claimed) report the legacy
+    singular `username` field as null and list every handle in `usernames`
+    instead (`[{"username": ..., "editable": ..., "active": ...}, ...]`).
+    `editable: True` marks the account's own chosen primary handle;
+    verified against a live multi-username channel (Task 17 DoD smoke).
+    """
+    legacy = obj.get("username")
+    if legacy:
+        return legacy
+    usernames = obj.get("usernames") or []
+    for entry in usernames:
+        if entry.get("editable"):
+            return entry.get("username")
+    for entry in usernames:
+        if entry.get("active"):
+            return entry.get("username")
+    return None
+
+
 def peer_ref_uri(peer: dict | None) -> str | None:
     """Convert a TL `Peer*`/`InputPeer*` reference dict (e.g. a message's
     `from_id` or a forward header's `from_id`) to a paperboy URI, or None if
     absent/unrecognized. Shared by the message projection and the history
     collector's forward-edge extraction so both agree on one mapping.
+
+    Matched case-insensitively: Telethon's `to_dict()` uses the PascalCase
+    class name (`"PeerUser"`, ...), not the lowercase TL constructor name.
     """
     if not peer:
         return None
-    kind = peer.get("_", "")
-    if kind in ("peerUser", "inputPeerUser"):
+    kind = peer.get("_", "").lower()
+    if kind in ("peeruser", "inputpeeruser"):
         return user_uri(peer["user_id"])
-    if kind in ("peerChannel", "inputPeerChannel"):
+    if kind in ("peerchannel", "inputpeerchannel"):
         return channel_uri(peer["channel_id"])
-    if kind in ("peerChat", "inputPeerChat"):
+    if kind in ("peerchat", "inputpeerchat"):
         return chat_uri(peer["chat_id"])
     return None
 

--- a/src/paperboy/logging_setup.py
+++ b/src/paperboy/logging_setup.py
@@ -78,17 +78,27 @@ def configure_logging(path: Path, console: bool = True) -> None:
     for f in list(logger.filters):
         logger.removeFilter(f)
 
+    # A filter attached to the `paperboy` logger itself is only consulted
+    # by `Logger.filter()` for records logged *through that logger* — the
+    # app logs exclusively through children (`paperboy.cli`, the `log`
+    # threaded into recipes/collectors), and `Logger.callHandlers` never
+    # re-checks an ancestor logger's own filters for a record bubbling up
+    # from a child. Attaching one shared (stateless) `RedactionFilter`
+    # instance to each handler instead works for every record regardless of
+    # which logger emitted it, since `callHandlers` always applies each
+    # handler's own filters.
+    rf = RedactionFilter()
+
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     file_handler = logging.FileHandler(path, encoding="utf-8")
     file_handler.setFormatter(_JsonFormatter())
+    file_handler.addFilter(rf)
     logger.addHandler(file_handler)
 
     if console:
         from rich.logging import RichHandler
 
-        logger.addHandler(RichHandler(show_path=False))
-
-    # One filter on the logger (not per-handler) so redaction runs exactly
-    # once and every handler sees the same scrubbed record.
-    logger.addFilter(RedactionFilter())
+        rich_handler = RichHandler(show_path=False)
+        rich_handler.addFilter(rf)
+        logger.addHandler(rich_handler)

--- a/src/paperboy/logging_setup.py
+++ b/src/paperboy/logging_setup.py
@@ -1,0 +1,94 @@
+"""Redacted logging: JSON file handler + optional rich console handler.
+
+Credentials (session string, `api_hash`, phone, login code) must never reach
+a log file (spec §2/§3). Rather than trust every call site to avoid logging
+them, sensitive values are registered once via `register_secret` and a
+`RedactionFilter` scrubs every record before it reaches any handler.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+_registered_secrets: set[str] = set()
+
+_MASK = "***"
+
+
+def register_secret(value: str) -> None:
+    """Register a sensitive string so every log record has it masked out.
+
+    Safe to call repeatedly (e.g. once a session/api_hash is loaded); empty
+    strings are ignored so an unset secret doesn't (harmlessly but
+    pointlessly) match everything.
+    """
+    if value:
+        _registered_secrets.add(value)
+
+
+class RedactionFilter(logging.Filter):
+    """Masks every registered secret out of a record before it is formatted.
+
+    Renders `record.getMessage()` once (applying any %-args), substitutes
+    registered secrets with `***`, then rewrites `record.msg` with the
+    redacted text and clears `record.args` so no handler ever re-renders the
+    original, unredacted arguments.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        # Longest-first so one secret that is a substring of another (e.g. a
+        # short test token contained in a longer one) doesn't leave a partial
+        # match unmasked.
+        for secret in sorted(_registered_secrets, key=len, reverse=True):
+            if secret in message:
+                message = message.replace(secret, _MASK)
+        record.msg = message
+        record.args = ()
+        return True
+
+
+class _JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, object] = {
+            "ts": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def configure_logging(path: Path, console: bool = True) -> None:
+    """Configure the `paperboy` logger: JSON file handler + optional rich console.
+
+    Idempotent: clears any handlers/filters from a prior call so tests (and a
+    CLI re-invocation within one process) can call it more than once safely.
+    """
+    logger = logging.getLogger("paperboy")
+    logger.setLevel(logging.DEBUG)
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        handler.close()
+    for f in list(logger.filters):
+        logger.removeFilter(f)
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    file_handler = logging.FileHandler(path, encoding="utf-8")
+    file_handler.setFormatter(_JsonFormatter())
+    logger.addHandler(file_handler)
+
+    if console:
+        from rich.logging import RichHandler
+
+        logger.addHandler(RichHandler(show_path=False))
+
+    # One filter on the logger (not per-handler) so redaction runs exactly
+    # once and every handler sees the same scrubbed record.
+    logger.addFilter(RedactionFilter())

--- a/src/paperboy/logging_setup.py
+++ b/src/paperboy/logging_setup.py
@@ -18,6 +18,14 @@ _registered_secrets: set[str] = set()
 _MASK = "***"
 
 
+def _redact(text: str) -> str:
+    """Mask every registered secret out of `text` (longest-first)."""
+    for secret in sorted(_registered_secrets, key=len, reverse=True):
+        if secret in text:
+            text = text.replace(secret, _MASK)
+    return text
+
+
 def register_secret(value: str) -> None:
     """Register a sensitive string so every log record has it masked out.
 
@@ -39,15 +47,18 @@ class RedactionFilter(logging.Filter):
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
-        message = record.getMessage()
-        # Longest-first so one secret that is a substring of another (e.g. a
-        # short test token contained in a longer one) doesn't leave a partial
-        # match unmasked.
-        for secret in sorted(_registered_secrets, key=len, reverse=True):
-            if secret in message:
-                message = message.replace(secret, _MASK)
-        record.msg = message
+        record.msg = _redact(record.getMessage())
         record.args = ()
+        # Exception tracebacks are a second credential-leak path: a secret in an
+        # exception's str() would otherwise reach the file/console unmasked. Pre-
+        # render exc_info to text here (before any formatter), scrub it, cache it
+        # on record.exc_text, and clear exc_info so no downstream formatter (JSON
+        # or Rich) re-derives an unredacted traceback from the raw exception.
+        if record.exc_info:
+            record.exc_text = _redact(logging.Formatter().formatException(record.exc_info))
+            record.exc_info = None
+        if record.exc_text:
+            record.exc_text = _redact(record.exc_text)
         return True
 
 
@@ -59,8 +70,11 @@ class _JsonFormatter(logging.Formatter):
             "logger": record.name,
             "message": record.getMessage(),
         }
-        if record.exc_info:
-            payload["exc_info"] = self.formatException(record.exc_info)
+        exc = record.exc_text or (
+            self.formatException(record.exc_info) if record.exc_info else None
+        )
+        if exc:
+            payload["exc_info"] = exc
         return json.dumps(payload, ensure_ascii=False)
 
 

--- a/src/paperboy/recipes.py
+++ b/src/paperboy/recipes.py
@@ -4,9 +4,9 @@ Runs `channel` (which populates `CollectContext.input_channel`/`channel_id`/
 `tier` for everything after it), then `history` (backfill, immediately
 followed by one `pts` catch-up so the channel's sync state is current as of
 *now*, not as of whenever backfill started — both folded into one `history`
-CollectResult). `PhaseStop` is recorded and that phase's result is marked
-stopped, but later phases still run; `HardStop` is recorded and the whole
-run ends there (spec §8). A `run_events` row is written for every phase.
+CollectResult). `SkipAndRecord` and `PhaseStop` are each recorded and that phase's result is
+marked stopped, but later phases still run; `HardStop` is recorded and the
+whole run ends there (spec §8). A `run_events` row is written for every phase.
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ import logging
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
-from paperboy.budget import HardStop, PhaseStop
+from paperboy.budget import HardStop, PhaseStop, SkipAndRecord
 from paperboy.collectors.base import CollectContext, CollectResult
 from paperboy.collectors.channel import ChannelCollector
 from paperboy.collectors.history import HistoryCollector
@@ -94,6 +94,16 @@ async def collect_channel(
             continue
         try:
             result = await _run_one(collector, ctx)
+        except SkipAndRecord as exc:
+            # Disposition.SKIP (e.g. ChannelPrivateError, ChatAdminRequiredError,
+            # MsgIdInvalidError, BroadcastForbiddenError, PremiumAccountRequiredError):
+            # skip this one collector, the run continues (spec §8) — this must
+            # never abort the whole run, unlike PhaseStop/HardStop below.
+            log.warning("phase %s skipped: %s", collector.name, exc)
+            detail = {"error": str(exc)}
+            _record_run_event(store, ctx.channel_id, collector.name, "skip", detail)
+            results.append(CollectResult(name=collector.name, counts={}, stopped="skip"))
+            continue
         except PhaseStop as exc:
             log.warning("phase %s stopped: %s", collector.name, exc)
             detail = {"error": str(exc)}

--- a/src/paperboy/recipes.py
+++ b/src/paperboy/recipes.py
@@ -1,0 +1,116 @@
+"""`collect_channel`: the ordered-collectors recipe orchestrator.
+
+Runs `channel` (which populates `CollectContext.input_channel`/`channel_id`/
+`tier` for everything after it), then `history` (backfill, immediately
+followed by one `pts` catch-up so the channel's sync state is current as of
+*now*, not as of whenever backfill started — both folded into one `history`
+CollectResult). `PhaseStop` is recorded and that phase's result is marked
+stopped, but later phases still run; `HardStop` is recorded and the whole
+run ends there (spec §8). A `run_events` row is written for every phase.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from paperboy.budget import HardStop, PhaseStop
+from paperboy.collectors.base import CollectContext, CollectResult
+from paperboy.collectors.channel import ChannelCollector
+from paperboy.collectors.history import HistoryCollector
+from paperboy.ids import utc_now_iso
+from paperboy.store.db import dumps
+
+if TYPE_CHECKING:
+    from paperboy.collectors.base import Collector
+    from paperboy.config import Settings
+    from paperboy.gateway import Gateway
+    from paperboy.store.db import Store
+    from paperboy.targets import Target
+
+
+def _default_collectors() -> list[Collector]:
+    return [ChannelCollector(), HistoryCollector()]
+
+
+def _record_run_event(
+    store: Store, channel_id: int | None, phase: str, kind: str, detail: dict | None
+) -> None:
+    store.conn.execute(
+        "INSERT INTO run_events(observed_at, channel_id, phase, kind, detail_json) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (utc_now_iso(), channel_id, phase, kind, dumps(detail) if detail is not None else None),
+    )
+
+
+def _merge_counts(a: dict[str, int], b: dict[str, int]) -> dict[str, int]:
+    merged = dict(a)
+    for k, v in b.items():
+        merged[k] = merged.get(k, 0) + v
+    return merged
+
+
+async def _run_one(collector: Collector, ctx: CollectContext) -> CollectResult:
+    """Run one collector's `collect()`, and its `catch_up()` too if it's a
+    `HistoryCollector` — folded into a single result so the phase list stays
+    one entry per collector, not per RPC pattern.
+    """
+    result = await collector.collect(ctx)
+    if isinstance(collector, HistoryCollector):
+        catchup_result = await collector.catch_up(ctx)
+        result = CollectResult(
+            name=result.name,
+            counts=_merge_counts(result.counts, catchup_result.counts),
+            stopped=catchup_result.stopped or result.stopped,
+        )
+    return result
+
+
+async def collect_channel(
+    gateway: Gateway,
+    store: Store,
+    settings: Settings,
+    target: Target,
+    phases: list[str] | None,
+    log: logging.Logger,
+    *,
+    collectors: Sequence[Collector] | None = None,
+) -> list[CollectResult]:
+    """Run `channel` then `history` (+ its `catch_up`) against `target`.
+
+    `phases` filters which collectors run by name (`None` runs all).
+    `collectors` overrides the default `[ChannelCollector(), HistoryCollector()]`
+    list — used by tests to inject a stub that raises `HardStop`/`PhaseStop`
+    without needing a real gateway failure to trigger one.
+    """
+    ctx = CollectContext(gateway, store, settings, target, None, None, "stranger", log)
+    active = collectors if collectors is not None else _default_collectors()
+    selected = set(phases) if phases is not None else {c.name for c in active}
+
+    results: list[CollectResult] = []
+    for collector in active:
+        if collector.name not in selected or not collector.applies_to(target):
+            continue
+        try:
+            result = await _run_one(collector, ctx)
+        except PhaseStop as exc:
+            log.warning("phase %s stopped: %s", collector.name, exc)
+            detail = {"error": str(exc)}
+            _record_run_event(store, ctx.channel_id, collector.name, "phase_stop", detail)
+            results.append(CollectResult(name=collector.name, counts={}, stopped="phase_stop"))
+            continue
+        except HardStop as exc:
+            log.error("hard stop during %s: %s", collector.name, exc)
+            detail = {"error": str(exc)}
+            _record_run_event(store, ctx.channel_id, collector.name, "hard_stop", detail)
+            results.append(CollectResult(name=collector.name, counts={}, stopped="hard_stop"))
+            break
+        else:
+            _record_run_event(
+                store, ctx.channel_id, collector.name, "complete",
+                {"counts": result.counts, "stopped": result.stopped},
+            )
+            results.append(result)
+
+    return results

--- a/src/paperboy/secrets.py
+++ b/src/paperboy/secrets.py
@@ -1,0 +1,63 @@
+"""Secret storage — `api_hash` and the MTProto session string.
+
+Per spec §3/§9, secrets live only in the OS keychain, never in `config.toml`,
+env, or logs. `SecretStore` is a small Protocol so collectors/CLI code never
+depend on `keyring` directly, and tests use `MemorySecrets` instead of
+touching the real keychain.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+import keyring
+
+SERVICE = "paperboy"
+
+
+class SecretStore(Protocol):
+    def get_api_hash(self) -> str | None: ...
+    def set_api_hash(self, value: str) -> None: ...
+    def get_session(self) -> str | None: ...
+    def set_session(self, value: str) -> None: ...
+
+
+class KeyringSecrets:
+    """Secrets backed by the OS keychain, scoped to one profile."""
+
+    def __init__(self, profile: str) -> None:
+        self._profile = profile
+
+    def _key(self, name: str) -> str:
+        return f"{self._profile}:{name}"
+
+    def get_api_hash(self) -> str | None:
+        return keyring.get_password(SERVICE, self._key("api_hash"))
+
+    def set_api_hash(self, value: str) -> None:
+        keyring.set_password(SERVICE, self._key("api_hash"), value)
+
+    def get_session(self) -> str | None:
+        return keyring.get_password(SERVICE, self._key("session"))
+
+    def set_session(self, value: str) -> None:
+        keyring.set_password(SERVICE, self._key("session"), value)
+
+
+class MemorySecrets:
+    """In-memory `SecretStore` for tests — never touches the real keychain."""
+
+    def __init__(self, values: dict[str, str] | None = None) -> None:
+        self._values: dict[str, str] = dict(values or {})
+
+    def get_api_hash(self) -> str | None:
+        return self._values.get("api_hash")
+
+    def set_api_hash(self, value: str) -> None:
+        self._values["api_hash"] = value
+
+    def get_session(self) -> str | None:
+        return self._values.get("session")
+
+    def set_session(self, value: str) -> None:
+        self._values["session"] = value

--- a/src/paperboy/store/__init__.py
+++ b/src/paperboy/store/__init__.py
@@ -1,0 +1,1 @@
+"""SQLite store: raw-record log + projections. See `paperboy.store.db.Store`."""

--- a/src/paperboy/store/channels.py
+++ b/src/paperboy/store/channels.py
@@ -1,0 +1,94 @@
+"""Channel projection: current state (`channels`) + an append-only observation history
+(`channel_snapshots`) of the counters/metadata that drift over time.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from paperboy.ids import channel_uri
+from paperboy.store.db import Store, dumps
+
+_FLAG_KEYS = (
+    "verified", "scam", "fake", "restricted", "signatures", "has_link", "has_geo",
+    "slowmode_enabled", "participants_hidden", "can_view_participants",
+)
+
+
+def _channel_kind(chan: dict) -> str | None:
+    if chan.get("broadcast"):
+        return "broadcast"
+    if chan.get("gigagroup"):
+        return "gigagroup"
+    if chan.get("megagroup"):
+        return "forum" if chan.get("forum") else "megagroup"
+    return None
+
+
+def upsert_channel(
+    store: Store,
+    full: dict,
+    chan: dict,
+    source_raw_id: int,
+    observed_at: str,
+) -> str:
+    """Project `channels.getFullChannel`'s `(full_chat, chat)` pair; returns the channel URI.
+
+    Writes current state to `channels` and always appends a `channel_snapshots`
+    row — snapshots are an observation time series, not deduplicated, so
+    counters like `participants_count` can be plotted over time.
+    """
+    id_ = chan["id"]
+    uri = channel_uri(id_)
+    title = chan.get("title")
+    username = chan.get("username")
+    about = full.get("about")
+    kind = _channel_kind(chan)
+    # `chan["date"]` is a join/observed date, not creation; left for a future
+    # collector to populate from a more authoritative source.
+    created_at = None
+    linked_chat_id = full.get("linked_chat_id") or None  # 0 means "no linked chat"
+    participants_count = full.get("participants_count")
+    restriction = chan.get("restriction_reason")
+    restriction_json = dumps(restriction) if restriction else None
+    flags = {k: (chan.get(k, full.get(k))) for k in _FLAG_KEYS if k in chan or k in full}
+    flags_json = dumps(flags) if flags else None
+
+    store.conn.execute(
+        """
+        INSERT INTO channels (
+            id, uri, username, title, about, kind, created_at, linked_chat_id,
+            participants_count, flags_json, restriction_json, source_raw_id,
+            first_seen, last_seen
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+            username=excluded.username,
+            title=excluded.title,
+            about=excluded.about,
+            kind=excluded.kind,
+            linked_chat_id=excluded.linked_chat_id,
+            participants_count=excluded.participants_count,
+            flags_json=excluded.flags_json,
+            restriction_json=excluded.restriction_json,
+            source_raw_id=excluded.source_raw_id,
+            last_seen=excluded.last_seen
+        """,
+        (
+            id_, uri, username, title, about, kind, created_at, linked_chat_id,
+            participants_count, flags_json, restriction_json, source_raw_id,
+            observed_at, observed_at,
+        ),
+    )
+
+    about_hash = hashlib.sha256(about.encode("utf-8")).hexdigest() if about else None
+    store.conn.execute(
+        "INSERT INTO channel_snapshots "
+        "(channel_id, observed_at, participants_count, online_count, title, username, "
+        "about_hash, source_raw_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            id_, observed_at, participants_count, full.get("online_count"), title, username,
+            about_hash, source_raw_id,
+        ),
+    )
+
+    return uri

--- a/src/paperboy/store/channels.py
+++ b/src/paperboy/store/channels.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import hashlib
 
-from paperboy.ids import channel_uri
+from paperboy.ids import channel_uri, primary_username
 from paperboy.store.db import Store, dumps
 
 _FLAG_KEYS = (
@@ -41,7 +41,7 @@ def upsert_channel(
     id_ = chan["id"]
     uri = channel_uri(id_)
     title = chan.get("title")
-    username = chan.get("username")
+    username = primary_username(chan)
     about = full.get("about")
     kind = _channel_kind(chan)
     # `chan["date"]` is a join/observed date, not creation; left for a future

--- a/src/paperboy/store/db.py
+++ b/src/paperboy/store/db.py
@@ -1,0 +1,114 @@
+"""SQLite connection lifecycle, migrations, and the raw-record log.
+
+SQLite is the system of record (ADR-0002): WAL mode, foreign keys on,
+explicit `migrations/NNNN_*.sql` files tracked in `schema_migrations`. Every
+TL object observed is appended to `raw_records` (see `add_raw`) *before* any
+projection — projections carry `source_raw_id` and can be rebuilt from raw
+after a Telethon layer bump.
+
+Connections use `isolation_level=None` (autocommit): every statement is
+durable the instant it runs, so a killed process never loses a write that
+already executed. This trades cross-table atomicity (e.g. a message update
+and its revision row are two separate commits) for the simpler, and for this
+tool more important, guarantee that nothing is silently rolled back on
+close — every writer here is idempotent (`INSERT ... ON CONFLICT DO UPDATE`,
+`CREATE ... IF NOT EXISTS`), so a re-run after an interruption repairs state
+rather than needing a transaction to undo.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sqlite3
+from datetime import date, datetime
+from pathlib import Path
+from types import TracebackType
+from typing import Self
+
+from paperboy.ids import to_iso, utc_now_iso
+
+_MIGRATIONS_DIR = Path(__file__).resolve().parent / "migrations"
+
+
+def _json_default(value: object) -> object:
+    if isinstance(value, bytes):
+        return base64.b64encode(value).decode("ascii")
+    if isinstance(value, datetime):
+        return to_iso(value)
+    if isinstance(value, date):
+        return value.isoformat()
+    raise TypeError(f"not JSON serializable: {type(value).__name__}")
+
+
+def dumps(payload: object) -> str:
+    """Canonical JSON used for every json-text column: sorted keys, UTF-8 text."""
+    return json.dumps(payload, sort_keys=True, ensure_ascii=False, default=_json_default)
+
+
+class Store:
+    """Owns one SQLite connection: pragmas, migrations, and the raw log.
+
+    Prefer `Store.open(path)` (a context manager) over constructing directly.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self.conn = conn
+
+    @classmethod
+    def open(cls, path: Path) -> Self:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(path, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        store = cls(conn)
+        store._apply_migrations()
+        return store
+
+    def _apply_migrations(self) -> None:
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS schema_migrations ("
+            "name TEXT PRIMARY KEY, applied_at TEXT NOT NULL)"
+        )
+        applied = {row["name"] for row in self.conn.execute("SELECT name FROM schema_migrations")}
+        for sql_path in sorted(_MIGRATIONS_DIR.glob("*.sql")):
+            stem = sql_path.stem
+            if stem in applied:
+                continue
+            self.conn.executescript(sql_path.read_text())
+            self.conn.execute(
+                "INSERT INTO schema_migrations(name, applied_at) VALUES (?, ?)",
+                (stem, utc_now_iso()),
+            )
+
+    def add_raw(self, kind: str, payload: dict, tier: str, context: dict | None) -> int:
+        """Append one TL object (as `to_dict()`) to the raw log; returns its rowid."""
+        cur = self.conn.execute(
+            "INSERT INTO raw_records(kind, observed_at, tier, context_json, payload_json) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                kind,
+                utc_now_iso(),
+                tier,
+                dumps(context) if context is not None else None,
+                dumps(payload),
+            ),
+        )
+        assert cur.lastrowid is not None
+        return cur.lastrowid
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()

--- a/src/paperboy/store/edges.py
+++ b/src/paperboy/store/edges.py
@@ -1,0 +1,30 @@
+"""The graph projection: triple-shaped `edges` (ADR-0002).
+
+Every entity has a URI id, so `(subject, predicate, object)` plus provenance
+(`observed_at`, `tier`, `source_raw_id`, `evidence_json`) is enough for
+RDF/Turtle or GraphML to be an export projection rather than a second store.
+"""
+
+from __future__ import annotations
+
+from paperboy.store.db import Store, dumps
+
+
+def add_edge(
+    store: Store,
+    subject: str,
+    predicate: str,
+    object_: str,
+    observed_at: str,
+    tier: str,
+    source_raw_id: int | None,
+    evidence: dict | None,
+) -> None:
+    store.conn.execute(
+        "INSERT INTO edges (subject_uri, predicate, object_uri, observed_at, tier, "
+        "source_raw_id, evidence_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            subject, predicate, object_, observed_at, tier, source_raw_id,
+            dumps(evidence) if evidence is not None else None,
+        ),
+    )

--- a/src/paperboy/store/messages.py
+++ b/src/paperboy/store/messages.py
@@ -1,0 +1,183 @@
+"""Message projection: current state + append-only revisions/metrics/tombstones.
+
+A message observed with a new `content_hash` appends a `message_revisions`
+row and updates the entity; identical content only advances `last_seen`
+(spec §7). Deletion evidence ranks `update` (unambiguous) > `empty`
+(`messageEmpty` inside a verified-complete range) > `gap` (never observed);
+`deleted_at` is set only for `update`/`empty` (ADR-0004).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from paperboy.ids import channel_uri, chat_uri, msg_uri, to_iso, user_uri
+from paperboy.store.db import Store, dumps
+
+_TOMBSTONE_SETS_DELETED_AT = {"update", "empty"}
+
+
+def content_hash(text: str, media_json: str | None) -> str:
+    """sha256 hex of the text + a NUL separator + the media json (or empty)."""
+    payload = f"{text}\x00{media_json or ''}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _iso_or_none(value: int | str | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return to_iso(value)
+
+
+def _peer_uri(peer: dict | None) -> str | None:
+    """Convert a TL `Peer*`/`InputPeer*` dict to a paperboy URI, or None."""
+    if not peer:
+        return None
+    kind = peer.get("_", "")
+    if kind in ("peerUser", "inputPeerUser"):
+        return user_uri(peer["user_id"])
+    if kind in ("peerChannel", "inputPeerChannel"):
+        return channel_uri(peer["channel_id"])
+    if kind in ("peerChat", "inputPeerChat"):
+        return chat_uri(peer["chat_id"])
+    return None
+
+
+def upsert_message(
+    store: Store,
+    channel_id: int,
+    msg: dict,
+    source_raw_id: int,
+    observed_at: str,
+    tier: str,
+) -> str:
+    """Project one `message`/`messageService` TL dict into the store.
+
+    Always writes current state to `messages`; appends a `message_revisions`
+    row iff the content hash changed since the last recorded revision
+    (including the very first observation); appends a `message_metrics` row
+    iff at least one of views/forwards/replies is present on this
+    observation. Returns the message's URI.
+    """
+    del tier  # not yet stored per-message; carried by raw_records/edges/peers
+    msg_id = msg["id"]
+    uri = msg_uri(channel_id, msg_id)
+
+    text = msg.get("message", "") or ""
+    media = msg.get("media")
+    media_json = dumps(media) if media else None
+    media_kind = media.get("_") if media else None
+    entities = msg.get("entities")
+    entities_json = dumps(entities) if entities is not None else None
+    fwd_from = msg.get("fwd_from")
+    fwd_json = dumps(fwd_from) if fwd_from else None
+    reply_to = msg.get("reply_to")
+    reply_to_msg_id = reply_to.get("reply_to_msg_id") if reply_to else None
+    reply_to_top_id = reply_to.get("reply_to_top_id") if reply_to else None
+    action = msg.get("action")
+    action_json = dumps(action) if action else None
+
+    date = _iso_or_none(msg.get("date"))
+    edit_date = _iso_or_none(msg.get("edit_date"))
+    from_uri = _peer_uri(msg.get("from_id"))
+    post_author = msg.get("post_author")
+    grouped_id = msg.get("grouped_id")
+    via_bot_id = msg.get("via_bot_id")
+    is_service = 1 if msg.get("_") == "messageService" else 0
+    chash = content_hash(text, media_json)
+
+    store.conn.execute(
+        """
+        INSERT INTO messages (
+            uri, channel_id, msg_id, date, edit_date, from_uri, post_author, text,
+            entities_json, media_kind, media_json, fwd_json, reply_to_msg_id,
+            reply_to_top_id, grouped_id, via_bot_id, is_service, action_json,
+            content_hash, deleted_at, source_raw_id, first_seen, last_seen
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)
+        ON CONFLICT(uri) DO UPDATE SET
+            date=excluded.date,
+            edit_date=excluded.edit_date,
+            from_uri=excluded.from_uri,
+            post_author=excluded.post_author,
+            text=excluded.text,
+            entities_json=excluded.entities_json,
+            media_kind=excluded.media_kind,
+            media_json=excluded.media_json,
+            fwd_json=excluded.fwd_json,
+            reply_to_msg_id=excluded.reply_to_msg_id,
+            reply_to_top_id=excluded.reply_to_top_id,
+            grouped_id=excluded.grouped_id,
+            via_bot_id=excluded.via_bot_id,
+            is_service=excluded.is_service,
+            action_json=excluded.action_json,
+            content_hash=excluded.content_hash,
+            source_raw_id=excluded.source_raw_id,
+            last_seen=excluded.last_seen
+        """,
+        (
+            uri, channel_id, msg_id, date, edit_date, from_uri, post_author, text,
+            entities_json, media_kind, media_json, fwd_json, reply_to_msg_id,
+            reply_to_top_id, grouped_id, via_bot_id, is_service, action_json,
+            chash, source_raw_id, observed_at, observed_at,
+        ),
+    )
+
+    latest = store.conn.execute(
+        "SELECT content_hash FROM message_revisions WHERE message_uri=? "
+        "ORDER BY observed_at DESC, id DESC LIMIT 1",
+        (uri,),
+    ).fetchone()
+    if latest is None or latest["content_hash"] != chash:
+        store.conn.execute(
+            "INSERT INTO message_revisions "
+            "(message_uri, observed_at, edit_date, content_hash, text, entities_json, "
+            "media_json, source_raw_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (uri, observed_at, edit_date, chash, text, entities_json, media_json, source_raw_id),
+        )
+
+    views = msg.get("views")
+    forwards = msg.get("forwards")
+    replies_obj = msg.get("replies")
+    replies = replies_obj.get("replies") if isinstance(replies_obj, dict) else None
+    reactions = msg.get("reactions")
+    reactions_json = dumps(reactions) if reactions else None
+    if views is not None or forwards is not None or replies is not None:
+        store.conn.execute(
+            "INSERT INTO message_metrics "
+            "(message_uri, observed_at, views, forwards, replies, reactions_json) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (uri, observed_at, views, forwards, replies, reactions_json),
+        )
+
+    return uri
+
+
+def mark_deleted(
+    store: Store,
+    channel_id: int,
+    msg_id: int,
+    evidence: str,
+    observed_at: str,
+) -> None:
+    """Record deletion evidence for a message; always tombstones, sometimes deletes.
+
+    `deleted_at` (on `messages`) is only set for `update`/`empty` evidence — a
+    `gap` (never observed at all) is ambiguous and may just be hidden/service.
+    A message that has never been seen locally still gets a tombstone row
+    (the `UPDATE ... WHERE uri=?` on `messages` simply affects zero rows).
+    """
+    uri = msg_uri(channel_id, msg_id)
+    store.conn.execute(
+        "INSERT INTO message_tombstones (message_uri, observed_at, evidence) VALUES (?, ?, ?)",
+        (uri, observed_at, evidence),
+    )
+    if evidence in _TOMBSTONE_SETS_DELETED_AT:
+        # COALESCE: keep the earliest-known deletion time if we've already
+        # recorded one (e.g. an `empty` probe followed later by an
+        # unambiguous `update` delete event for the same message).
+        store.conn.execute(
+            "UPDATE messages SET deleted_at = COALESCE(deleted_at, ?) WHERE uri = ?",
+            (observed_at, uri),
+        )

--- a/src/paperboy/store/messages.py
+++ b/src/paperboy/store/messages.py
@@ -71,7 +71,7 @@ def upsert_message(
     post_author = msg.get("post_author")
     grouped_id = msg.get("grouped_id")
     via_bot_id = msg.get("via_bot_id")
-    is_service = 1 if msg.get("_") == "messageService" else 0
+    is_service = 1 if msg.get("_", "").lower() == "messageservice" else 0
     chash = content_hash(text, media_json)
 
     store.conn.execute(

--- a/src/paperboy/store/messages.py
+++ b/src/paperboy/store/messages.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import hashlib
 
-from paperboy.ids import channel_uri, chat_uri, msg_uri, to_iso, user_uri
+from paperboy.ids import msg_uri, peer_ref_uri, to_iso
 from paperboy.store.db import Store, dumps
 
 _TOMBSTONE_SETS_DELETED_AT = {"update", "empty"}
@@ -29,20 +29,6 @@ def _iso_or_none(value: int | str | None) -> str | None:
     if isinstance(value, str):
         return value
     return to_iso(value)
-
-
-def _peer_uri(peer: dict | None) -> str | None:
-    """Convert a TL `Peer*`/`InputPeer*` dict to a paperboy URI, or None."""
-    if not peer:
-        return None
-    kind = peer.get("_", "")
-    if kind in ("peerUser", "inputPeerUser"):
-        return user_uri(peer["user_id"])
-    if kind in ("peerChannel", "inputPeerChannel"):
-        return channel_uri(peer["channel_id"])
-    if kind in ("peerChat", "inputPeerChat"):
-        return chat_uri(peer["chat_id"])
-    return None
 
 
 def upsert_message(
@@ -81,7 +67,7 @@ def upsert_message(
 
     date = _iso_or_none(msg.get("date"))
     edit_date = _iso_or_none(msg.get("edit_date"))
-    from_uri = _peer_uri(msg.get("from_id"))
+    from_uri = peer_ref_uri(msg.get("from_id"))
     post_author = msg.get("post_author")
     grouped_id = msg.get("grouped_id")
     via_bot_id = msg.get("via_bot_id")

--- a/src/paperboy/store/migrations/0001_init.sql
+++ b/src/paperboy/store/migrations/0001_init.sql
@@ -1,0 +1,213 @@
+-- 0001_init: raw log, entity/history/edge projections, sync state, search.
+--
+-- Every CREATE is IF NOT EXISTS: migrations run via sqlite3.executescript,
+-- which auto-commits each DDL statement as it runs (no multi-statement
+-- transaction wraps the whole file), so a migration interrupted partway
+-- through must be safe to re-run from the top. See store/db.py.
+
+-- ── Raw (system of record) ──────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS raw_records (
+    id           INTEGER PRIMARY KEY,
+    kind         TEXT NOT NULL,
+    observed_at  TEXT NOT NULL,
+    tier         TEXT NOT NULL,
+    context_json TEXT,
+    payload_json TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_raw_records_kind ON raw_records(kind, observed_at);
+
+-- ── Entities (current state) ────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS channels (
+    id                  INTEGER PRIMARY KEY,
+    uri                 TEXT NOT NULL UNIQUE,
+    username            TEXT,
+    title               TEXT,
+    about               TEXT,
+    kind                TEXT,
+    created_at          TEXT,
+    linked_chat_id      INTEGER,
+    participants_count  INTEGER,
+    flags_json          TEXT,
+    restriction_json    TEXT,
+    source_raw_id       INTEGER REFERENCES raw_records(id),
+    first_seen          TEXT NOT NULL,
+    last_seen           TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS peers (
+    uri            TEXT PRIMARY KEY,
+    kind           TEXT NOT NULL,
+    id             INTEGER NOT NULL,
+    access_hash    INTEGER,
+    is_min         INTEGER NOT NULL DEFAULT 0,
+    seen_in_chat   INTEGER,
+    seen_in_msg    INTEGER,
+    username       TEXT,
+    first_name     TEXT,
+    last_name      TEXT,
+    flags_json     TEXT,
+    source_raw_id  INTEGER REFERENCES raw_records(id),
+    first_seen     TEXT NOT NULL,
+    last_seen      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    uri              TEXT PRIMARY KEY,
+    channel_id       INTEGER NOT NULL,
+    msg_id           INTEGER NOT NULL,
+    date             TEXT,
+    edit_date        TEXT,
+    from_uri         TEXT,
+    post_author      TEXT,
+    text             TEXT NOT NULL DEFAULT '',
+    entities_json    TEXT,
+    media_kind       TEXT,
+    media_json       TEXT,
+    fwd_json         TEXT,
+    reply_to_msg_id  INTEGER,
+    reply_to_top_id  INTEGER,
+    grouped_id       INTEGER,
+    via_bot_id       INTEGER,
+    is_service       INTEGER NOT NULL DEFAULT 0,
+    action_json      TEXT,
+    content_hash     TEXT NOT NULL,
+    deleted_at       TEXT,
+    source_raw_id    INTEGER REFERENCES raw_records(id),
+    first_seen       TEXT NOT NULL,
+    last_seen        TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_channel_msg ON messages(channel_id, msg_id);
+
+CREATE TABLE IF NOT EXISTS media (
+    sha256          TEXT PRIMARY KEY,
+    message_uri     TEXT REFERENCES messages(uri),
+    kind            TEXT,
+    mime_type       TEXT,
+    size            INTEGER,
+    file_name       TEXT,
+    attributes_json TEXT,
+    path            TEXT,
+    downloaded_at   TEXT,
+    exif_json       TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_media_message ON media(message_uri);
+
+-- ── History (append-only) ───────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS channel_snapshots (
+    id                  INTEGER PRIMARY KEY,
+    channel_id          INTEGER NOT NULL,
+    observed_at         TEXT NOT NULL,
+    participants_count  INTEGER,
+    online_count        INTEGER,
+    title               TEXT,
+    username            TEXT,
+    about_hash          TEXT,
+    source_raw_id       INTEGER REFERENCES raw_records(id)
+);
+CREATE INDEX IF NOT EXISTS idx_channel_snapshots_channel ON channel_snapshots(channel_id, observed_at);
+
+CREATE TABLE IF NOT EXISTS message_revisions (
+    id             INTEGER PRIMARY KEY,
+    message_uri    TEXT NOT NULL REFERENCES messages(uri),
+    observed_at    TEXT NOT NULL,
+    edit_date      TEXT,
+    content_hash   TEXT NOT NULL,
+    text           TEXT,
+    entities_json  TEXT,
+    media_json     TEXT,
+    source_raw_id  INTEGER REFERENCES raw_records(id)
+);
+CREATE INDEX IF NOT EXISTS idx_message_revisions_msg ON message_revisions(message_uri, observed_at);
+
+CREATE TABLE IF NOT EXISTS message_metrics (
+    id             INTEGER PRIMARY KEY,
+    message_uri    TEXT NOT NULL REFERENCES messages(uri),
+    observed_at    TEXT NOT NULL,
+    views          INTEGER,
+    forwards       INTEGER,
+    replies        INTEGER,
+    reactions_json TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_message_metrics_msg ON message_metrics(message_uri, observed_at);
+
+CREATE TABLE IF NOT EXISTS message_tombstones (
+    id           INTEGER PRIMARY KEY,
+    message_uri  TEXT NOT NULL REFERENCES messages(uri),
+    observed_at  TEXT NOT NULL,
+    evidence     TEXT NOT NULL CHECK (evidence IN ('update', 'gap', 'empty'))
+);
+CREATE INDEX IF NOT EXISTS idx_message_tombstones_msg ON message_tombstones(message_uri, observed_at);
+
+-- ── Edges (triple-shaped graph) ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS edges (
+    id             INTEGER PRIMARY KEY,
+    subject_uri    TEXT NOT NULL,
+    predicate      TEXT NOT NULL,
+    object_uri     TEXT NOT NULL,
+    observed_at    TEXT NOT NULL,
+    tier           TEXT NOT NULL,
+    source_raw_id  INTEGER REFERENCES raw_records(id),
+    evidence_json  TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_edges_subject ON edges(subject_uri, predicate, object_uri);
+
+-- ── Sync ─────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS sync_state (
+    scope      TEXT NOT NULL,
+    key        TEXT NOT NULL,
+    value_json TEXT NOT NULL,
+    PRIMARY KEY (scope, key)
+);
+
+CREATE TABLE IF NOT EXISTS sync_ranges (
+    id          INTEGER PRIMARY KEY,
+    channel_id  INTEGER NOT NULL,
+    lo          INTEGER NOT NULL,
+    hi          INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sync_ranges_channel ON sync_ranges(channel_id, lo);
+
+CREATE TABLE IF NOT EXISTS flood_log (
+    id           INTEGER PRIMARY KEY,
+    method       TEXT NOT NULL,
+    until        TEXT NOT NULL,
+    seconds      INTEGER NOT NULL,
+    recorded_at  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_flood_log_method ON flood_log(method, recorded_at);
+
+-- ── Run bookkeeping ─────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS run_events (
+    id           INTEGER PRIMARY KEY,
+    observed_at  TEXT NOT NULL,
+    channel_id   INTEGER,
+    phase        TEXT,
+    kind         TEXT NOT NULL,
+    detail_json  TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_run_events_channel ON run_events(channel_id, observed_at);
+
+-- ── Custody ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS custody_log (
+    id                  INTEGER PRIMARY KEY,
+    path                TEXT NOT NULL,
+    sha256              TEXT NOT NULL,
+    recorded_at         TEXT NOT NULL,
+    source_message_uri  TEXT
+);
+
+-- ── Full-text search (Datasette-friendly external-content FTS5) ─────────
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+    text, content='messages', content_rowid='rowid'
+);
+
+CREATE TRIGGER IF NOT EXISTS messages_fts_ai AFTER INSERT ON messages BEGIN
+    INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
+END;
+CREATE TRIGGER IF NOT EXISTS messages_fts_ad AFTER DELETE ON messages BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, text) VALUES ('delete', old.rowid, old.text);
+END;
+CREATE TRIGGER IF NOT EXISTS messages_fts_au AFTER UPDATE ON messages BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, text) VALUES ('delete', old.rowid, old.text);
+    INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
+END;

--- a/src/paperboy/store/migrations/0001_init.sql
+++ b/src/paperboy/store/migrations/0001_init.sql
@@ -34,6 +34,11 @@ CREATE TABLE IF NOT EXISTS channels (
     last_seen           TEXT NOT NULL
 );
 
+-- `peers` is the generic min-provenance-tracked projection for ANY entity id
+-- encountered (`user`, `channel`, `chat`) — not just users. `title` covers
+-- channel/chat-typed peers; `first_name`/`last_name` cover user-typed peers.
+-- The richer, channel-specific state (about, kind, linked_chat_id, ...)
+-- lives in `channels`, which a channel-typed peer row also has an entry in.
 CREATE TABLE IF NOT EXISTS peers (
     uri            TEXT PRIMARY KEY,
     kind           TEXT NOT NULL,
@@ -45,6 +50,7 @@ CREATE TABLE IF NOT EXISTS peers (
     username       TEXT,
     first_name     TEXT,
     last_name      TEXT,
+    title          TEXT,
     flags_json     TEXT,
     source_raw_id  INTEGER REFERENCES raw_records(id),
     first_seen     TEXT NOT NULL,

--- a/src/paperboy/store/migrations/0001_init.sql
+++ b/src/paperboy/store/migrations/0001_init.sql
@@ -130,9 +130,13 @@ CREATE TABLE IF NOT EXISTS message_metrics (
 );
 CREATE INDEX IF NOT EXISTS idx_message_metrics_msg ON message_metrics(message_uri, observed_at);
 
+-- No FK to messages(uri): a `gap`/`empty` tombstone can be recorded for a
+-- message id that was probed but never itself observed/stored (spec §7 —
+-- deletion evidence for ids that never appeared in a verified-complete
+-- range or in any page of history).
 CREATE TABLE IF NOT EXISTS message_tombstones (
     id           INTEGER PRIMARY KEY,
-    message_uri  TEXT NOT NULL REFERENCES messages(uri),
+    message_uri  TEXT NOT NULL,
     observed_at  TEXT NOT NULL,
     evidence     TEXT NOT NULL CHECK (evidence IN ('update', 'gap', 'empty'))
 );

--- a/src/paperboy/store/peers.py
+++ b/src/paperboy/store/peers.py
@@ -1,0 +1,87 @@
+"""Peer projection: any `user`/`channel`/`chat` id ever encountered, with min-provenance.
+
+A `min` object (Telegram's stripped-down peer shape, seen inline in other
+responses) carries only enough to identify the id — never enough to be
+authoritative. If a fuller (non-min) row already exists, a `min` observation
+updates only *where we last saw it referenced* (`seen_in_chat`/`seen_in_msg`,
+used later for `inputPeerFromMessage`) and `last_seen`, never clobbering the
+richer stored profile with blanks.
+"""
+
+from __future__ import annotations
+
+from paperboy.ids import channel_uri, chat_uri, user_uri
+from paperboy.store.db import Store, dumps
+
+_FLAG_KEYS = (
+    "verified", "scam", "fake", "restricted", "bot", "premium", "deleted",
+    "broadcast", "megagroup", "gigagroup", "forum",
+)
+
+
+def _classify(obj: dict) -> tuple[str, str, int]:
+    """Map a TL peer-ish dict's `_` discriminator to (kind, uri, numeric id)."""
+    tag = obj["_"]
+    id_ = obj["id"]
+    if tag.startswith("user"):
+        return "user", user_uri(id_), id_
+    if tag.startswith("channel"):
+        return "channel", channel_uri(id_), id_
+    if tag.startswith("chat"):
+        return "chat", chat_uri(id_), id_
+    raise ValueError(f"not a peer object: {tag!r}")
+
+
+def upsert_peer(
+    store: Store,
+    obj: dict,
+    source_raw_id: int,
+    observed_at: str,
+    *,
+    seen_in_chat: int | None,
+    seen_in_msg: int | None,
+) -> str:
+    kind, uri, id_ = _classify(obj)
+    is_min = bool(obj.get("min"))
+
+    existing = store.conn.execute("SELECT is_min FROM peers WHERE uri=?", (uri,)).fetchone()
+    if is_min and existing is not None and not existing["is_min"]:
+        store.conn.execute(
+            "UPDATE peers SET seen_in_chat=?, seen_in_msg=?, source_raw_id=?, last_seen=? "
+            "WHERE uri=?",
+            (seen_in_chat, seen_in_msg, source_raw_id, observed_at, uri),
+        )
+        return uri
+
+    flags = {k: obj[k] for k in _FLAG_KEYS if k in obj}
+    flags_json = dumps(flags) if flags else None
+
+    store.conn.execute(
+        """
+        INSERT INTO peers (
+            uri, kind, id, access_hash, is_min, seen_in_chat, seen_in_msg,
+            username, first_name, last_name, title, flags_json, source_raw_id,
+            first_seen, last_seen
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(uri) DO UPDATE SET
+            kind=excluded.kind,
+            id=excluded.id,
+            access_hash=excluded.access_hash,
+            is_min=excluded.is_min,
+            seen_in_chat=excluded.seen_in_chat,
+            seen_in_msg=excluded.seen_in_msg,
+            username=excluded.username,
+            first_name=excluded.first_name,
+            last_name=excluded.last_name,
+            title=excluded.title,
+            flags_json=excluded.flags_json,
+            source_raw_id=excluded.source_raw_id,
+            last_seen=excluded.last_seen
+        """,
+        (
+            uri, kind, id_, obj.get("access_hash"), int(is_min), seen_in_chat, seen_in_msg,
+            obj.get("username"), obj.get("first_name"), obj.get("last_name"), obj.get("title"),
+            flags_json, source_raw_id, observed_at, observed_at,
+        ),
+    )
+    return uri

--- a/src/paperboy/store/peers.py
+++ b/src/paperboy/store/peers.py
@@ -10,7 +10,7 @@ richer stored profile with blanks.
 
 from __future__ import annotations
 
-from paperboy.ids import channel_uri, chat_uri, user_uri
+from paperboy.ids import channel_uri, chat_uri, primary_username, user_uri
 from paperboy.store.db import Store, dumps
 
 _FLAG_KEYS = (
@@ -20,8 +20,14 @@ _FLAG_KEYS = (
 
 
 def _classify(obj: dict) -> tuple[str, str, int]:
-    """Map a TL peer-ish dict's `_` discriminator to (kind, uri, numeric id)."""
-    tag = obj["_"]
+    """Map a TL peer-ish dict's `_` discriminator to (kind, uri, numeric id).
+
+    Telethon's `to_dict()` uses the PascalCase class name (`"Channel"`,
+    `"ChannelForbidden"`, ...), not the lowercase TL constructor name — this
+    lowercases before matching so both that and any hand-authored lowercase
+    test fixture work.
+    """
+    tag = obj["_"].lower()
     id_ = obj["id"]
     if tag.startswith("user"):
         return "user", user_uri(id_), id_
@@ -80,7 +86,7 @@ def upsert_peer(
         """,
         (
             uri, kind, id_, obj.get("access_hash"), int(is_min), seen_in_chat, seen_in_msg,
-            obj.get("username"), obj.get("first_name"), obj.get("last_name"), obj.get("title"),
+            primary_username(obj), obj.get("first_name"), obj.get("last_name"), obj.get("title"),
             flags_json, source_raw_id, observed_at, observed_at,
         ),
     )

--- a/src/paperboy/store/sync.py
+++ b/src/paperboy/store/sync.py
@@ -1,0 +1,73 @@
+"""Sync bookkeeping: opaque per-scope state (`pts`, cursors) and verified-range gap math.
+
+`sync_ranges` records message-id spans a collector has fully walked (every id
+in the span was either stored or probed) — the complement within a queried
+span is the set of gap candidates for `channels.getMessages` probing
+(spec §7).
+"""
+
+from __future__ import annotations
+
+import json
+
+from paperboy.store.db import Store, dumps
+
+
+def get_state(store: Store, scope: str, key: str) -> dict | None:
+    row = store.conn.execute(
+        "SELECT value_json FROM sync_state WHERE scope=? AND key=?", (scope, key)
+    ).fetchone()
+    return json.loads(row["value_json"]) if row else None
+
+
+def set_state(store: Store, scope: str, key: str, value: dict) -> None:
+    store.conn.execute(
+        "INSERT INTO sync_state(scope, key, value_json) VALUES (?, ?, ?) "
+        "ON CONFLICT(scope, key) DO UPDATE SET value_json=excluded.value_json",
+        (scope, key, dumps(value)),
+    )
+
+
+def add_range(store: Store, channel_id: int, lo: int, hi: int) -> None:
+    """Record `[lo, hi]` as verified-complete, coalescing with any touching range.
+
+    "Touching" includes adjacency (`existing.hi + 1 == lo`), not just overlap,
+    so two ranges walked in separate pages merge into one contiguous span
+    instead of leaving a phantom seam.
+    """
+    rows = store.conn.execute(
+        "SELECT id, lo, hi FROM sync_ranges WHERE channel_id=? ORDER BY lo", (channel_id,)
+    ).fetchall()
+    merged_lo, merged_hi = lo, hi
+    to_delete = []
+    for r in rows:
+        if r["lo"] <= merged_hi + 1 and r["hi"] >= merged_lo - 1:
+            merged_lo = min(merged_lo, r["lo"])
+            merged_hi = max(merged_hi, r["hi"])
+            to_delete.append(r["id"])
+    if to_delete:
+        store.conn.executemany(
+            "DELETE FROM sync_ranges WHERE id=?", [(i,) for i in to_delete]
+        )
+    store.conn.execute(
+        "INSERT INTO sync_ranges(channel_id, lo, hi) VALUES (?, ?, ?)",
+        (channel_id, merged_lo, merged_hi),
+    )
+
+
+def missing_ids(store: Store, channel_id: int, lo: int, hi: int) -> list[int]:
+    """Ids in `[lo, hi]` not covered by any verified-complete range for this channel."""
+    rows = store.conn.execute(
+        "SELECT lo, hi FROM sync_ranges WHERE channel_id=? AND hi >= ? AND lo <= ? ORDER BY lo",
+        (channel_id, lo, hi),
+    ).fetchall()
+    missing: list[int] = []
+    cursor = lo
+    for r in rows:
+        rlo, rhi = max(r["lo"], lo), min(r["hi"], hi)
+        if rlo > cursor:
+            missing.extend(range(cursor, rlo))
+        cursor = max(cursor, rhi + 1)
+    if cursor <= hi:
+        missing.extend(range(cursor, hi + 1))
+    return missing

--- a/src/paperboy/targets.py
+++ b/src/paperboy/targets.py
@@ -1,0 +1,87 @@
+"""Parse a user-supplied string into a typed :class:`Target`.
+
+Accepted shapes: ``@name``, bare ``name``, ``t.me/name``, ``t.me/+hash``,
+``t.me/joinchat/hash``, ``t.me/name/123`` (a message link), numeric peer ids,
+``+phone`` numbers, and ``#hashtag``. v1 recipes only act on channel-like
+targets (``is_channel_like``); the others parse cleanly so future recipes
+(phone lookup, hashtag search) can consume them, but attempting to collect
+against them today raises :class:`UnsupportedTarget` at the recipe layer, not
+here.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+
+class TargetKind(Enum):
+    USERNAME = "username"
+    INVITE = "invite"
+    MSG_LINK = "msg_link"
+    PEER_ID = "peer_id"
+    PHONE = "phone"
+    HASHTAG = "hashtag"
+
+
+class UnsupportedTarget(Exception):
+    """Raised when the input string does not match any known target shape."""
+
+
+@dataclass(frozen=True)
+class Target:
+    kind: TargetKind
+    raw: str
+    value: str
+    msg_id: int | None = None
+
+    @property
+    def is_channel_like(self) -> bool:
+        return self.kind in (
+            TargetKind.USERNAME,
+            TargetKind.INVITE,
+            TargetKind.MSG_LINK,
+            TargetKind.PEER_ID,
+        )
+
+
+_SCHEME_RE = re.compile(r"^(https?://)?(www\.)?t\.me/", re.IGNORECASE)
+# Invite hashes (`t.me/+AbCdEf...`) share the `+` prefix with E.164 phone
+# numbers (`+15551234567`); the negative lookahead excludes all-digit bodies
+# so a bare phone number falls through to `_PHONE_RE` instead.
+_INVITE_PLUS_RE = re.compile(r"^\+(?!\d+$)([A-Za-z0-9_-]+)$")
+_INVITE_JOINCHAT_RE = re.compile(r"^joinchat/([A-Za-z0-9_-]+)$")
+_MSG_LINK_RE = re.compile(r"^([A-Za-z][A-Za-z0-9_]{3,31})/(\d+)$")
+_USERNAME_RE = re.compile(r"^@?([A-Za-z][A-Za-z0-9_]{3,31})$")
+_PHONE_RE = re.compile(r"^\+\d{7,15}$")
+_PEER_ID_RE = re.compile(r"^-?\d+$")
+_HASHTAG_RE = re.compile(r"^#(\w+)$")
+
+
+def parse_target(text: str) -> Target:
+    raw = text
+    stripped = text.strip()
+    if not stripped:
+        raise UnsupportedTarget(f"empty target: {text!r}")
+
+    # Normalize away scheme + host so `t.me/...` and `https://t.me/...` share
+    # one code path.
+    body = _SCHEME_RE.sub("", stripped)
+
+    if m := _INVITE_PLUS_RE.match(body):
+        return Target(TargetKind.INVITE, raw, m.group(1))
+    if m := _INVITE_JOINCHAT_RE.match(body):
+        return Target(TargetKind.INVITE, raw, m.group(1))
+    if m := _MSG_LINK_RE.match(body):
+        return Target(TargetKind.MSG_LINK, raw, m.group(1), msg_id=int(m.group(2)))
+    if m := _USERNAME_RE.match(body):
+        return Target(TargetKind.USERNAME, raw, m.group(1))
+    if _PHONE_RE.match(body):
+        return Target(TargetKind.PHONE, raw, body)
+    if m := _HASHTAG_RE.match(body):
+        return Target(TargetKind.HASHTAG, raw, m.group(1))
+    if _PEER_ID_RE.match(body):
+        return Target(TargetKind.PEER_ID, raw, body)
+
+    raise UnsupportedTarget(f"unrecognized target: {text!r}")

--- a/src/paperboy/targets.py
+++ b/src/paperboy/targets.py
@@ -52,8 +52,11 @@ _SCHEME_RE = re.compile(r"^(https?://)?(www\.)?t\.me/", re.IGNORECASE)
 # so a bare phone number falls through to `_PHONE_RE` instead.
 _INVITE_PLUS_RE = re.compile(r"^\+(?!\d+$)([A-Za-z0-9_-]+)$")
 _INVITE_JOINCHAT_RE = re.compile(r"^joinchat/([A-Za-z0-9_-]+)$")
-_MSG_LINK_RE = re.compile(r"^([A-Za-z][A-Za-z0-9_]{3,31})/(\d+)$")
-_USERNAME_RE = re.compile(r"^@?([A-Za-z][A-Za-z0-9_]{3,31})$")
+_MSG_LINK_RE = re.compile(r"^([A-Za-z][A-Za-z0-9_]{0,31})/(\d+)$")
+# Telegram enforces its own (longer) minimum public-username length; this
+# module only recognizes the *shape* of a username-like token — an invalid
+# or nonexistent one still fails, later, at resolve() time.
+_USERNAME_RE = re.compile(r"^@?([A-Za-z][A-Za-z0-9_]{0,31})$")
 _PHONE_RE = re.compile(r"^\+\d{7,15}$")
 _PEER_ID_RE = re.compile(r"^-?\d+$")
 _HASHTAG_RE = re.compile(r"^#(\w+)$")

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,0 +1,9 @@
+"""Re-export `FakeGateway` under `tests.fakes` for collector/CLI tests.
+
+`pyproject.toml` sets `pythonpath = ["."]`, which is what makes
+`from tests.fakes import FakeGateway` resolve.
+"""
+
+from paperboy.gateway import FakeGateway
+
+__all__ = ["FakeGateway"]

--- a/tests/fixtures/tl/full_channel.json
+++ b/tests/fixtures/tl/full_channel.json
@@ -1,0 +1,22 @@
+{
+  "_": "messages.chatFull",
+  "full_chat": {
+    "_": "channelFull",
+    "id": 5,
+    "participants_count": 100,
+    "about": "x",
+    "pts": 42,
+    "linked_chat_id": 0
+  },
+  "chats": [
+    {
+      "_": "channel",
+      "id": 5,
+      "access_hash": 99,
+      "title": "Durov",
+      "username": "durov",
+      "broadcast": true
+    }
+  ],
+  "users": []
+}

--- a/tests/fixtures/tl/resolve_durov.json
+++ b/tests/fixtures/tl/resolve_durov.json
@@ -1,0 +1,14 @@
+{
+  "_": "contacts.resolvedPeer",
+  "chats": [
+    {
+      "_": "channel",
+      "id": 5,
+      "access_hash": 99,
+      "title": "Durov",
+      "username": "durov",
+      "broadcast": true
+    }
+  ],
+  "users": []
+}

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -96,6 +96,30 @@ async def test_admin_required_is_skip_and_record(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_transient_network_error_retries_without_polluting_flood_log(tmp_path):
+    # ConnectionError/TimeoutError/OSError classify as Disposition.RETRY too,
+    # but they carry no `.seconds` — `getattr(exc, "seconds", 0)` is 0, so a
+    # retry here must not write a spurious flood_log row (until=now,
+    # seconds=0); only genuine FloodWait retries belong in flood_log.
+    s = load_settings("default", {})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        b = Budget(s, st, sleeper=lambda x: None)
+
+        calls = {"n": 0}
+
+        async def flaky():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ConnectionError("connection reset")
+            return "ok"
+
+        result = await b.call("messages.getHistory", flaky)
+        assert result == "ok"
+        rows = st.conn.execute("select * from flood_log").fetchall()
+        assert rows == []
+
+
+@pytest.mark.asyncio
 async def test_min_interval_paces_repeat_calls_to_same_method(tmp_path):
     s = load_settings("default", {})
     with Store.open(tmp_path / "p.sqlite") as st:

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,118 @@
+import pytest
+
+from paperboy.budget import Budget, HardStop, PhaseStop, SkipAndRecord
+from paperboy.config import load_settings
+from paperboy.errors import Disposition, FakeFlood, FakePeerFlood, classify
+from paperboy.store.db import Store
+
+
+def test_flood_short_is_retryable():
+    assert classify(FakeFlood(3)) == Disposition.RETRY
+
+
+def test_flood_long_is_phase_stop():
+    assert classify(FakeFlood(120), threshold=60) == Disposition.PHASE_STOP
+
+
+def test_peer_flood_is_hard_stop():
+    assert classify(FakePeerFlood()) == Disposition.HARD_STOP
+
+
+def test_unrecognized_exception_is_reraised():
+    class Weird(Exception):
+        pass
+
+    with pytest.raises(Weird):
+        classify(Weird("boom"))
+
+
+@pytest.mark.asyncio
+async def test_rpc_cap(tmp_path):
+    s = load_settings("default", {"max_rpc_per_run": 2})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        slept = []
+        b = Budget(s, st, sleeper=lambda x: slept.append(x))
+
+        async def ok():
+            return 1
+
+        await b.call("m", ok)
+        await b.call("m", ok)
+        with pytest.raises(HardStop):
+            await b.call("m", ok)
+
+
+@pytest.mark.asyncio
+async def test_short_flood_wait_sleeps_and_retries(tmp_path):
+    s = load_settings("default", {})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        slept = []
+        b = Budget(s, st, sleeper=lambda x: slept.append(x))
+
+        calls = {"n": 0}
+
+        async def flaky():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise FakeFlood(3)
+            return "ok"
+
+        result = await b.call("messages.getHistory", flaky)
+        assert result == "ok"
+        assert slept == [3]
+        row = st.conn.execute("select method, seconds from flood_log").fetchone()
+        assert row["method"] == "messages.getHistory"
+        assert row["seconds"] == 3
+
+
+@pytest.mark.asyncio
+async def test_long_flood_wait_raises_phase_stop_and_persists_cooldown(tmp_path):
+    s = load_settings("default", {"flood_sleep_threshold": 10})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        b = Budget(s, st, sleeper=lambda x: None)
+
+        async def boom():
+            raise FakeFlood(999)
+
+        with pytest.raises(PhaseStop):
+            await b.call("messages.getHistory", boom)
+        row = st.conn.execute("select seconds from flood_log").fetchone()
+        assert row["seconds"] == 999
+
+
+@pytest.mark.asyncio
+async def test_admin_required_is_skip_and_record(tmp_path):
+    from telethon.errors import ChatAdminRequiredError
+
+    s = load_settings("default", {})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        b = Budget(s, st, sleeper=lambda x: None)
+
+        async def boom():
+            raise ChatAdminRequiredError(None)
+
+        with pytest.raises(SkipAndRecord):
+            await b.call("channels.getParticipants", boom)
+
+
+@pytest.mark.asyncio
+async def test_min_interval_paces_repeat_calls_to_same_method(tmp_path):
+    s = load_settings("default", {})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        slept = []
+        clock_time = [1000.0]
+
+        class FakeClock:
+            def time(self):
+                return clock_time[0]
+
+        b = Budget(s, st, clock=FakeClock(), sleeper=lambda x: slept.append(x))
+
+        async def ok():
+            return 1
+
+        await b.call("m", ok)
+        # No time has passed -> the second call to the same method must wait
+        # out the per-method minimum interval before proceeding.
+        await b.call("m", ok)
+        assert slept and slept[0] > 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,6 +71,28 @@ def test_collect_unsupported_target_exits_nonzero(tmp_path, monkeypatch):
     assert result.exit_code != 0
 
 
+def test_collect_history_alone_rejected_with_clear_message(tmp_path, monkeypatch):
+    # `history` depends on `channel_id`/`input_channel`, which only the
+    # `channel` collector populates *within one run* (access_hash isn't
+    # persisted between runs — see cli.py). Selecting `--phases history`
+    # alone must fail fast with an actionable message, not the raw
+    # `AssertionError` `HistoryCollector.collect` would otherwise raise.
+    async def fake_build_gateway(settings, secrets, profile, store):
+        del settings, secrets, profile, store
+        return FakeGateway(_fixtures())
+
+    monkeypatch.setattr(composition, "build_gateway", fake_build_gateway)
+
+    result = runner.invoke(
+        app,
+        ["collect", "@x", "--profile", "clitest_history_only", "--phases", "history", "--unsafe"],
+        env={"PAPERBOY_DATA_DIR": str(tmp_path)},
+    )
+    assert result.exit_code != 0
+    assert "channel" in result.stdout
+    assert "AssertionError" not in result.stdout
+
+
 def test_doctor_noncompliant_exits_nonzero(tmp_path, monkeypatch):
     async def fake_run_doctor(gateway, settings):
         del gateway, settings

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,136 @@
+from typer.testing import CliRunner
+
+from paperboy import app as composition
+from paperboy.cli import app
+from paperboy.doctor import Check
+from tests.fakes import FakeGateway
+
+runner = CliRunner()
+
+
+def _fixtures():
+    return {
+        "resolve": {
+            "chats": [
+                {
+                    "_": "channel", "id": 5, "access_hash": 99, "title": "X", "username": "x",
+                    "broadcast": True,
+                }
+            ],
+            "users": [],
+        },
+        "full_channel": {
+            "full_chat": {"_": "channelFull", "id": 5, "participants_count": 1, "pts": 1},
+            "chats": [
+                {"_": "channel", "id": 5, "access_hash": 99, "title": "X", "username": "x"}
+            ],
+            "users": [],
+        },
+        "self": {"_": "user", "id": 1, "self": True},
+        "history": [],
+        "channel_difference": {"_": "updates.channelDifferenceEmpty", "final": True, "pts": 1},
+    }
+
+
+def test_help_lists_commands():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    for cmd in ("auth", "doctor", "collect", "status", "export", "watch", "lookup"):
+        assert cmd in result.stdout
+
+
+def test_collect_writes_sqlite_and_exits_zero(tmp_path, monkeypatch):
+    async def fake_build_gateway(settings, secrets, profile, store):
+        del settings, secrets, profile, store
+        return FakeGateway(_fixtures())
+
+    monkeypatch.setattr(composition, "build_gateway", fake_build_gateway)
+
+    result = runner.invoke(
+        app,
+        ["collect", "@x", "--profile", "clitest", "--phases", "channel,history", "--unsafe"],
+        env={"PAPERBOY_DATA_DIR": str(tmp_path)},
+    )
+    assert result.exit_code == 0, result.stdout
+    db_path = tmp_path / "clitest" / "paperboy.sqlite"
+    assert db_path.exists()
+
+
+def test_collect_unsupported_target_exits_nonzero(tmp_path, monkeypatch):
+    async def fake_build_gateway(settings, secrets, profile, store):
+        del settings, secrets, profile, store
+        return FakeGateway(_fixtures())
+
+    monkeypatch.setattr(composition, "build_gateway", fake_build_gateway)
+
+    result = runner.invoke(
+        app,
+        ["collect", "", "--profile", "clitest2"],
+        env={"PAPERBOY_DATA_DIR": str(tmp_path)},
+    )
+    assert result.exit_code != 0
+
+
+def test_doctor_noncompliant_exits_nonzero(tmp_path, monkeypatch):
+    async def fake_run_doctor(gateway, settings):
+        del gateway, settings
+        return [Check("proxy", False, "no proxy configured", "fail")]
+
+    async def fake_build_gateway(settings, secrets, profile, store):
+        del settings, secrets, profile, store
+        return FakeGateway(_fixtures())
+
+    monkeypatch.setattr(composition, "build_gateway", fake_build_gateway)
+    monkeypatch.setattr("paperboy.cli.run_doctor", fake_run_doctor)
+
+    result = runner.invoke(
+        app, ["doctor", "--profile", "clitest3"], env={"PAPERBOY_DATA_DIR": str(tmp_path)}
+    )
+    assert result.exit_code != 0
+    assert "BLOCKED" in result.stdout
+
+
+def test_doctor_compliant_exits_zero(tmp_path, monkeypatch):
+    async def fake_run_doctor(gateway, settings):
+        del gateway, settings
+        return [Check("proxy", True, "proxy configured", "fail")]
+
+    async def fake_build_gateway(settings, secrets, profile, store):
+        del settings, secrets, profile, store
+        return FakeGateway(_fixtures())
+
+    monkeypatch.setattr(composition, "build_gateway", fake_build_gateway)
+    monkeypatch.setattr("paperboy.cli.run_doctor", fake_run_doctor)
+
+    result = runner.invoke(
+        app, ["doctor", "--profile", "clitest4"], env={"PAPERBOY_DATA_DIR": str(tmp_path)}
+    )
+    assert result.exit_code == 0
+    assert "PASS" in result.stdout
+
+
+def test_watch_and_lookup_are_phase_2_stubs():
+    result = runner.invoke(app, ["watch", "@x"])
+    assert result.exit_code != 0
+    assert "Phase 2" in result.stdout
+
+    result = runner.invoke(app, ["lookup", "phone", "+15551234567"])
+    assert result.exit_code != 0
+    assert "Phase 2" in result.stdout
+
+
+def test_status_on_empty_profile(tmp_path):
+    result = runner.invoke(
+        app, ["status", "--profile", "clitest5"], env={"PAPERBOY_DATA_DIR": str(tmp_path)}
+    )
+    assert result.exit_code == 0
+    assert "channels" in result.stdout
+
+
+def test_export_without_prior_collect_exits_nonzero(tmp_path):
+    result = runner.invoke(
+        app,
+        ["export", "@nosuchchannel", "--profile", "clitest6"],
+        env={"PAPERBOY_DATA_DIR": str(tmp_path)},
+    )
+    assert result.exit_code != 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,6 +131,58 @@ def test_doctor_compliant_exits_zero(tmp_path, monkeypatch):
     assert "PASS" in result.stdout
 
 
+def test_doctor_missing_credentials_exits_cleanly(tmp_path, monkeypatch):
+    # `build_gateway` -> `build_client` -> `resolve_api_id` raises `ConfigError`
+    # when no api_id/api_hash is configured for the profile (found live during
+    # VALIDATE-phase smoke testing: this previously reached `cli.py` as an
+    # uncaught exception and printed a raw traceback instead of `doctor`'s own
+    # actionable message).
+    async def raising_build_gateway(settings, secrets, profile, store):
+        del settings, secrets, store
+        raise composition.ConfigError(f"No api_id configured for profile {profile!r}")
+
+    monkeypatch.setattr(composition, "build_gateway", raising_build_gateway)
+
+    result = runner.invoke(
+        app, ["doctor", "--profile", "clitest_noconfig"], env={"PAPERBOY_DATA_DIR": str(tmp_path)}
+    )
+    assert result.exit_code == 1
+    assert "No api_id configured" in result.stdout
+    assert "Traceback" not in result.stdout
+
+
+def test_collect_missing_credentials_exits_cleanly(tmp_path, monkeypatch):
+    async def raising_build_gateway(settings, secrets, profile, store):
+        del settings, secrets, store
+        raise composition.ConfigError(f"No api_id configured for profile {profile!r}")
+
+    monkeypatch.setattr(composition, "build_gateway", raising_build_gateway)
+
+    result = runner.invoke(
+        app,
+        ["collect", "@x", "--profile", "clitest_noconfig2", "--unsafe"],
+        env={"PAPERBOY_DATA_DIR": str(tmp_path)},
+    )
+    assert result.exit_code == 1
+    assert "No api_id configured" in result.stdout
+    assert "Traceback" not in result.stdout
+
+
+def test_auth_missing_credentials_exits_cleanly(tmp_path, monkeypatch):
+    def raising_build_client(settings, secrets, profile):
+        del settings, secrets
+        raise composition.ConfigError(f"No api_id configured for profile {profile!r}")
+
+    monkeypatch.setattr(composition, "build_client", raising_build_client)
+
+    result = runner.invoke(
+        app, ["auth", "--profile", "clitest_noconfig3"], env={"PAPERBOY_DATA_DIR": str(tmp_path)}
+    )
+    assert result.exit_code == 1
+    assert "No api_id configured" in result.stdout
+    assert "Traceback" not in result.stdout
+
+
 def test_watch_and_lookup_are_phase_2_stubs():
     result = runner.invoke(app, ["watch", "@x"])
     assert result.exit_code != 0

--- a/tests/test_collector_base.py
+++ b/tests/test_collector_base.py
@@ -1,0 +1,46 @@
+import logging
+
+from paperboy.collectors.base import CollectContext, CollectResult
+from paperboy.config import load_settings
+from paperboy.targets import parse_target
+from tests.fakes import FakeGateway
+
+
+class DummyCollector:
+    name = "dummy"
+
+    def applies_to(self, target):
+        return target.is_channel_like
+
+    async def collect(self, ctx: CollectContext) -> CollectResult:
+        ctx.channel_id = 7
+        return CollectResult(name=self.name, counts={"things": 1})
+
+
+async def test_dummy_collector_runs_against_a_context(tmp_path):
+    from paperboy.store.db import Store
+
+    with Store.open(tmp_path / "p.sqlite") as st:
+        ctx = CollectContext(
+            gateway=FakeGateway({}),
+            store=st,
+            settings=load_settings("default", {}),
+            target=parse_target("@durov"),
+            input_channel=None,
+            channel_id=None,
+            tier="stranger",
+            log=logging.getLogger("t"),
+        )
+        collector = DummyCollector()
+        assert collector.applies_to(ctx.target)
+        result = await collector.collect(ctx)
+        assert result.name == "dummy"
+        assert result.counts == {"things": 1}
+        assert result.stopped is None
+        assert ctx.channel_id == 7
+
+
+def test_collect_result_defaults():
+    r = CollectResult(name="x")
+    assert r.counts == {}
+    assert r.stopped is None

--- a/tests/test_collector_channel.py
+++ b/tests/test_collector_channel.py
@@ -1,0 +1,83 @@
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from paperboy.collectors.base import CollectContext
+from paperboy.collectors.channel import ChannelCollector
+from paperboy.config import load_settings
+from paperboy.store.db import Store
+from paperboy.store.sync import get_state
+from paperboy.targets import parse_target
+from tests.fakes import FakeGateway
+
+FX = Path("tests/fixtures/tl")
+
+
+def _fixtures():
+    return {
+        "resolve": json.loads((FX / "resolve_durov.json").read_text()),
+        "full_channel": json.loads((FX / "full_channel.json").read_text()),
+        "self": {"_": "user", "id": 1, "self": True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_channel_collector(tmp_path):
+    gw = FakeGateway(_fixtures())
+    with Store.open(tmp_path / "p.sqlite") as st:
+        ctx = CollectContext(
+            gw, st, load_settings("default", {}), parse_target("@durov"),
+            None, None, "stranger", logging.getLogger("t"),
+        )
+        res = await ChannelCollector().collect(ctx)
+        assert ctx.channel_id is not None
+        row = st.conn.execute("select title, participants_count from channels").fetchone()
+        assert row["participants_count"] >= 0
+        assert res.counts["channels"] == 1
+
+
+@pytest.mark.asyncio
+async def test_channel_collector_sets_context_for_history(tmp_path):
+    gw = FakeGateway(_fixtures())
+    with Store.open(tmp_path / "p.sqlite") as st:
+        ctx = CollectContext(
+            gw, st, load_settings("default", {}), parse_target("@durov"),
+            None, None, "stranger", logging.getLogger("t"),
+        )
+        await ChannelCollector().collect(ctx)
+        assert ctx.channel_id == 5
+        assert ctx.input_channel == {"channel_id": 5, "access_hash": 99}
+
+
+@pytest.mark.asyncio
+async def test_channel_collector_seeds_pts(tmp_path):
+    gw = FakeGateway(_fixtures())
+    with Store.open(tmp_path / "p.sqlite") as st:
+        ctx = CollectContext(
+            gw, st, load_settings("default", {}), parse_target("@durov"),
+            None, None, "stranger", logging.getLogger("t"),
+        )
+        await ChannelCollector().collect(ctx)
+        assert get_state(st, "channel", "5") == {"pts": 42}
+
+
+@pytest.mark.asyncio
+async def test_channel_collector_records_raw_and_peers(tmp_path):
+    gw = FakeGateway(_fixtures())
+    with Store.open(tmp_path / "p.sqlite") as st:
+        ctx = CollectContext(
+            gw, st, load_settings("default", {}), parse_target("@durov"),
+            None, None, "stranger", logging.getLogger("t"),
+        )
+        await ChannelCollector().collect(ctx)
+        raw_kinds = {r["kind"] for r in st.conn.execute("select kind from raw_records")}
+        assert "channelFull" in raw_kinds or "messages.chatFull" in raw_kinds
+        peer_row = st.conn.execute("select uri from peers where uri='tg:channel:5'").fetchone()
+        assert peer_row is not None
+
+
+def test_applies_to_channel_like_targets():
+    assert ChannelCollector().applies_to(parse_target("@durov"))
+    assert not ChannelCollector().applies_to(parse_target("#osint"))

--- a/tests/test_collector_history.py
+++ b/tests/test_collector_history.py
@@ -1,0 +1,124 @@
+import logging
+
+import pytest
+
+from paperboy.collectors.base import CollectContext
+from paperboy.collectors.history import HistoryCollector
+from paperboy.config import load_settings
+from paperboy.store.db import Store
+from paperboy.store.sync import get_state
+from paperboy.targets import parse_target
+from tests.fakes import FakeGateway
+
+
+def _m(i, **extra):
+    m = {
+        "_": "message",
+        "id": i,
+        "message": f"m{i}",
+        "date": 1767322445,
+        "peer_id": {"channel_id": 5},
+    }
+    m.update(extra)
+    return m
+
+
+def _ctx(st, gw, channel_id=5, tier="stranger"):
+    return CollectContext(
+        gw, st, load_settings("default", {}), parse_target("@x"),
+        {"channel_id": channel_id, "access_hash": 9}, channel_id, tier, logging.getLogger("t"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_backfill_detects_gap(tmp_path):
+    # ids 5,4,2,1 present; id 3 is a hole -> get_messages returns messageEmpty for 3
+    gw = FakeGateway({
+        "history": [_m(5), _m(4), _m(2), _m(1)],
+        "get_messages": {3: {"_": "messageEmpty", "id": 3}},
+    })
+    with Store.open(tmp_path / "p.sqlite") as st:
+        res = await HistoryCollector().collect(_ctx(st, gw))
+        assert res.counts["messages"] == 4
+        tomb = st.conn.execute("select message_uri, evidence from message_tombstones").fetchall()
+        assert tomb and tomb[0]["evidence"] == "empty"
+        assert tomb[0]["message_uri"] == "tg:msg:5/3"
+
+
+@pytest.mark.asyncio
+async def test_backfill_records_verified_range(tmp_path):
+    gw = FakeGateway({
+        "history": [_m(5), _m(4), _m(2), _m(1)],
+        "get_messages": {3: {"_": "messageEmpty", "id": 3}},
+    })
+    with Store.open(tmp_path / "p.sqlite") as st:
+        await HistoryCollector().collect(_ctx(st, gw))
+        rows = st.conn.execute("select lo, hi from sync_ranges where channel_id=5").fetchall()
+        assert [(r["lo"], r["hi"]) for r in rows] == [(1, 5)]
+
+
+@pytest.mark.asyncio
+async def test_backfill_persists_resume_cursor(tmp_path):
+    gw = FakeGateway({"history": [_m(5), _m(4), _m(3)]})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        await HistoryCollector().collect(_ctx(st, gw))
+        assert get_state(st, "history", "5") == {"offset_id": 3}
+
+
+@pytest.mark.asyncio
+async def test_backfill_resumes_from_stored_cursor(tmp_path):
+    from paperboy.store.sync import set_state
+
+    gw = FakeGateway({"history": [_m(5), _m(4), _m(3), _m(2), _m(1)]})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        set_state(st, "history", "5", {"offset_id": 3})
+        res = await HistoryCollector().collect(_ctx(st, gw))
+        # Resumes at offset_id=3 -> only ids strictly below 3 are fetched.
+        assert res.counts["messages"] == 2
+        stored = {r["msg_id"] for r in st.conn.execute("select msg_id from messages")}
+        assert stored == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_no_gap_means_no_tombstones(tmp_path):
+    gw = FakeGateway({"history": [_m(3), _m(2), _m(1)]})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        res = await HistoryCollector().collect(_ctx(st, gw))
+        assert res.counts["messages"] == 3
+        assert res.counts["tombstones"] == 0
+        assert st.conn.execute("select count(*) as n from message_tombstones").fetchone()["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_forwarded_from_edge_recorded(tmp_path):
+    fwd_from = {"_": "messageFwdHeader", "from_id": {"_": "peerChannel", "channel_id": 999}}
+    msg = _m(1, fwd_from=fwd_from)
+    gw = FakeGateway({"history": [msg]})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        res = await HistoryCollector().collect(_ctx(st, gw))
+        assert res.counts["edges"] == 1
+        row = st.conn.execute(
+            "select subject_uri, predicate, object_uri from edges where predicate='forwarded_from'"
+        ).fetchone()
+        assert row["subject_uri"] == "tg:msg:5/1"
+        assert row["object_uri"] == "tg:channel:999"
+
+
+@pytest.mark.asyncio
+async def test_min_peer_recorded_with_message_provenance(tmp_path):
+    msg = _m(1, from_id={"_": "peerUser", "user_id": 42})
+    gw = FakeGateway({"history": [msg]})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        await HistoryCollector().collect(_ctx(st, gw))
+        row = st.conn.execute(
+            "select is_min, seen_in_chat, seen_in_msg from peers where uri='tg:user:42'"
+        ).fetchone()
+        assert row is not None
+        assert row["is_min"] == 1
+        assert row["seen_in_chat"] == 5
+        assert row["seen_in_msg"] == 1
+
+
+def test_applies_to_channel_like_targets():
+    assert HistoryCollector().applies_to(parse_target("@durov"))
+    assert not HistoryCollector().applies_to(parse_target("#osint"))

--- a/tests/test_collector_history.py
+++ b/tests/test_collector_history.py
@@ -2,6 +2,7 @@ import logging
 
 import pytest
 
+from paperboy.budget import PhaseStop
 from paperboy.collectors.base import CollectContext
 from paperboy.collectors.history import HistoryCollector
 from paperboy.config import load_settings
@@ -122,3 +123,29 @@ async def test_min_peer_recorded_with_message_provenance(tmp_path):
 def test_applies_to_channel_like_targets():
     assert HistoryCollector().applies_to(parse_target("@durov"))
     assert not HistoryCollector().applies_to(parse_target("#osint"))
+
+
+def _unset_ctx(st, gw):
+    # Mirrors what `collect_channel` builds before `channel` has run, and
+    # what it's left with if `channel` raised `PhaseStop` before setting
+    # `input_channel`/`channel_id` (e.g. a FLOOD_WAIT during resolve()).
+    return CollectContext(
+        gw, st, load_settings("default", {}), parse_target("@x"),
+        None, None, "stranger", logging.getLogger("t"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_collect_raises_phase_stop_when_channel_context_unset(tmp_path):
+    gw = FakeGateway({"history": [_m(1)]})
+    with Store.open(tmp_path / "p.sqlite") as st, pytest.raises(PhaseStop):
+        await HistoryCollector().collect(_unset_ctx(st, gw))
+
+
+@pytest.mark.asyncio
+async def test_catch_up_raises_phase_stop_when_channel_context_unset(tmp_path):
+    gw = FakeGateway({
+        "channel_difference": {"_": "updates.channelDifferenceEmpty", "final": True, "pts": 1},
+    })
+    with Store.open(tmp_path / "p.sqlite") as st, pytest.raises(PhaseStop):
+        await HistoryCollector().catch_up(_unset_ctx(st, gw))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+from paperboy.config import Settings, load_settings, profile_dir
+
+
+def test_env_override(monkeypatch):
+    monkeypatch.setenv("PAPERBOY_MAX_RPC_PER_RUN", "5")
+    s = load_settings("default", {})
+    assert s.max_rpc_per_run == 5
+    assert s.require_proxy is True
+
+
+def test_cli_override_beats_env(monkeypatch):
+    monkeypatch.setenv("PAPERBOY_PROFILE_BUDGET", "10")
+    s = load_settings("default", {"profile_budget": 3})
+    assert s.profile_budget == 3
+
+
+def test_defaults_match_spec(monkeypatch):
+    for var in (
+        "PAPERBOY_MAX_RPC_PER_RUN",
+        "PAPERBOY_PROFILE_BUDGET",
+        "PAPERBOY_MIN_SESSION_AGE_DAYS",
+        "PAPERBOY_FLOOD_SLEEP_THRESHOLD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    s = load_settings("default", {})
+    assert s.min_session_age_days == 7
+    assert s.flood_sleep_threshold == 60
+    assert s.max_rpc_per_run == 20000
+    assert s.profile_budget == 2000
+    assert s.allow_join is False
+    assert s.allow_phone_lookup is False
+    assert s.api_id is None
+    assert s.proxy is None
+
+
+def test_data_dir_expands_user():
+    s = load_settings("default", {"data_dir": "~/somewhere"})
+    assert s.data_dir == Path.home() / "somewhere"
+
+
+def test_device_identity_is_generic_not_official_client():
+    s = Settings()
+    d = s.device.device_model + s.device.system_version + s.device.app_version
+    for banned in ("Telegram Desktop", "TelegramAndroid", "iOS"):
+        assert banned not in d
+
+
+def test_profile_dir_scopes_data_dir(tmp_path):
+    s = load_settings("default", {"data_dir": str(tmp_path)})
+    assert profile_dir(s, "investigation-1") == tmp_path / "investigation-1"
+
+
+def test_two_profiles_dont_share_a_dir(tmp_path):
+    s = load_settings("default", {"data_dir": str(tmp_path)})
+    assert profile_dir(s, "a") != profile_dir(s, "b")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,103 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from paperboy.config import load_settings
+from paperboy.doctor import doctor_blocks, run_doctor
+from tests.fakes import FakeGateway
+
+
+def _fixtures(
+    *, proxy_ok=True, session_age_days=30, has_password=True, restrictive=True, minimal=True
+):
+    now = datetime.now(UTC)
+    created = now - timedelta(days=session_age_days)
+    self_user = {"_": "user", "id": 1, "self": True}
+    if not minimal:
+        self_user["username"] = "notminimal"
+        self_user["photo"] = {"_": "userProfilePhoto"}
+        self_user["about"] = "hello, this is my bio"
+
+    rule = {"_": "privacyValueDisallowAll"} if restrictive else {"_": "privacyValueAllowAll"}
+
+    return {
+        "self": self_user,
+        "authorizations": {
+            "authorizations": [
+                {"_": "authorization", "current": True, "date_created": created, "date_active": now}
+            ]
+        },
+        "password_state": {"_": "account.password", "has_password": has_password},
+        "privacy": {
+            "phone": {"rules": [rule]},
+            "lastseen": {"rules": [rule]},
+            "photo": {"rules": [rule]},
+        },
+    }, proxy_ok
+
+
+def _settings(proxy_ok, **overrides):
+    overrides.setdefault("require_proxy", True)
+    if proxy_ok:
+        overrides.setdefault("proxy", "socks5://127.0.0.1:9050")
+    return load_settings("default", overrides)
+
+
+@pytest.mark.asyncio
+async def test_compliant_account_passes_everything():
+    fx, proxy_ok = _fixtures()
+    gw = FakeGateway(fx)
+    settings = _settings(proxy_ok)
+    checks = await run_doctor(gw, settings)
+    assert checks
+    assert not doctor_blocks(checks)
+    assert all(c.ok for c in checks)
+
+
+@pytest.mark.asyncio
+async def test_no_proxy_and_young_session_both_fail():
+    fx, _ = _fixtures(session_age_days=1)
+    gw = FakeGateway(fx)
+    settings = _settings(proxy_ok=False)
+    checks = await run_doctor(gw, settings)
+    by_name = {c.name: c for c in checks}
+    assert by_name["proxy"].ok is False
+    assert by_name["proxy"].severity == "fail"
+    assert by_name["session_age"].ok is False
+    assert doctor_blocks(checks) is True
+
+
+@pytest.mark.asyncio
+async def test_no_2fa_fails():
+    fx, proxy_ok = _fixtures(has_password=False)
+    gw = FakeGateway(fx)
+    checks = await run_doctor(gw, _settings(proxy_ok))
+    by_name = {c.name: c for c in checks}
+    assert by_name["two_factor_auth"].ok is False
+    assert doctor_blocks(checks) is True
+
+
+@pytest.mark.asyncio
+async def test_permissive_privacy_fails():
+    fx, proxy_ok = _fixtures(restrictive=False)
+    gw = FakeGateway(fx)
+    checks = await run_doctor(gw, _settings(proxy_ok))
+    privacy_checks = [c for c in checks if c.name.startswith("privacy_")]
+    assert len(privacy_checks) == 3
+    assert all(not c.ok for c in privacy_checks)
+    assert doctor_blocks(checks) is True
+
+
+@pytest.mark.asyncio
+async def test_non_minimal_profile_warns_but_does_not_block():
+    fx, proxy_ok = _fixtures(minimal=False)
+    gw = FakeGateway(fx)
+    checks = await run_doctor(gw, _settings(proxy_ok))
+    by_name = {c.name: c for c in checks}
+    assert by_name["minimal_profile"].ok is False
+    assert by_name["minimal_profile"].severity == "warn"
+    assert doctor_blocks(checks) is False
+
+
+def test_doctor_blocks_is_false_for_no_checks():
+    assert doctor_blocks([]) is False

--- a/tests/test_export_jsonl.py
+++ b/tests/test_export_jsonl.py
@@ -1,0 +1,91 @@
+import json
+
+from paperboy.export.jsonl import export_jsonl
+from paperboy.store.channels import upsert_channel
+from paperboy.store.db import Store
+from paperboy.store.edges import add_edge
+from paperboy.store.messages import upsert_message
+from paperboy.store.sync import set_state
+
+
+def _seed(st, self_uri="tg:user:1"):
+    chan = {"_": "channel", "id": 5, "title": "Durov", "broadcast": True}
+    full = {"_": "channelFull", "id": 5, "participants_count": 10}
+    r = st.add_raw("channelFull", full, "stranger", None)
+    upsert_channel(st, full, chan, r, "2026-01-01T00:00:00+00:00")
+    set_state(st, "account", "self", {"uri": self_uri, "id": 1})
+
+
+def test_export_writes_three_files_with_revisions(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed(st)
+        m = {
+            "_": "message", "id": 1, "message": "hello", "date": 1767322445,
+            "peer_id": {"channel_id": 5},
+        }
+        r1 = st.add_raw("message", m, "stranger", None)
+        upsert_message(st, 5, m, r1, "2026-01-01T00:00:00+00:00", "stranger")
+        m2 = {**m, "message": "hello EDITED", "edit_date": 1767322900}
+        r2 = st.add_raw("message", m2, "stranger", None)
+        upsert_message(st, 5, m2, r2, "2026-01-02T00:00:00+00:00", "stranger")
+
+        out = tmp_path / "out"
+        counts = export_jsonl(st, "tg:channel:5", out)
+
+        assert counts == {"channel": 1, "messages": 1, "edges": 0}
+        assert (out / "channel.jsonl").exists()
+        lines = (out / "messages.jsonl").read_text().splitlines()
+        assert len(lines) == 1
+        row = json.loads(lines[0])
+        assert row["text"] == "hello EDITED"
+        assert row["deleted_at"] is None
+        assert [rev["text"] for rev in row["revisions"]] == ["hello", "hello EDITED"]
+        assert (out / "edges.jsonl").read_text() == ""
+
+
+def test_export_scrubs_self_authored_messages(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed(st, self_uri="tg:user:1")
+        m = {
+            "_": "message", "id": 1, "message": "not mine", "date": 1767322445,
+            "peer_id": {"channel_id": 5}, "from_id": {"_": "peerUser", "user_id": 2},
+        }
+        r1 = st.add_raw("message", m, "stranger", None)
+        upsert_message(st, 5, m, r1, "2026-01-01T00:00:00+00:00", "stranger")
+        self_msg = {
+            "_": "message", "id": 2, "message": "mine", "date": 1767322445,
+            "peer_id": {"channel_id": 5}, "from_id": {"_": "peerUser", "user_id": 1},
+        }
+        r2 = st.add_raw("message", self_msg, "self", None)
+        upsert_message(st, 5, self_msg, r2, "2026-01-01T00:00:00+00:00", "self")
+
+        out = tmp_path / "out"
+        counts = export_jsonl(st, "tg:channel:5", out)
+        assert counts["messages"] == 1
+        lines = (out / "messages.jsonl").read_text().splitlines()
+        assert json.loads(lines[0])["text"] == "not mine"
+
+
+def test_export_scopes_edges_to_channel(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed(st)
+        add_edge(
+            st, "tg:channel:5", "linked_group", "tg:channel:77",
+            "2026-01-01T00:00:00+00:00", "stranger", None, None,
+        )
+        add_edge(
+            st, "tg:channel:999", "linked_group", "tg:channel:888",
+            "2026-01-01T00:00:00+00:00", "stranger", None, None,
+        )
+        out = tmp_path / "out"
+        counts = export_jsonl(st, "tg:channel:5", out)
+        assert counts["edges"] == 1
+        lines = (out / "edges.jsonl").read_text().splitlines()
+        assert json.loads(lines[0])["object_uri"] == "tg:channel:77"
+
+
+def test_export_rejects_non_channel_uri(tmp_path):
+    import pytest
+
+    with Store.open(tmp_path / "p.sqlite") as st, pytest.raises(ValueError, match="channel URI"):
+        export_jsonl(st, "tg:user:1", tmp_path / "out")

--- a/tests/test_gateway_fake.py
+++ b/tests/test_gateway_fake.py
@@ -1,0 +1,59 @@
+import pytest
+
+from tests.fakes import FakeGateway
+
+
+@pytest.mark.asyncio
+async def test_fake_history_pages():
+    fx = {
+        "history": [
+            {"_": "message", "id": i, "message": f"m{i}", "date": 1767322445} for i in (3, 2, 1)
+        ]
+    }
+    gw = FakeGateway(fx)
+    ids = [m["id"] async for m in gw.iter_history({"channel_id": 7}, offset_id=0, limit=100)]
+    assert ids == [3, 2, 1]
+
+
+@pytest.mark.asyncio
+async def test_fake_history_resumes_from_offset_id():
+    fx = {"history": [{"_": "message", "id": i, "date": 1767322445} for i in (5, 4, 3, 2, 1)]}
+    gw = FakeGateway(fx)
+    ids = [m["id"] async for m in gw.iter_history({"channel_id": 7}, offset_id=3, limit=100)]
+    assert ids == [2, 1]
+
+
+@pytest.mark.asyncio
+async def test_fake_history_respects_limit():
+    fx = {"history": [{"_": "message", "id": i, "date": 1767322445} for i in (5, 4, 3, 2, 1)]}
+    gw = FakeGateway(fx)
+    ids = [m["id"] async for m in gw.iter_history({"channel_id": 7}, offset_id=0, limit=2)]
+    assert ids == [5, 4]
+
+
+@pytest.mark.asyncio
+async def test_fake_get_messages_fills_unknown_ids_with_message_empty():
+    gw = FakeGateway({"get_messages": {3: {"_": "messageEmpty", "id": 3}}})
+    result = await gw.get_messages({"channel_id": 7}, [3, 4])
+    assert result[0] == {"_": "messageEmpty", "id": 3}
+    assert result[1] == {"_": "messageEmpty", "id": 4}
+
+
+@pytest.mark.asyncio
+async def test_fake_resolve_and_full_channel_and_self():
+    fx = {
+        "resolve": {"chats": [{"_": "channel", "id": 5}], "users": []},
+        "full_channel": {"full_chat": {"_": "channelFull", "id": 5}},
+        "self": {"_": "user", "id": 1, "self": True},
+    }
+    gw = FakeGateway(fx)
+    assert await gw.resolve("durov") == fx["resolve"]
+    assert await gw.get_full_channel({"channel_id": 5}) == fx["full_channel"]
+    assert await gw.get_self() == fx["self"]
+
+
+@pytest.mark.asyncio
+async def test_fake_channel_difference():
+    diff = {"_": "updates.channelDifference", "pts": 50}
+    gw = FakeGateway({"channel_difference": diff})
+    assert await gw.get_channel_difference({"channel_id": 5}, pts=40, limit=100) == diff

--- a/tests/test_gateway_fake.py
+++ b/tests/test_gateway_fake.py
@@ -33,10 +33,10 @@ async def test_fake_history_respects_limit():
 
 @pytest.mark.asyncio
 async def test_fake_get_messages_fills_unknown_ids_with_message_empty():
-    gw = FakeGateway({"get_messages": {3: {"_": "messageEmpty", "id": 3}}})
+    gw = FakeGateway({"get_messages": {3: {"_": "MessageEmpty", "id": 3}}})
     result = await gw.get_messages({"channel_id": 7}, [3, 4])
-    assert result[0] == {"_": "messageEmpty", "id": 3}
-    assert result[1] == {"_": "messageEmpty", "id": 4}
+    assert result[0] == {"_": "MessageEmpty", "id": 3}
+    assert result[1] == {"_": "MessageEmpty", "id": 4}
 
 
 @pytest.mark.asyncio

--- a/tests/test_history_catchup.py
+++ b/tests/test_history_catchup.py
@@ -88,8 +88,8 @@ async def test_catchup_new_message_is_inserted(tmp_path):
 @pytest.mark.asyncio
 async def test_catchup_too_long_resyncs_pts_and_flags_resynced(tmp_path):
     diff = {
-        "_": "updates.channelDifferenceTooLong",
-        "dialog": {"_": "dialog", "pts": 999},
+        "_": "ChannelDifferenceTooLong",
+        "dialog": {"_": "Dialog", "pts": 999},
         "messages": [], "chats": [], "users": [],
     }
     gw = FakeGateway({"channel_difference": diff})

--- a/tests/test_history_catchup.py
+++ b/tests/test_history_catchup.py
@@ -1,0 +1,112 @@
+import logging
+
+import pytest
+
+from paperboy.collectors.base import CollectContext
+from paperboy.collectors.history import HistoryCollector
+from paperboy.config import load_settings
+from paperboy.store.db import Store
+from paperboy.store.messages import upsert_message
+from paperboy.store.sync import get_state, set_state
+from paperboy.targets import parse_target
+from tests.fakes import FakeGateway
+
+
+def _ctx(st, gw, channel_id=5):
+    return CollectContext(
+        gw, st, load_settings("default", {}), parse_target("@x"),
+        {"channel_id": channel_id, "access_hash": 9}, channel_id, "stranger",
+        logging.getLogger("t"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_catchup_applies_edit_and_delete(tmp_path):
+    diff = {
+        "_": "updates.channelDifference", "final": True, "pts": 50,
+        "new_messages": [
+            {
+                "_": "message", "id": 20, "message": "new", "date": 1767322445,
+                "peer_id": {"channel_id": 5},
+            }
+        ],
+        "other_updates": [
+            {
+                "_": "updateEditChannelMessage",
+                "message": {
+                    "_": "message", "id": 10, "message": "edited", "date": 1767322445,
+                    "edit_date": 1767322900, "peer_id": {"channel_id": 5},
+                },
+            },
+            {"_": "updateDeleteChannelMessages", "messages": [11]},
+        ],
+        "chats": [], "users": [],
+    }
+    gw = FakeGateway({"channel_difference": diff})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        for mid in (10, 11):
+            m = {
+                "_": "message", "id": mid, "message": "orig", "date": 1767322445,
+                "peer_id": {"channel_id": 5},
+            }
+            r = st.add_raw("message", m, "stranger", None)
+            upsert_message(st, 5, m, r, "2026-01-01T00:00:00+00:00", "stranger")
+        set_state(st, "channel", "5", {"pts": 40})
+        ctx = _ctx(st, gw)
+        res = await HistoryCollector().catch_up(ctx)
+        assert st.conn.execute(
+            "select deleted_at from messages where uri='tg:msg:5/11'"
+        ).fetchone()["deleted_at"] is not None
+        assert st.conn.execute(
+            "select text from messages where uri='tg:msg:5/10'"
+        ).fetchone()["text"] == "edited"
+        assert get_state(st, "channel", "5") == {"pts": 50}
+        assert res.counts["messages"] == 2  # the new message + the edit-applied one
+        assert res.counts["tombstones"] == 1
+
+
+@pytest.mark.asyncio
+async def test_catchup_new_message_is_inserted(tmp_path):
+    diff = {
+        "_": "updates.channelDifference", "final": True, "pts": 5,
+        "new_messages": [
+            {
+                "_": "message", "id": 1, "message": "hi", "date": 1767322445,
+                "peer_id": {"channel_id": 5},
+            }
+        ],
+        "other_updates": [], "chats": [], "users": [],
+    }
+    gw = FakeGateway({"channel_difference": diff})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        set_state(st, "channel", "5", {"pts": 1})
+        await HistoryCollector().catch_up(_ctx(st, gw))
+        row = st.conn.execute("select text from messages where uri='tg:msg:5/1'").fetchone()
+        assert row["text"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_catchup_too_long_resyncs_pts_and_flags_resynced(tmp_path):
+    diff = {
+        "_": "updates.channelDifferenceTooLong",
+        "dialog": {"_": "dialog", "pts": 999},
+        "messages": [], "chats": [], "users": [],
+    }
+    gw = FakeGateway({"channel_difference": diff})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        set_state(st, "channel", "5", {"pts": 1})
+        res = await HistoryCollector().catch_up(_ctx(st, gw))
+        assert get_state(st, "channel", "5") == {"pts": 999}
+        assert res.stopped == "resynced"
+
+
+@pytest.mark.asyncio
+async def test_catchup_defaults_pts_to_zero_when_unseeded(tmp_path):
+    diff = {
+        "_": "updates.channelDifference", "final": True, "pts": 5,
+        "new_messages": [], "other_updates": [], "chats": [], "users": [],
+    }
+    gw = FakeGateway({"channel_difference": diff})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        await HistoryCollector().catch_up(_ctx(st, gw))
+        assert get_state(st, "channel", "5") == {"pts": 5}

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -1,0 +1,43 @@
+from datetime import UTC, datetime
+
+from paperboy.ids import channel_uri, chat_uri, msg_uri, parse_uri, to_iso, user_uri, utc_now_iso
+
+
+def test_uris():
+    assert channel_uri(123) == "tg:channel:123"
+    assert chat_uri(456) == "tg:chat:456"
+    assert user_uri(789) == "tg:user:789"
+    assert msg_uri(123, 45) == "tg:msg:123/45"
+    assert parse_uri("tg:msg:123/45") == ("msg", (123, 45))
+    assert parse_uri("tg:user:9") == ("user", (9,))
+    assert parse_uri("tg:channel:5") == ("channel", (5,))
+    assert parse_uri("tg:chat:5") == ("chat", (5,))
+
+
+def test_parse_uri_malformed_raises():
+    import pytest
+
+    with pytest.raises(ValueError):
+        parse_uri("not-a-uri")
+    with pytest.raises(ValueError):
+        parse_uri("tg:msg:abc/def")
+
+
+def test_to_iso_normalizes_utc():
+    assert to_iso(datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)) == "2026-01-02T03:04:05+00:00"
+    # Epoch for 2026-01-02T03:04:05+00:00 (verified against datetime.fromtimestamp).
+    assert to_iso(1767323045) == "2026-01-02T03:04:05+00:00"
+
+
+def test_to_iso_requires_aware_datetime():
+    import pytest
+
+    with pytest.raises(ValueError):
+        to_iso(datetime(2026, 1, 2, 3, 4, 5))  # noqa: DTZ001 - deliberately naive
+
+
+def test_utc_now_iso_is_iso_utc():
+    s = utc_now_iso()
+    assert s.endswith("+00:00")
+    # round-trips through fromisoformat
+    datetime.fromisoformat(s)

--- a/tests/test_logging_redaction.py
+++ b/tests/test_logging_redaction.py
@@ -47,3 +47,25 @@ def test_child_logger_is_also_redacted(tmp_path):
     text = logf.read_text()
     assert "TOPSECRET_SESSION_STRING" not in text
     assert "***" in text
+
+
+def test_exception_traceback_is_redacted(tmp_path):
+    """A secret inside an exception's message must not reach the log via exc_info."""
+    import json as _json
+
+    logf = tmp_path / "p.log"
+    configure_logging(logf, console=False)
+    register_secret("SUPER_SECRET_HASH_VALUE")
+    log = logging.getLogger("paperboy.cli")
+    try:
+        raise RuntimeError("boom with SUPER_SECRET_HASH_VALUE inside")
+    except RuntimeError:
+        log.error("operation failed", exc_info=True)
+
+    raw = logf.read_text()
+    assert "SUPER_SECRET_HASH_VALUE" not in raw
+    # the exc_info field exists and is masked, and the traceback still logged
+    line = _json.loads([ln for ln in raw.splitlines() if ln.strip()][-1])
+    assert "exc_info" in line
+    assert "***" in line["exc_info"]
+    assert "RuntimeError" in line["exc_info"]

--- a/tests/test_logging_redaction.py
+++ b/tests/test_logging_redaction.py
@@ -1,0 +1,32 @@
+import logging
+
+from paperboy.logging_setup import configure_logging, register_secret
+
+
+def test_secret_is_masked(tmp_path, capsys):
+    logf = tmp_path / "p.log"
+    configure_logging(logf, console=True)
+    register_secret("hunter2SECRET")
+    logging.getLogger("paperboy").warning("session=%s", "hunter2SECRET")
+    assert "hunter2SECRET" not in logf.read_text()
+    assert "***" in logf.read_text()
+
+
+def test_unregistered_text_passes_through(tmp_path):
+    logf = tmp_path / "p2.log"
+    configure_logging(logf, console=False)
+    logging.getLogger("paperboy").info("resolved target=%s", "tg:channel:5")
+    assert "tg:channel:5" in logf.read_text()
+
+
+def test_multiple_secrets_all_masked(tmp_path):
+    logf = tmp_path / "p3.log"
+    configure_logging(logf, console=False)
+    register_secret("apihashvalue")
+    register_secret("sessionstringvalue")
+    logging.getLogger("paperboy").warning(
+        "auth api_hash=%s session=%s", "apihashvalue", "sessionstringvalue"
+    )
+    text = logf.read_text()
+    assert "apihashvalue" not in text
+    assert "sessionstringvalue" not in text

--- a/tests/test_logging_redaction.py
+++ b/tests/test_logging_redaction.py
@@ -30,3 +30,20 @@ def test_multiple_secrets_all_masked(tmp_path):
     text = logf.read_text()
     assert "apihashvalue" not in text
     assert "sessionstringvalue" not in text
+
+
+def test_child_logger_is_also_redacted(tmp_path):
+    # The app logs exclusively through child loggers (`paperboy.cli`, the
+    # `log` threaded into recipes/collectors) — records that propagate up
+    # from a child are only ever checked against each *handler's* filters
+    # (`Logger.callHandlers`), never re-checked against an ancestor logger's
+    # own filters. The `RedactionFilter` must therefore live on the
+    # handlers, not just the `paperboy` logger, or secrets logged through
+    # any child logger reach the file unmasked.
+    logf = tmp_path / "p4.log"
+    configure_logging(logf, console=False)
+    register_secret("TOPSECRET_SESSION_STRING")
+    logging.getLogger("paperboy.cli").warning("session=%s", "TOPSECRET_SESSION_STRING")
+    text = logf.read_text()
+    assert "TOPSECRET_SESSION_STRING" not in text
+    assert "***" in text

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from paperboy.budget import HardStop, PhaseStop
+from paperboy.budget import HardStop, PhaseStop, SkipAndRecord
 from paperboy.collectors.base import CollectContext, CollectResult
 from paperboy.config import load_settings
 from paperboy.recipes import collect_channel
@@ -98,3 +98,24 @@ async def test_phase_stop_continues_to_next_phase(tmp_path):
         assert [r.name for r in results] == ["a", "b"]
         assert results[0].stopped == "phase_stop"
         assert results[1].stopped is None
+
+
+@pytest.mark.asyncio
+async def test_skip_and_record_continues_to_next_phase(tmp_path):
+    # SkipAndRecord (Budget's Disposition.SKIP: e.g. ChannelPrivateError,
+    # ChatAdminRequiredError) means "skip this RPC/collector, the run
+    # continues" — it must never abort the whole run (spec §8).
+    with Store.open(tmp_path / "p.sqlite") as st:
+        collectors = [
+            _StubCollector("a", exc=SkipAndRecord("Channel is private")),
+            _StubCollector("b"),
+        ]
+        results = await collect_channel(
+            FakeGateway({}), st, load_settings("default", {}), parse_target("@durov"),
+            phases=["a", "b"], log=logging.getLogger("t"), collectors=collectors,
+        )
+        assert [r.name for r in results] == ["a", "b"]
+        assert results[0].stopped == "skip"
+        assert results[1].stopped is None
+        events = st.conn.execute("select kind from run_events order by id").fetchall()
+        assert [e["kind"] for e in events] == ["skip", "complete"]

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -1,0 +1,100 @@
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from paperboy.budget import HardStop, PhaseStop
+from paperboy.collectors.base import CollectContext, CollectResult
+from paperboy.config import load_settings
+from paperboy.recipes import collect_channel
+from paperboy.store.db import Store
+from paperboy.targets import parse_target
+from tests.fakes import FakeGateway
+
+FX = Path("tests/fixtures/tl")
+
+
+def _fixtures():
+    return {
+        "resolve": json.loads((FX / "resolve_durov.json").read_text()),
+        "full_channel": json.loads((FX / "full_channel.json").read_text()),
+        "self": {"_": "user", "id": 1, "self": True},
+        "history": [
+            {"_": "message", "id": i, "message": f"m{i}", "date": 1767322445} for i in (2, 1)
+        ],
+        "channel_difference": {"_": "updates.channelDifferenceEmpty", "final": True, "pts": 42},
+    }
+
+
+@pytest.mark.asyncio
+async def test_collect_channel_runs_channel_then_history(tmp_path):
+    gw = FakeGateway(_fixtures())
+    with Store.open(tmp_path / "p.sqlite") as st:
+        results = await collect_channel(
+            gw, st, load_settings("default", {}), parse_target("@durov"),
+            phases=["channel", "history"], log=logging.getLogger("t"),
+        )
+        assert [r.name for r in results] == ["channel", "history"]
+        assert st.conn.execute("select count(*) as n from channels").fetchone()["n"] == 1
+        assert st.conn.execute("select count(*) as n from messages").fetchone()["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_collect_channel_honors_phases_filter(tmp_path):
+    gw = FakeGateway(_fixtures())
+    with Store.open(tmp_path / "p.sqlite") as st:
+        results = await collect_channel(
+            gw, st, load_settings("default", {}), parse_target("@durov"),
+            phases=["channel"], log=logging.getLogger("t"),
+        )
+        assert [r.name for r in results] == ["channel"]
+        assert st.conn.execute("select count(*) as n from messages").fetchone()["n"] == 0
+
+
+class _StubCollector:
+    def __init__(self, name, exc=None):
+        self.name = name
+        self._exc = exc
+
+    def applies_to(self, target):
+        return True
+
+    async def collect(self, ctx: CollectContext) -> CollectResult:
+        if self._exc:
+            raise self._exc
+        return CollectResult(name=self.name, counts={"ok": 1})
+
+
+@pytest.mark.asyncio
+async def test_hard_stop_aborts_remaining_phases(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        collectors = [
+            _StubCollector("a"),
+            _StubCollector("b", exc=HardStop("boom")),
+            _StubCollector("c"),
+        ]
+        results = await collect_channel(
+            FakeGateway({}), st, load_settings("default", {}), parse_target("@durov"),
+            phases=["a", "b", "c"], log=logging.getLogger("t"), collectors=collectors,
+        )
+        assert [r.name for r in results] == ["a", "b"]
+        assert results[-1].stopped == "hard_stop"
+        events = st.conn.execute("select kind from run_events order by id").fetchall()
+        assert [e["kind"] for e in events] == ["complete", "hard_stop"]
+
+
+@pytest.mark.asyncio
+async def test_phase_stop_continues_to_next_phase(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        collectors = [
+            _StubCollector("a", exc=PhaseStop("flood")),
+            _StubCollector("b"),
+        ]
+        results = await collect_channel(
+            FakeGateway({}), st, load_settings("default", {}), parse_target("@durov"),
+            phases=["a", "b"], log=logging.getLogger("t"), collectors=collectors,
+        )
+        assert [r.name for r in results] == ["a", "b"]
+        assert results[0].stopped == "phase_stop"
+        assert results[1].stopped is None

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,16 @@
+from paperboy.secrets import MemorySecrets
+
+
+def test_memory_secrets_round_trip():
+    store = MemorySecrets()
+    assert store.get_api_hash() is None
+    assert store.get_session() is None
+    store.set_api_hash("abc123")
+    store.set_session("sess:xyz")
+    assert store.get_api_hash() == "abc123"
+    assert store.get_session() == "sess:xyz"
+
+
+def test_memory_secrets_seeded():
+    store = MemorySecrets({"api_hash": "seeded"})
+    assert store.get_api_hash() == "seeded"

--- a/tests/test_store_channels.py
+++ b/tests/test_store_channels.py
@@ -1,0 +1,69 @@
+from paperboy.store.channels import upsert_channel
+from paperboy.store.db import Store
+
+
+def test_upsert_channel_and_snapshot(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        chan = {
+            "_": "channel",
+            "id": 5,
+            "access_hash": 99,
+            "title": "Durov",
+            "username": "durov",
+            "broadcast": True,
+            "verified": True,
+        }
+        full = {
+            "_": "channelFull",
+            "id": 5,
+            "about": "Channel about text",
+            "participants_count": 100,
+            "pts": 42,
+            "linked_chat_id": 0,
+        }
+        r = st.add_raw("channelFull", full, "stranger", None)
+        uri = upsert_channel(st, full, chan, r, "2026-01-01T00:00:00+00:00")
+        assert uri == "tg:channel:5"
+        row = st.conn.execute(
+            "select title, participants_count, kind, about, linked_chat_id from channels where id=5"
+        ).fetchone()
+        assert row["title"] == "Durov"
+        assert row["participants_count"] == 100
+        assert row["kind"] == "broadcast"
+        assert row["about"] == "Channel about text"
+        assert row["linked_chat_id"] is None  # 0 normalized to "no linked chat"
+
+        snaps = st.conn.execute(
+            "select participants_count from channel_snapshots where channel_id=5"
+        ).fetchall()
+        assert [s["participants_count"] for s in snaps] == [100]
+
+
+def test_upsert_channel_records_a_new_snapshot_each_call(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        chan = {"_": "channel", "id": 5, "title": "Durov", "megagroup": True}
+        full1 = {"_": "channelFull", "id": 5, "participants_count": 100}
+        r1 = st.add_raw("channelFull", full1, "stranger", None)
+        upsert_channel(st, full1, chan, r1, "2026-01-01T00:00:00+00:00")
+        full2 = {"_": "channelFull", "id": 5, "participants_count": 150}
+        r2 = st.add_raw("channelFull", full2, "stranger", None)
+        upsert_channel(st, full2, chan, r2, "2026-01-02T00:00:00+00:00")
+
+        row = st.conn.execute("select participants_count from channels where id=5").fetchone()
+        assert row["participants_count"] == 150  # current state advances
+
+        snaps = st.conn.execute(
+            "select participants_count from channel_snapshots "
+            "where channel_id=5 order by observed_at"
+        ).fetchall()
+        assert [s["participants_count"] for s in snaps] == [100, 150]  # history preserved
+
+
+def test_linked_chat_id_preserved_when_present(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        chan = {"_": "channel", "id": 5, "title": "Durov", "broadcast": True}
+        full = {"_": "channelFull", "id": 5, "linked_chat_id": 77}
+        r = st.add_raw("channelFull", full, "stranger", None)
+        upsert_channel(st, full, chan, r, "2026-01-01T00:00:00+00:00")
+        row = st.conn.execute("select linked_chat_id from channels where id=5").fetchone()
+        assert row["linked_chat_id"] == 77

--- a/tests/test_store_edges.py
+++ b/tests/test_store_edges.py
@@ -1,0 +1,30 @@
+from paperboy.store.db import Store
+from paperboy.store.edges import add_edge
+
+
+def test_add_edge_round_trip(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        r = st.add_raw("channelFull", {"id": 5}, "stranger", None)
+        add_edge(
+            st, "tg:channel:5", "linked_group", "tg:chat:77",
+            "2026-01-01T00:00:00+00:00", "stranger", r, evidence={"field": "linked_chat_id"},
+        )
+        row = st.conn.execute(
+            "select subject_uri, predicate, object_uri, tier, evidence_json from edges"
+        ).fetchone()
+        assert row["subject_uri"] == "tg:channel:5"
+        assert row["predicate"] == "linked_group"
+        assert row["object_uri"] == "tg:chat:77"
+        assert row["tier"] == "stranger"
+        assert '"field"' in row["evidence_json"]
+
+
+def test_add_edge_without_evidence(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        r = st.add_raw("message", {"id": 1}, "stranger", None)
+        add_edge(
+            st, "tg:msg:5/1", "forwarded_from", "tg:channel:9",
+            "2026-01-01T00:00:00+00:00", "stranger", r, None,
+        )
+        row = st.conn.execute("select evidence_json from edges").fetchone()
+        assert row["evidence_json"] is None

--- a/tests/test_store_messages.py
+++ b/tests/test_store_messages.py
@@ -1,0 +1,106 @@
+from paperboy.store.db import Store
+from paperboy.store.messages import content_hash, mark_deleted, upsert_message
+
+
+def _msg(mid, text, views=None, edit=None, channel_id=7):
+    m = {
+        "_": "message",
+        "id": mid,
+        "date": 1767322445,
+        "message": text,
+        "peer_id": {"channel_id": channel_id},
+    }
+    if views is not None:
+        m["views"] = views
+    if edit is not None:
+        m["edit_date"] = edit
+    return m
+
+
+def test_edit_appends_revision(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        r1 = st.add_raw("message", _msg(10, "hello"), "stranger", None)
+        u = upsert_message(
+            st, 7, _msg(10, "hello", views=5), r1, "2026-01-01T00:00:00+00:00", "stranger"
+        )
+        r2 = st.add_raw("message", _msg(10, "hello EDITED", edit=1767322500), "stranger", None)
+        upsert_message(
+            st, 7, _msg(10, "hello EDITED", views=9, edit=1767322500), r2,
+            "2026-01-02T00:00:00+00:00", "stranger",
+        )
+        revs = st.conn.execute(
+            "select text from message_revisions where message_uri=? order by observed_at", (u,)
+        ).fetchall()
+        assert [r["text"] for r in revs] == ["hello", "hello EDITED"]
+        metrics = st.conn.execute(
+            "select views from message_metrics where message_uri=? order by observed_at", (u,)
+        ).fetchall()
+        assert [m["views"] for m in metrics] == [5, 9]
+
+
+def test_unchanged_content_does_not_append_revision(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        r1 = st.add_raw("message", _msg(12, "same"), "stranger", None)
+        u = upsert_message(st, 7, _msg(12, "same"), r1, "2026-01-01T00:00:00+00:00", "stranger")
+        r2 = st.add_raw("message", _msg(12, "same"), "stranger", None)
+        upsert_message(st, 7, _msg(12, "same"), r2, "2026-01-02T00:00:00+00:00", "stranger")
+        revs = st.conn.execute(
+            "select count(*) as n from message_revisions where message_uri=?", (u,)
+        ).fetchone()
+        assert revs["n"] == 1
+        # last_seen still advances even without a content change.
+        row = st.conn.execute(
+            "select last_seen, first_seen from messages where uri=?", (u,)
+        ).fetchone()
+        assert row["first_seen"] == "2026-01-01T00:00:00+00:00"
+        assert row["last_seen"] == "2026-01-02T00:00:00+00:00"
+
+
+def test_no_metrics_row_when_no_counters_present(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        r = st.add_raw("message", _msg(13, "x"), "stranger", None)
+        u = upsert_message(st, 7, _msg(13, "x"), r, "2026-01-01T00:00:00+00:00", "stranger")
+        n = st.conn.execute(
+            "select count(*) as n from message_metrics where message_uri=?", (u,)
+        ).fetchone()["n"]
+        assert n == 0
+
+
+def test_tombstone_only_sets_deleted_for_update(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        r = st.add_raw("message", _msg(11, "x"), "stranger", None)
+        u = upsert_message(st, 7, _msg(11, "x"), r, "2026-01-01T00:00:00+00:00", "stranger")
+        mark_deleted(st, 7, 11, "gap", "2026-01-03T00:00:00+00:00")
+
+        def _deleted_at():
+            return st.conn.execute(
+                "select deleted_at from messages where uri=?", (u,)
+            ).fetchone()["deleted_at"]
+
+        assert _deleted_at() is None
+        mark_deleted(st, 7, 11, "update", "2026-01-04T00:00:00+00:00")
+        assert _deleted_at() is not None
+        tombstones = st.conn.execute(
+            "select evidence from message_tombstones where message_uri=? order by observed_at", (u,)
+        ).fetchall()
+        assert [t["evidence"] for t in tombstones] == ["gap", "update"]
+
+
+def test_mark_deleted_for_never_seen_message_still_records_tombstone(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        mark_deleted(st, 7, 999, "empty", "2026-01-01T00:00:00+00:00")
+        rows = st.conn.execute("select evidence from message_tombstones").fetchall()
+        assert [r["evidence"] for r in rows] == ["empty"]
+
+
+def test_content_hash_changes_with_text():
+    a = content_hash("hello", None)
+    b = content_hash("hello!", None)
+    assert a != b
+    assert content_hash("hello", None) == a
+
+
+def test_content_hash_includes_media():
+    a = content_hash("hello", None)
+    b = content_hash("hello", '{"_": "messageMediaPhoto"}')
+    assert a != b

--- a/tests/test_store_migrations.py
+++ b/tests/test_store_migrations.py
@@ -1,0 +1,82 @@
+from paperboy.store.db import Store
+
+
+def test_migrations_and_raw(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        rid = st.add_raw(
+            "channelFull", {"id": 1, "title": "x"}, tier="stranger", context={"target": "@x"}
+        )
+        assert isinstance(rid, int)
+        row = st.conn.execute(
+            "select kind, payload_json, tier from raw_records where id=?", (rid,)
+        ).fetchone()
+        assert row["kind"] == "channelFull"
+        assert '"title"' in row["payload_json"]
+        assert row["tier"] == "stranger"
+        applied = [
+            r["name"]
+            for r in st.conn.execute("select name from schema_migrations order by name")
+        ]
+        assert "0001_init" in applied
+        assert st.conn.execute("pragma journal_mode").fetchone()[0].lower() == "wal"
+        assert st.conn.execute("pragma foreign_keys").fetchone()[0] == 1
+
+
+def test_add_raw_without_context(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        rid = st.add_raw("message", {"id": 5}, tier="member", context=None)
+        row = st.conn.execute("select context_json from raw_records where id=?", (rid,)).fetchone()
+        assert row["context_json"] is None
+
+
+def test_reopen_does_not_reapply_migrations(tmp_path):
+    path = tmp_path / "p.sqlite"
+    with Store.open(path) as st:
+        st.add_raw("x", {}, tier="stranger", context=None)
+    with Store.open(path) as st:
+        count = st.conn.execute("select count(*) from schema_migrations").fetchone()[0]
+        assert count == 1  # not reapplied / duplicated
+        rows = st.conn.execute("select count(*) from raw_records").fetchone()[0]
+        assert rows == 1
+
+
+def test_expected_tables_exist(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        names = {
+            r["name"]
+            for r in st.conn.execute("select name from sqlite_master where type='table'")
+        }
+        for expected in (
+            "raw_records",
+            "channels",
+            "peers",
+            "messages",
+            "media",
+            "channel_snapshots",
+            "message_revisions",
+            "message_metrics",
+            "message_tombstones",
+            "edges",
+            "sync_state",
+            "sync_ranges",
+            "flood_log",
+            "custody_log",
+            "run_events",
+            "schema_migrations",
+        ):
+            assert expected in names, f"missing table {expected}"
+
+
+def test_messages_fts_tracks_inserts(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        st.conn.execute(
+            "insert into messages"
+            "(uri, channel_id, msg_id, text, content_hash, first_seen, last_seen) "
+            "values ('tg:msg:1/1', 1, 1, 'hello world', 'h', 'now', 'now')"
+        )
+        hits = st.conn.execute(
+            "select messages.uri from messages "
+            "join messages_fts on messages.rowid = messages_fts.rowid "
+            "where messages_fts match 'hello'"
+        ).fetchall()
+        assert len(hits) == 1

--- a/tests/test_store_peers.py
+++ b/tests/test_store_peers.py
@@ -1,0 +1,58 @@
+from paperboy.store.db import Store
+from paperboy.store.peers import upsert_peer
+
+
+def test_min_does_not_clobber_full(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        full = {"_": "user", "id": 9, "access_hash": 111, "username": "real", "first_name": "Real"}
+        r1 = st.add_raw("user", full, "member", None)
+        upsert_peer(st, full, r1, "2026-01-01T00:00:00+00:00", seen_in_chat=None, seen_in_msg=None)
+        mn = {"_": "user", "id": 9, "min": True, "first_name": "MinName"}
+        r2 = st.add_raw("user", mn, "stranger", None)
+        upsert_peer(st, mn, r2, "2026-01-02T00:00:00+00:00", seen_in_chat=7, seen_in_msg=34)
+        row = st.conn.execute(
+            "select username, first_name, is_min, seen_in_msg from peers where uri='tg:user:9'"
+        ).fetchone()
+        assert row["username"] == "real"
+        assert row["first_name"] == "Real"  # not clobbered
+        assert row["seen_in_msg"] == 34  # provenance updated
+        assert row["is_min"] == 0  # the full row's is_min flag is untouched
+
+
+def test_first_observation_min_is_stored_as_is(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        mn = {"_": "user", "id": 42, "min": True, "first_name": "OnlyMin"}
+        r = st.add_raw("user", mn, "stranger", None)
+        uri = upsert_peer(st, mn, r, "2026-01-01T00:00:00+00:00", seen_in_chat=7, seen_in_msg=1)
+        assert uri == "tg:user:42"
+        row = st.conn.execute("select is_min, first_name from peers where uri=?", (uri,)).fetchone()
+        assert row["is_min"] == 1
+        assert row["first_name"] == "OnlyMin"
+
+
+def test_full_observation_overwrites_a_prior_full_observation(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        old = {"_": "user", "id": 9, "username": "old_handle", "first_name": "Old"}
+        r1 = st.add_raw("user", old, "member", None)
+        upsert_peer(st, old, r1, "2026-01-01T00:00:00+00:00", seen_in_chat=None, seen_in_msg=None)
+        new = {"_": "user", "id": 9, "username": "new_handle", "first_name": "New"}
+        r2 = st.add_raw("user", new, "member", None)
+        upsert_peer(st, new, r2, "2026-01-02T00:00:00+00:00", seen_in_chat=None, seen_in_msg=None)
+        row = st.conn.execute(
+            "select username, first_name from peers where uri='tg:user:9'"
+        ).fetchone()
+        assert row["username"] == "new_handle"
+        assert row["first_name"] == "New"
+
+
+def test_channel_typed_peer_stores_title(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        chan = {"_": "channel", "id": 5, "access_hash": 99, "title": "Durov", "username": "durov"}
+        r = st.add_raw("channel", chan, "stranger", None)
+        uri = upsert_peer(
+            st, chan, r, "2026-01-01T00:00:00+00:00", seen_in_chat=None, seen_in_msg=None
+        )
+        assert uri == "tg:channel:5"
+        row = st.conn.execute("select kind, title from peers where uri=?", (uri,)).fetchone()
+        assert row["kind"] == "channel"
+        assert row["title"] == "Durov"

--- a/tests/test_store_sync.py
+++ b/tests/test_store_sync.py
@@ -1,0 +1,55 @@
+from paperboy.store.db import Store
+from paperboy.store.sync import add_range, get_state, missing_ids, set_state
+
+
+def test_range_merge_and_gap(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        add_range(st, 7, 1, 5)
+        add_range(st, 7, 6, 10)  # adjacent -> merges to 1..10
+        add_range(st, 7, 20, 25)
+        assert missing_ids(st, 7, 1, 25) == list(range(11, 20))
+        rows = st.conn.execute(
+            "select lo,hi from sync_ranges where channel_id=7 order by lo"
+        ).fetchall()
+        assert [(r["lo"], r["hi"]) for r in rows] == [(1, 10), (20, 25)]
+
+
+def test_range_merge_bridges_a_gap_from_both_sides(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        add_range(st, 7, 1, 5)
+        add_range(st, 7, 8, 10)
+        add_range(st, 7, 6, 7)  # fills the gap between the two -> single 1..10
+        rows = st.conn.execute(
+            "select lo,hi from sync_ranges where channel_id=7 order by lo"
+        ).fetchall()
+        assert [(r["lo"], r["hi"]) for r in rows] == [(1, 10)]
+
+
+def test_overlapping_ranges_merge(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        add_range(st, 7, 1, 10)
+        add_range(st, 7, 5, 15)
+        rows = st.conn.execute(
+            "select lo,hi from sync_ranges where channel_id=7 order by lo"
+        ).fetchall()
+        assert [(r["lo"], r["hi"]) for r in rows] == [(1, 15)]
+
+
+def test_missing_ids_with_no_ranges_is_everything(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        assert missing_ids(st, 7, 1, 5) == [1, 2, 3, 4, 5]
+
+
+def test_channels_have_independent_ranges(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        add_range(st, 7, 1, 10)
+        assert missing_ids(st, 8, 1, 10) == list(range(1, 11))
+
+
+def test_state_round_trip(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        assert get_state(st, "channel", "5") is None
+        set_state(st, "channel", "5", {"pts": 42})
+        assert get_state(st, "channel", "5") == {"pts": 42}
+        set_state(st, "channel", "5", {"pts": 99})
+        assert get_state(st, "channel", "5") == {"pts": 99}

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -53,4 +53,4 @@ def test_unsupported_target_raises():
 def test_target_is_frozen():
     t = parse_target("@durov")
     with pytest.raises(Exception):  # noqa: B017, PT011 - frozen dataclass raises FrozenInstanceError
-        t.value = "x"
+        setattr(t, "value", "x")  # noqa: B010 - setattr avoids a static assignment to a frozen field

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -1,0 +1,56 @@
+import pytest
+
+from paperboy.targets import TargetKind, UnsupportedTarget, parse_target
+
+
+@pytest.mark.parametrize(
+    "text,kind,value",
+    [
+        ("@durov", TargetKind.USERNAME, "durov"),
+        ("https://t.me/durov", TargetKind.USERNAME, "durov"),
+        ("t.me/+AbCdEf", TargetKind.INVITE, "AbCdEf"),
+        ("t.me/joinchat/AbCdEf", TargetKind.INVITE, "AbCdEf"),
+        ("https://t.me/durov/1234", TargetKind.MSG_LINK, "durov"),
+        ("-1001234567890", TargetKind.PEER_ID, "-1001234567890"),
+        ("+15551234567", TargetKind.PHONE, "+15551234567"),
+        ("#osint", TargetKind.HASHTAG, "osint"),
+    ],
+)
+def test_parse(text, kind, value):
+    t = parse_target(text)
+    assert t.kind == kind
+    assert t.value == value
+    assert t.raw == text
+
+
+def test_msg_link_captures_id():
+    assert parse_target("t.me/durov/1234").msg_id == 1234
+
+
+def test_non_msg_link_has_no_msg_id():
+    assert parse_target("@durov").msg_id is None
+
+
+def test_channel_like():
+    assert parse_target("@durov").is_channel_like
+    assert parse_target("t.me/+AbCdEf").is_channel_like
+    assert parse_target("https://t.me/durov/1234").is_channel_like
+    assert parse_target("-1001234567890").is_channel_like
+    assert not parse_target("#osint").is_channel_like
+    assert not parse_target("+15551234567").is_channel_like
+
+
+def test_bare_username_without_at():
+    bare, at = parse_target("durov"), parse_target("@durov")
+    assert (bare.kind, bare.value) == (at.kind, at.value) == (TargetKind.USERNAME, "durov")
+
+
+def test_unsupported_target_raises():
+    with pytest.raises(UnsupportedTarget):
+        parse_target("")
+
+
+def test_target_is_frozen():
+    t = parse_target("@durov")
+    with pytest.raises(Exception):  # noqa: B017, PT011 - frozen dataclass raises FrozenInstanceError
+        t.value = "x"

--- a/uv.lock
+++ b/uv.lock
@@ -320,6 +320,7 @@ dependencies = [
     { name = "httpx" },
     { name = "keyring" },
     { name = "pydantic-settings" },
+    { name = "pysocks" },
     { name = "rich" },
     { name = "structlog" },
     { name = "telethon" },
@@ -339,6 +340,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "keyring", specifier = ">=25" },
     { name = "pydantic-settings", specifier = ">=2.4" },
+    { name = "pysocks", specifier = ">=1.7" },
     { name = "rich", specifier = ">=13" },
     { name = "structlog", specifier = ">=24" },
     { name = "telethon", specifier = "==1.44.*" },
@@ -510,6 +512,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
+]
+
+[[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements **paperboy core (`collect-channel`)** — issue #5, Tasks 1–17 of the pre-approved plan. Read-only channel collection: metadata + snapshots, full message history with edit revisions, gap-based deletion tombstones, `pts` incremental sync, JSONL export, and an opsec `doctor` preflight — all behind the budget/guardrail layer.

> **How this landed:** the `single-feature-run` workflow implemented all 17 tasks (Sonnet) and ran the review panel (Opus). Security ✓ and adversarial ✓ passed; correctness **rejected** with 3 real defects, which are fixed in the last two commits. The workflow then **died** when a sandboxed agent, trying to run the live smoke, attempted to read the Keychain and then to loosen the sandbox — **blocked by the safety classifier; no credentials were read or exposed.** The code fixes it had committed were vetted line-by-line (clean, no credential access) and merged; the live smoke was then run on the main thread. Details in issue #5.

---

## Changes
Implements paperboy core (`collect-channel`), Tasks 1–17 of `docs/superpowers/plans/2026-08-20-paperboy-core.md`, as 20 TDD commits on `feat/core`:
- `ids.py`, `targets.py` — URI ids/time helpers; target parsing.
- `config.py`, `secrets.py`, `logging_setup.py` — Settings, keyring SecretStore, **handler-level redaction** (child-logger-safe).
- `store/` — SQLite WAL, migrations, raw-record log, message projection (revisions/tombstones/metrics), min-provenance peers, channel/edge projections, sync-range math, FTS5.
- `budget.py`, `errors.py` — per-method pacing, persisted cooldowns, RPC error→disposition classification (RETRY/SKIP/PHASE_STOP/HARD_STOP).
- `gateway.py` — `Gateway` Protocol + `FakeGateway` + `TelethonGateway` (returns `to_dict()`).
- `collectors/` — `channel`, `history` (backfill + gap tombstones + `pts` catch-up).
- `recipes.py`, `export/jsonl.py`, `doctor.py`, `cli.py`, `app.py`.

Includes the correctness-review fixes (SkipAndRecord caught + continue; history guards → handled PhaseStop; **redaction moved to handlers**; spurious flood_log rows guarded; ConfigError → clean CLI message).

## Tests
- unit + integration + regression: **124 passed** (`uv run pytest -q`)
- lint: **pass** (`uv run ruff check` — All checks passed)
- type-check: **pass** (`uv run pyright` — 0 errors, 0 warnings)

## Smoke test transcript (live, main thread, read-only, against @durov)
Sandboxed workflow agents cannot reach the Keychain (a deliberate boundary); the live smoke was run on the main thread where keyring resolves the research account.

```
$ paperboy --help
  → lists auth, doctor, collect, status, export; watch/lookup marked "not in core v1"

$ paperboy doctor --profile default            # real API reads of the live account
  proxy            fail  require_proxy set but no proxy configured
  session_age      fail  session 0.1 days old, below min_session_age_days=7
  two_factor_auth  fail  no 2FA password set
  privacy_phone    ok    phone privacy restricted
  privacy_lastseen fail  lastseen privacy Everyone
  privacy_photo    fail  photo privacy Everyone
  minimal_profile  ok    self profile minimal
  BLOCKED: collect refuses to run without --unsafe.

$ paperboy collect @durov --profile default    # doctor-FAIL blocks collect
  doctor preflight failed — refusing to collect. ... pass --unsafe to override.   (exit 1)

$ paperboy collect @durov --profile default --unsafe   # real un-joined collection
  channel  {'channels': 1, 'peers': 2}
  history  {'messages': 476, 'revisions': 476, 'tombstones': 67, 'edges': 1}

$ paperboy status @durov      → messages 476, revisions 476, tombstones 67
$ paperboy export @durov --format jsonl
  channel.jsonl 1 | messages.jsonl 476 | edges.jsonl 1
```

Database verification (live DB):
```
raw_records          547     # raw-first persistence: every TL object stored before projection
messages             476
message_revisions    476
message_tombstones    67     # all evidence='empty' — gap-based deletion detection worked
edges                  1
peers                  3
messages_fts         476     # FTS5 populated (Datasette/tapedeck-ready)
```
Redaction spot-check on the live `paperboy.log`: **0** api_hash-shaped (32-hex) tokens.

### Edge cases covered (from the plan/DoD)
- happy path (collect + status + export) ✓
- `--help` ✓
- **doctor FAIL blocks collect** ✓ (and `--unsafe` override ✓)
- un-joined reading of a public channel ✓ (never joined @durov)
- gap-based deletion tombstones ✓ (67 real deletions detected)

### Not re-run live (honest gaps)
- `CHAT_ADMIN_REQUIRED` skip through the *full* recipe (settled at the `Budget.call` layer in Spike 1; the recipe-level `except SkipAndRecord` is unit-tested but not yet driven by a live private channel).
- A real `FLOOD_WAIT` sleep, and Ctrl-C-resume against live network (unit-tested; not driven live).
These are follow-ups for the next interactive session; commands in `docs/features/collect-channel.md`.

## Docs updated
- `docs/features/collect-channel.md` (feature doc + both smoke transcripts).

## Follow-ups
- Live-drive the recipe-level SKIP path against a private/no-admin channel.
- **CI is billing-blocked** on this private repo (GitHub Actions spending limit) — local green + this transcript are the validation gate until that's resolved or the repo goes public.
- Operator note: the research account fails most `doctor` checks (no proxy, young session, no 2FA, lax privacy) — harden before real collection.

---
## Reviewer verdicts
- **Security (Opus):** pass — SQL parameterized, secrets keychain-only + log-redacted, safe-by-default opsec gates.
- **Adversarial (Opus):** pass — re-ran the suite, reconciled counts, verified the `--phases` fix is discriminating.
- **Correctness (Opus):** reject → **all 3 findings fixed** (SkipAndRecord caught + continue; history guards; handler-level redaction). An independent correctness re-review of the fixes is running; verdict will be posted as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
