### PR TITLE
Phase 2 (wave 1): media, graph, web collectors

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -2,8 +2,9 @@
 
 The complete reference for the SQLite database paperboy writes to
 `<data_dir>/<profile>/paperboy.sqlite` (default `./data/default/paperboy.sqlite`).
-The authoritative schema is `src/paperboy/store/migrations/0001_init.sql`; this
-document explains what each table and column means.
+The authoritative schema is `src/paperboy/store/migrations/*.sql`
+(`0001_init.sql` + per-feature files like `0002_web.sql`); this document
+explains what each table and column means.
 
 For a quick orientation and how to browse the data (Datasette, `sqlite3`), see
 the **"What's in the database"** section of the [README](../README.md).
@@ -280,6 +281,30 @@ SHA-256 of every file paperboy writes to disk, for forensic integrity.
 | `sha256` | TEXT | Hash at write time. |
 | `recorded_at` | TEXT | When. |
 | `source_message_uri` | TEXT | Message the file came from, if any. |
+
+## Web (Phase 2)
+
+### `web_snapshots` — `t.me/s/` post captures + Wayback CDX index (migration `0002_web`)
+
+Append-only observation log (like `channel_snapshots`), written by the `web`
+collector (`collectors/web.py`) over `WebClient` — the allow-listed HTTP
+seam (`t.me`/`www.t.me`/`web.archive.org` only, spec §2). `source='tme'` is
+one row per post parsed off a `t.me/s/<name>` page; `source='wayback'` is
+one row per Wayback Machine CDX index entry for `t.me/s/<name>*` (the whole
+page snapshot index, not per-post — `msg_id` is `NULL`).
+
+| Column | Type | Meaning |
+|---|---|---|
+| `id` | INTEGER PK | Row id. |
+| `source` | TEXT | `tme` or `wayback`. |
+| `url` | TEXT | The post permalink (`tme`) or the CDX row's `original` URL (`wayback`). |
+| `fetched_at` | TEXT | When paperboy fetched this. |
+| `channel_username` | TEXT | The `t.me/s/<name>` username. |
+| `msg_id` | INTEGER | Post id (`tme` only; `NULL` for `wayback`). |
+| `timestamp` | TEXT | The post's `datetime` attribute (`tme`), or the CDX snapshot time converted to ISO-8601 UTC (`wayback`). |
+| `content_hash` | TEXT | SHA-256 of the post text (`tme`), or the CDX row's own `digest` (`wayback`). |
+| `raw` | TEXT (JSON) | The parsed post fields (`tme`) or the full CDX row (`wayback`) — the verbatim page/response itself is in `raw_records` (`kind='tme_page'`/`'wayback_cdx'`), not duplicated here. |
+| `meta_json` | TEXT (JSON) | `tme`: `views`, `author_signature`, `forwarded_from`, `tombstoned_in_store` (deleted-post recovery — set when this post id is tombstoned in `message_tombstones`, meaning the web page still serves content the MTProto API no longer will). `wayback`: `statuscode`, `length`, `mimetype`. |
 
 ## Full-text search
 

--- a/src/paperboy/cli.py
+++ b/src/paperboy/cli.py
@@ -131,13 +131,14 @@ async def _run_doctor(settings, secrets, profile: str, store):
 def collect(
     target: str,
     profile: str = typer.Option("default", "--profile"),
-    phases: str = typer.Option(None, "--phases", help="Comma-separated: channel,history"),
+    phases: str = typer.Option(None, "--phases", help="Comma-separated: channel,history,graph"),
     join: bool = typer.Option(False, "--join", help="Not implemented in core v1 (Phase 2)."),
     profile_budget: int = typer.Option(None, "--profile-budget"),
     max_rpc: int = typer.Option(None, "--max-rpc"),
     unsafe: bool = typer.Option(False, "--unsafe", help="Skip the doctor preflight gate."),
 ) -> None:
-    """Collect channel metadata + full message history for TARGET."""
+    """Collect channel metadata, full message history, and the discovery/
+    relationship graph for TARGET."""
     if join:
         console.print(
             "[yellow]--join is accepted but not implemented in core v1 — "
@@ -156,21 +157,23 @@ def collect(
     parsed_target = parse_target(target)
     secrets = composition.build_secrets(profile)
     phase_list = phases.split(",") if phases else None
-    if phase_list is not None and "history" in phase_list and "channel" not in phase_list:
+    _dependent_phases = [p for p in ("history", "graph") if phase_list and p in phase_list]
+    if phase_list is not None and _dependent_phases and "channel" not in phase_list:
         # `channel` populates `CollectContext.input_channel`/`channel_id` (the
         # channel's numeric id + access_hash) for every later collector in
         # *this run* — it is per-process context, not reloaded from
         # `channels` even if a prior run already stored that channel, since
         # `access_hash` can rotate and isn't persisted. Selecting `history`
-        # without `channel` in the same run leaves that context unset and
-        # `HistoryCollector.collect` would crash on its own assertion;
-        # reject it here instead, before any RPC (or even doctor/store setup)
-        # runs, with a clear, actionable message.
+        # or `graph` (its `getChannelRecommendations`/`getSponsoredMessages`
+        # calls need `input_channel` too) without `channel` in the same run
+        # leaves that context unset and the collector would crash on its own
+        # assertion; reject it here instead, before any RPC (or even
+        # doctor/store setup) runs, with a clear, actionable message.
         console.print(
-            "[red]--phases history requires channel in the same run[/] "
-            "(channel resolves the access hash history needs — it isn't "
-            "persisted between runs). Pass --phases channel,history, or "
-            "omit --phases to run both."
+            f"[red]--phases {','.join(_dependent_phases)} requires channel in the same run[/] "
+            "(channel resolves the access hash they need — it isn't "
+            "persisted between runs). Pass --phases channel,history,graph, or "
+            "omit --phases to run all three."
         )
         raise typer.Exit(code=1)
 

--- a/src/paperboy/cli.py
+++ b/src/paperboy/cli.py
@@ -131,7 +131,7 @@ async def _run_doctor(settings, secrets, profile: str, store):
 def collect(
     target: str,
     profile: str = typer.Option("default", "--profile"),
-    phases: str = typer.Option(None, "--phases", help="Comma-separated: channel,history"),
+    phases: str = typer.Option(None, "--phases", help="Comma-separated: channel,history,web"),
     join: bool = typer.Option(False, "--join", help="Not implemented in core v1 (Phase 2)."),
     profile_budget: int = typer.Option(None, "--profile-budget"),
     max_rpc: int = typer.Option(None, "--max-rpc"),

--- a/src/paperboy/cli.py
+++ b/src/paperboy/cli.py
@@ -131,7 +131,9 @@ async def _run_doctor(settings, secrets, profile: str, store):
 def collect(
     target: str,
     profile: str = typer.Option("default", "--profile"),
-    phases: str = typer.Option(None, "--phases", help="Comma-separated: channel,history,graph,media"),
+    phases: str = typer.Option(
+        None, "--phases", help="Comma-separated: channel,history,graph,media"
+    ),
     join: bool = typer.Option(False, "--join", help="Not implemented in core v1 (Phase 2)."),
     media: bool = typer.Option(
         False, "--media", help="Also download message media (opt-in; off by default)."

--- a/src/paperboy/cli.py
+++ b/src/paperboy/cli.py
@@ -131,8 +131,11 @@ async def _run_doctor(settings, secrets, profile: str, store):
 def collect(
     target: str,
     profile: str = typer.Option("default", "--profile"),
-    phases: str = typer.Option(None, "--phases", help="Comma-separated: channel,history"),
+    phases: str = typer.Option(None, "--phases", help="Comma-separated: channel,history,media"),
     join: bool = typer.Option(False, "--join", help="Not implemented in core v1 (Phase 2)."),
+    media: bool = typer.Option(
+        False, "--media", help="Also download message media (opt-in; off by default)."
+    ),
     profile_budget: int = typer.Option(None, "--profile-budget"),
     max_rpc: int = typer.Option(None, "--max-rpc"),
     unsafe: bool = typer.Option(False, "--unsafe", help="Skip the doctor preflight gate."),
@@ -156,27 +159,31 @@ def collect(
     parsed_target = parse_target(target)
     secrets = composition.build_secrets(profile)
     phase_list = phases.split(",") if phases else None
-    if phase_list is not None and "history" in phase_list and "channel" not in phase_list:
+    if phase_list is not None and "channel" not in phase_list and (
+        "history" in phase_list or "media" in phase_list
+    ):
         # `channel` populates `CollectContext.input_channel`/`channel_id` (the
         # channel's numeric id + access_hash) for every later collector in
         # *this run* — it is per-process context, not reloaded from
         # `channels` even if a prior run already stored that channel, since
         # `access_hash` can rotate and isn't persisted. Selecting `history`
-        # without `channel` in the same run leaves that context unset and
-        # `HistoryCollector.collect` would crash on its own assertion;
-        # reject it here instead, before any RPC (or even doctor/store setup)
-        # runs, with a clear, actionable message.
+        # or `media` without `channel` in the same run leaves that context
+        # unset and the collector would crash on its own assertion; reject it
+        # here instead, before any RPC (or even doctor/store setup) runs,
+        # with a clear, actionable message.
         console.print(
-            "[red]--phases history requires channel in the same run[/] "
-            "(channel resolves the access hash history needs — it isn't "
-            "persisted between runs). Pass --phases channel,history, or "
-            "omit --phases to run both."
+            "[red]--phases history/media requires channel in the same run[/] "
+            "(channel resolves the access hash they need — it isn't "
+            "persisted between runs). Pass --phases channel,history[,media], "
+            "or omit --phases to run the default set."
         )
         raise typer.Exit(code=1)
 
     with composition.build_store(settings, profile) as store:
         results = _run_async_or_exit(
-            _run_collect(settings, secrets, profile, store, parsed_target, phase_list, log, unsafe)
+            _run_collect(
+                settings, secrets, profile, store, parsed_target, phase_list, log, unsafe, media
+            )
         )
 
     table = Table(title=f"collect {target}")
@@ -188,7 +195,7 @@ def collect(
     console.print(table)
 
 
-async def _run_collect(settings, secrets, profile, store, target, phase_list, log, unsafe):
+async def _run_collect(settings, secrets, profile, store, target, phase_list, log, unsafe, media):
     gateway = await composition.build_gateway(settings, secrets, profile, store)
     if not unsafe:
         checks = await run_doctor(gateway, settings)
@@ -198,7 +205,9 @@ async def _run_collect(settings, secrets, profile, store, target, phase_list, lo
                 "Run `paperboy doctor` for details, or pass --unsafe to override."
             )
             raise typer.Exit(code=1)
-    return await collect_channel(gateway, store, settings, target, phase_list, log)
+    return await collect_channel(
+        gateway, store, settings, target, phase_list, log, media=media, profile=profile
+    )
 
 
 @app.command()

--- a/src/paperboy/collectors/base.py
+++ b/src/paperboy/collectors/base.py
@@ -28,6 +28,12 @@ class CollectContext:
     channel_id: int | None
     tier: str
     log: Logger
+    # Which profile this run is collecting into — only `media` needs it (to
+    # derive `<data_dir>/<profile>/media/...`, matching `profile_dir()` in
+    # config.py); every other field above is required, so this is appended
+    # at the end with a default rather than threaded through every existing
+    # positional `CollectContext(...)` call site (recipes.py, every test).
+    profile: str = "default"
 
 
 @dataclass

--- a/src/paperboy/collectors/graph.py
+++ b/src/paperboy/collectors/graph.py
@@ -1,0 +1,280 @@
+"""The `graph` collector: similar-channel recommendations, entity-derived
+mentions, unjoined invite-link previews, and sponsored-message provenance —
+the four sources that fill the otherwise-sparse `edges` table (spec §6, §2.6).
+
+Each of the four sub-features is independent and wrapped in its own
+`SkipAndRecord` handling: a documented per-RPC failure (`CHAT_NOT_MODIFIED`,
+`CHAT_ADMIN_REQUIRED`, `PREMIUM_ACCOUNT_REQUIRED`, ...) skips *that*
+sub-feature only, logged and counted as zero, so one account's lack of
+access to (say) sponsored messages never blocks recommendations or the
+(RPC-free) mention scan.
+
+Follow-up, deliberately out of scope for this pass (spec instruction): bare
+`MessageEntityMention`s (`@name` typed inline, no numeric id attached) are
+not resolved to a peer id here — doing so would cost a `contacts.resolveUsername`
+RPC per unique handle, unbounded by anything already in the message. A later
+pass can batch-resolve the distinct handles this phase leaves as gaps.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from paperboy.budget import PhaseStop, SkipAndRecord
+from paperboy.collectors.base import CollectContext, CollectResult
+from paperboy.ids import (
+    channel_uri,
+    invite_uri,
+    msg_uri,
+    parse_tme_link,
+    user_uri,
+    username_uri,
+    utc_now_iso,
+    utf16_slice,
+)
+from paperboy.store.edges import add_edge
+from paperboy.store.peers import upsert_peer
+from paperboy.targets import Target
+
+# Predicates used here, from the spec §2 edge vocabulary.
+_RECOMMENDED = "recommended_with"
+_MENTIONS = "mentions"
+_INVITED_VIA = "invited_via"
+
+_RESOLVED_INVITE_KINDS = {"chatinvitealready", "chatinvitepeek"}
+
+
+class GraphCollector:
+    name = "graph"
+
+    def applies_to(self, target: Target) -> bool:
+        return target.is_channel_like
+
+    async def collect(self, ctx: CollectContext) -> CollectResult:
+        if ctx.input_channel is None or ctx.channel_id is None:
+            raise PhaseStop(
+                "graph skipped: channel context not established "
+                "(channel phase did not complete)"
+            )
+        counts = {"edges": 0, "peers": 0, "raw": 0, "skipped": 0}
+
+        await self._collect_recommendations(ctx, counts)
+
+        rows = ctx.store.conn.execute(
+            "SELECT channel_id, msg_id, text, entities_json, source_raw_id FROM messages "
+            "WHERE channel_id=? AND entities_json IS NOT NULL",
+            (ctx.channel_id,),
+        ).fetchall()
+        mention_edges, invite_hashes = _scan_message_entities(rows)
+        self._write_mention_edges(ctx, mention_edges, counts)
+
+        await self._collect_invite_previews(ctx, invite_hashes, counts)
+        await self._collect_sponsored(ctx, counts)
+
+        return CollectResult(name=self.name, counts=counts)
+
+    async def _collect_recommendations(self, ctx: CollectContext, counts: dict) -> None:
+        assert ctx.input_channel is not None and ctx.channel_id is not None
+        try:
+            result = await ctx.gateway.get_channel_recommendations(ctx.input_channel)
+        except SkipAndRecord as exc:
+            ctx.log.warning("graph recommendations skipped: %s", exc)
+            counts["skipped"] += 1
+            return
+
+        observed_at = utc_now_iso()
+        raw_id = ctx.store.add_raw(
+            result.get("_", "ChatsSlice"), result, ctx.tier, {"channel_id": ctx.channel_id}
+        )
+        counts["raw"] += 1
+        chats = result.get("chats", [])
+        # `messages.ChatsSlice.count` is the true total even when Telegram
+        # only returns ~10 `chats`; plain `messages.Chats` means the list
+        # returned *is* the full set, so its own length is the true count.
+        true_count = result.get("count", len(chats))
+
+        subject = channel_uri(ctx.channel_id)
+        for chat in chats:
+            if chat.get("id") == ctx.channel_id:
+                continue
+            peer_uri = upsert_peer(
+                ctx.store, chat, raw_id, observed_at, seen_in_chat=None, seen_in_msg=None
+            )
+            counts["peers"] += 1
+            add_edge(
+                ctx.store, subject, _RECOMMENDED, peer_uri, observed_at, ctx.tier, raw_id,
+                {"total_count": true_count},
+            )
+            counts["edges"] += 1
+
+    def _write_mention_edges(
+        self,
+        ctx: CollectContext,
+        mention_edges: list[tuple[str, str, dict, int | None]],
+        counts: dict,
+    ) -> None:
+        observed_at = utc_now_iso()
+        for subject, object_, evidence, source_raw_id in mention_edges:
+            add_edge(
+                ctx.store, subject, _MENTIONS, object_, observed_at, ctx.tier, source_raw_id,
+                evidence,
+            )
+            counts["edges"] += 1
+
+    async def _collect_invite_previews(
+        self, ctx: CollectContext, invite_hashes: dict[str, list[str]], counts: dict
+    ) -> None:
+        for hash_, msg_uris in invite_hashes.items():
+            try:
+                preview = await ctx.gateway.check_chat_invite(hash_)
+            except SkipAndRecord as exc:
+                ctx.log.warning("graph invite preview skipped for %s: %s", hash_, exc)
+                counts["skipped"] += 1
+                continue
+
+            observed_at = utc_now_iso()
+            raw_id = ctx.store.add_raw(
+                preview.get("_", "ChatInvite"), preview, ctx.tier, {"hash": hash_}
+            )
+            counts["raw"] += 1
+
+            kind = preview.get("_", "").lower()
+            chat = preview.get("chat")
+            if kind in _RESOLVED_INVITE_KINDS and chat:
+                # Already-known chat (member, or a public/peekable one) —
+                # link to the real peer instead of the hash pseudo-URI.
+                object_uri = upsert_peer(
+                    ctx.store, chat, raw_id, observed_at, seen_in_chat=None, seen_in_msg=None
+                )
+                counts["peers"] += 1
+                evidence = {"resolved": True, "chat_id": chat.get("id")}
+            else:
+                # Unjoined preview: no numeric chat id, so the edge targets
+                # the invite-hash pseudo-URI, evidenced by what the preview
+                # *does* reveal (spec §6: title, participants_count, photo).
+                object_uri = invite_uri(hash_)
+                evidence = {
+                    "resolved": False,
+                    "title": preview.get("title"),
+                    "participants_count": preview.get("participants_count"),
+                    "has_photo": preview.get("photo") is not None,
+                }
+
+            for m_uri in msg_uris:
+                add_edge(
+                    ctx.store, m_uri, _INVITED_VIA, object_uri, observed_at, ctx.tier, raw_id,
+                    evidence,
+                )
+                counts["edges"] += 1
+
+    async def _collect_sponsored(self, ctx: CollectContext, counts: dict) -> None:
+        assert ctx.input_channel is not None and ctx.channel_id is not None
+        try:
+            result = await ctx.gateway.get_sponsored_messages(ctx.input_channel)
+        except SkipAndRecord as exc:
+            ctx.log.warning("graph sponsored messages skipped: %s", exc)
+            counts["skipped"] += 1
+            return
+
+        kind = result.get("_", "").lower()
+        if kind == "sponsoredmessagesempty":
+            return
+
+        observed_at = utc_now_iso()
+        subject = channel_uri(ctx.channel_id)
+        for sponsored in result.get("messages", []):
+            # No dedicated table (spec instruction) — raw + edges only. Every
+            # sponsored message is raw-logged individually (not just the
+            # envelope) so `sponsor_info`/`url`/`title` are each queryable
+            # from `raw_records` without re-parsing the batch.
+            raw_id = ctx.store.add_raw(
+                sponsored.get("_", "SponsoredMessage"), sponsored, ctx.tier,
+                {"channel_id": ctx.channel_id},
+            )
+            counts["raw"] += 1
+
+            url = sponsored.get("url", "")
+            parsed = parse_tme_link(url)
+            if parsed is None:
+                continue
+            link_kind, value = parsed
+            object_uri = invite_uri(value) if link_kind == "invite" else username_uri(value)
+            add_edge(
+                ctx.store, subject, _MENTIONS, object_uri, observed_at, ctx.tier, raw_id,
+                {
+                    "source": "sponsored",
+                    "url": url,
+                    "sponsor_info": sponsored.get("sponsor_info"),
+                    "title": sponsored.get("title"),
+                },
+            )
+            counts["edges"] += 1
+
+
+def _scan_message_entities(
+    rows: list[sqlite3.Row],
+) -> tuple[list[tuple[str, str, dict, int | None]], dict[str, list[str]]]:
+    """Walk stored messages' `entities_json` for `MentionName`/`TextUrl`/`Url`
+    entities, without any RPC. Returns `(mention_edges, invite_hashes)`:
+    `mention_edges` is `(subject_uri, object_uri, evidence, source_raw_id)`
+    ready for `add_edge` (provenance borrowed from the message's own raw
+    record); `invite_hashes` maps each distinct invite hash found to the
+    list of message URIs that referenced it, for `_collect_invite_previews`
+    to dedupe the `checkChatInvite` RPC by hash rather than by mention.
+    """
+    mention_edges: list[tuple[str, str, dict, int | None]] = []
+    invite_hashes: dict[str, list[str]] = {}
+
+    for row in rows:
+        entities = json.loads(row["entities_json"]) or []
+        text = row["text"] or ""
+        uri = msg_uri(row["channel_id"], row["msg_id"])
+        source_raw_id = row["source_raw_id"]
+
+        for entity in entities:
+            kind = (entity.get("_") or "").lower()
+            if kind == "messageentitymentionname":
+                user_id = entity.get("user_id")
+                if user_id is not None:
+                    mention_edges.append((
+                        uri, user_uri(user_id),
+                        {"entity": "MessageEntityMentionName"}, source_raw_id,
+                    ))
+            elif kind == "messageentitytexturl":
+                _record_link(
+                    uri, entity.get("url", ""), "MessageEntityTextUrl", source_raw_id,
+                    mention_edges, invite_hashes,
+                )
+            elif kind == "messageentityurl":
+                offset, length = entity.get("offset"), entity.get("length")
+                if offset is None or length is None:
+                    continue
+                url = utf16_slice(text, offset, length)
+                _record_link(
+                    uri, url, "MessageEntityUrl", source_raw_id, mention_edges, invite_hashes
+                )
+            # else: MessageEntityMention (bare @name) and every other entity
+            # kind (bold, code, custom emoji, ...) carry nothing graph-shaped.
+
+    return mention_edges, invite_hashes
+
+
+def _record_link(
+    subject_uri: str,
+    url: str,
+    entity_name: str,
+    source_raw_id: int | None,
+    mention_edges: list[tuple[str, str, dict, int | None]],
+    invite_hashes: dict[str, list[str]],
+) -> None:
+    parsed = parse_tme_link(url)
+    if parsed is None:
+        return
+    kind, value = parsed
+    object_uri = invite_uri(value) if kind == "invite" else username_uri(value)
+    mention_edges.append((
+        subject_uri, object_uri, {"entity": entity_name, "url": url}, source_raw_id,
+    ))
+    if kind == "invite":
+        invite_hashes.setdefault(value, []).append(subject_uri)

--- a/src/paperboy/collectors/media.py
+++ b/src/paperboy/collectors/media.py
@@ -29,7 +29,7 @@ import mimetypes
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from paperboy.budget import PhaseStop
+from paperboy.budget import PhaseStop, SkipAndRecord
 from paperboy.collectors.base import CollectContext, CollectResult
 from paperboy.config import profile_dir
 from paperboy.ids import utc_now_iso
@@ -109,7 +109,10 @@ class MediaCollector:
                 "(channel phase did not complete)"
             )
         channel_id = ctx.channel_id
-        counts = {"downloaded": 0, "duplicates": 0, "unavailable": 0, "skipped_kind": 0}
+        counts = {
+            "downloaded": 0, "duplicates": 0, "unavailable": 0,
+            "skipped_kind": 0, "skipped": 0,
+        }
         media_root = profile_dir(ctx.settings, ctx.profile) / "media"
 
         content_index = self._load_content_index(ctx, channel_id)
@@ -135,9 +138,16 @@ class MediaCollector:
                 counts["duplicates"] += 1
                 continue
 
-            data = await ctx.gateway.download_media(
-                ctx.input_channel, {"id": row["msg_id"], "media": media}
-            )
+            try:
+                data = await ctx.gateway.download_media(
+                    ctx.input_channel, {"id": row["msg_id"], "media": media}
+                )
+            except SkipAndRecord as exc:
+                # A per-file skip (e.g. file_reference expired twice) must not
+                # abort the whole media phase — skip this one file and continue.
+                ctx.log.warning("media: skipping msg %s: %s", row["msg_id"], exc)
+                counts["skipped"] += 1
+                continue
             if data is None:
                 counts["unavailable"] += 1
                 continue

--- a/src/paperboy/collectors/media.py
+++ b/src/paperboy/collectors/media.py
@@ -1,0 +1,226 @@
+"""The `media` collector (Phase 2, opt-in): download every stored message's
+media, content-address it under
+`<data_dir>/<profile>/media/<sha256[:2]>/<sha256><ext>`, and record chain of
+custody. Mirrors `channel`/`history`'s shape (spec §6); unlike `history` it
+does not itself talk to `messages.getHistory` — it walks messages already
+projected into the store by an earlier `history` run.
+
+Dedup is by SHA-256 (spec §6), but the actual bytes are the *expensive* thing
+to compare, so this collector uses the Telegram-native `document.id`/
+`photo.id` embedded in each message's stored `media_json` as a pre-download
+proxy for content identity: a repost/forward carries the same document/photo
+id as the original, so a duplicate is recognized *before* a single byte is
+downloaded. A raw SHA-256 check right after every download is the safety net
+for the (rare) case two distinct document/photo ids happen to hash to
+identical bytes — either way, `media.sha256` is the primary key, so only the
+first-seen message for a given file owns the `media` row; every later
+occurrence (by content-id or by hash) still gets its own `custody_log` row.
+
+EXIF/metadata extraction (`media.exif_json`) is out of scope for this pass —
+it needs a dependency decision (Pillow/exifread/...) not yet made — left
+NULL; tracked as a follow-up.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import mimetypes
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from paperboy.budget import PhaseStop
+from paperboy.collectors.base import CollectContext, CollectResult
+from paperboy.config import profile_dir
+from paperboy.ids import utc_now_iso
+from paperboy.store.db import dumps
+
+if TYPE_CHECKING:
+    from paperboy.targets import Target
+
+# Telethon's `to_dict()` uses the PascalCase TL class name ("MessageMediaPhoto",
+# "MessageMediaDocument"), not the lowercase constructor name — matched
+# case-insensitively like every other `_`-discriminator check in this repo
+# (see `channel.py`/`ids.py`). Every other media kind (webpage/geo/contact/
+# poll/venue/...) has nothing to download and is left alone.
+_DOWNLOADABLE_KINDS = {"messagemediaphoto": "photo", "messagemediadocument": "document"}
+
+
+def _content_key(media: dict) -> tuple[str, int] | None:
+    """A pre-download proxy for file identity: Telegram's own document/photo
+    `id`, stable across every message carrying the same underlying file.
+    `None` for a non-downloadable media kind or a malformed/id-less dict.
+    """
+    kind = (media.get("_") or "").lower()
+    if kind == "messagemediaphoto":
+        photo = media.get("photo") or {}
+        pid = photo.get("id")
+        return ("photo", pid) if pid is not None else None
+    if kind == "messagemediadocument":
+        doc = media.get("document") or {}
+        did = doc.get("id")
+        return ("document", did) if did is not None else None
+    return None
+
+
+def _document_attrs(media: dict) -> tuple[str | None, str | None, list | None]:
+    """`(mime_type, file_name, attributes)` for a `messageMediaDocument`."""
+    doc = media.get("document") or {}
+    mime_type = doc.get("mime_type")
+    attributes = doc.get("attributes") or []
+    file_name = None
+    for attr in attributes:
+        if (attr.get("_") or "").lower() == "documentattributefilename":
+            file_name = attr.get("file_name")
+            break
+    return mime_type, file_name, attributes
+
+
+def _guess_ext(kind: str, mime_type: str | None, file_name: str | None) -> str:
+    """Best-effort file extension for the content-addressed path.
+
+    Telegram server-re-encodes photos as JPEG (spec §6), so `photo` is
+    always `.jpg`. `document` prefers the original filename's own suffix,
+    falls back to a `mimetypes` guess from the MIME type, and finally to no
+    extension at all — the sha256-named file is still perfectly valid
+    without one.
+    """
+    if kind == "photo":
+        return ".jpg"
+    if file_name and (suffix := Path(file_name).suffix):
+        return suffix
+    if mime_type and (guessed := mimetypes.guess_extension(mime_type)):
+        return guessed
+    return ""
+
+
+class MediaCollector:
+    name = "media"
+
+    def applies_to(self, target: Target) -> bool:
+        return target.is_channel_like
+
+    async def collect(self, ctx: CollectContext) -> CollectResult:
+        if ctx.input_channel is None or ctx.channel_id is None:
+            # Same guard as `history`/`catch_up`: the `channel` phase didn't
+            # complete this run, so there's no access hash to download with.
+            raise PhaseStop(
+                "media skipped: channel context not established "
+                "(channel phase did not complete)"
+            )
+        channel_id = ctx.channel_id
+        counts = {"downloaded": 0, "duplicates": 0, "unavailable": 0, "skipped_kind": 0}
+        media_root = profile_dir(ctx.settings, ctx.profile) / "media"
+
+        content_index = self._load_content_index(ctx, channel_id)
+
+        rows = ctx.store.conn.execute(
+            "SELECT uri, msg_id, media_kind, media_json FROM messages "
+            "WHERE channel_id=? AND media_kind IS NOT NULL AND deleted_at IS NULL "
+            "ORDER BY msg_id",
+            (channel_id,),
+        ).fetchall()
+
+        for row in rows:
+            media = json.loads(row["media_json"]) if row["media_json"] else {}
+            kind = _DOWNLOADABLE_KINDS.get((row["media_kind"] or "").lower())
+            if kind is None:
+                counts["skipped_kind"] += 1
+                continue
+
+            key = _content_key(media)
+            if key is not None and key in content_index:
+                sha, path = content_index[key]
+                self._record_custody(ctx, path, sha, row["uri"])
+                counts["duplicates"] += 1
+                continue
+
+            data = await ctx.gateway.download_media(
+                ctx.input_channel, {"id": row["msg_id"], "media": media}
+            )
+            if data is None:
+                counts["unavailable"] += 1
+                continue
+
+            sha = hashlib.sha256(data).hexdigest()
+            existing = self._lookup_by_sha(ctx, sha)
+            if existing is not None:
+                # Safety-net dedup: two distinct document/photo ids hashed to
+                # the same bytes (or `key` was None, e.g. a malformed dict).
+                self._record_custody(ctx, existing, sha, row["uri"])
+                counts["duplicates"] += 1
+                if key is not None:
+                    content_index[key] = (sha, existing)
+                continue
+
+            mime_type: str | None
+            file_name: str | None
+            attributes: list | None
+            if kind == "photo":
+                mime_type, file_name, attributes = "image/jpeg", None, None
+            else:
+                mime_type, file_name, attributes = _document_attrs(media)
+            ext = _guess_ext(kind, mime_type, file_name)
+            path = media_root / sha[:2] / f"{sha}{ext}"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(data)
+            path_str = str(path)
+
+            downloaded_at = utc_now_iso()
+            ctx.store.conn.execute(
+                "INSERT INTO media (sha256, message_uri, kind, mime_type, size, file_name, "
+                "attributes_json, path, downloaded_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    sha, row["uri"], kind, mime_type, len(data), file_name,
+                    dumps(attributes) if attributes is not None else None,
+                    path_str, downloaded_at,
+                ),
+            )
+            self._record_custody(ctx, path_str, sha, row["uri"])
+            ctx.store.add_raw(
+                "MediaDownload",
+                {
+                    "sha256": sha, "kind": kind, "size": len(data), "mime_type": mime_type,
+                    "file_name": file_name, "path": path_str, "message_uri": row["uri"],
+                },
+                ctx.tier,
+                {"channel_id": channel_id, "msg_id": row["msg_id"]},
+            )
+            counts["downloaded"] += 1
+            if key is not None:
+                content_index[key] = (sha, path_str)
+
+        return CollectResult(name=self.name, counts=counts)
+
+    def _load_content_index(
+        self, ctx: CollectContext, channel_id: int
+    ) -> dict[tuple[str, int], tuple[str, str]]:
+        """`content_key -> (sha256, path)` for every file already downloaded
+        for this channel — seeded from persisted state, so dedup works
+        across separate `collect` runs, not just within one.
+        """
+        rows = ctx.store.conn.execute(
+            "SELECT media.sha256 AS sha256, media.path AS path, "
+            "messages.media_json AS media_json "
+            "FROM media JOIN messages ON media.message_uri = messages.uri "
+            "WHERE messages.channel_id = ?",
+            (channel_id,),
+        ).fetchall()
+        index: dict[tuple[str, int], tuple[str, str]] = {}
+        for r in rows:
+            media = json.loads(r["media_json"]) if r["media_json"] else {}
+            key = _content_key(media)
+            if key is not None:
+                index[key] = (r["sha256"], r["path"])
+        return index
+
+    def _lookup_by_sha(self, ctx: CollectContext, sha: str) -> str | None:
+        row = ctx.store.conn.execute("SELECT path FROM media WHERE sha256=?", (sha,)).fetchone()
+        return row["path"] if row else None
+
+    def _record_custody(self, ctx: CollectContext, path: str, sha: str, message_uri: str) -> None:
+        ctx.store.conn.execute(
+            "INSERT INTO custody_log (path, sha256, recorded_at, source_message_uri) "
+            "VALUES (?, ?, ?, ?)",
+            (path, sha, utc_now_iso(), message_uri),
+        )

--- a/src/paperboy/collectors/web.py
+++ b/src/paperboy/collectors/web.py
@@ -20,7 +20,7 @@ import httpx
 from paperboy.budget import SkipAndRecord
 from paperboy.collectors.base import CollectContext, CollectResult
 from paperboy.ids import msg_uri, utc_now_iso
-from paperboy.store.sync import get_state, set_state
+from paperboy.store.sync import set_state
 from paperboy.store.web import insert_tme_snapshot, insert_wayback_snapshot
 from paperboy.targets import Target, TargetKind
 from paperboy.web.client import WebClient
@@ -126,8 +126,14 @@ class WebCollector:
         self, ctx: CollectContext, client: WebClient, username: str, channel_id: int | None
     ) -> dict[str, int]:
         counts = {"tme_posts": 0, "deleted_recovered": 0}
-        resume = get_state(ctx.store, "web_tme", username) or {}
-        before_cursor: int | None = resume.get("before")
+        # Always start from the NEWEST posts each run (t.me/s with no
+        # `?before=`), then page backward within the run. The previous design
+        # persisted the backward cursor across runs, so a re-run only ever
+        # continued deeper into the past and never re-captured posts published
+        # since — this guarantees the newest are always fetched. web_snapshots
+        # is a time series, so re-observing a recent post later is expected.
+        before_cursor: int | None = None
+        newest_seen: int | None = None
 
         for _ in range(_MAX_TME_PAGES):
             url = f"https://t.me/s/{username}"
@@ -152,12 +158,16 @@ class WebCollector:
                 self._store_post(ctx, fetched_at, username, channel_id, post, counts)
                 if post.msg_id is not None:
                     new_min = post.msg_id if new_min is None else min(new_min, post.msg_id)
+                    newest_seen = (
+                        post.msg_id if newest_seen is None else max(newest_seen, post.msg_id)
+                    )
 
             if new_min is None or (before_cursor is not None and new_min >= before_cursor):
                 break
             before_cursor = new_min
-            set_state(ctx.store, "web_tme", username, {"before": before_cursor})
 
+        if newest_seen is not None:
+            set_state(ctx.store, "web_tme", username, {"newest_seen": newest_seen})
         return counts
 
     def _store_post(

--- a/src/paperboy/collectors/web.py
+++ b/src/paperboy/collectors/web.py
@@ -30,6 +30,7 @@ from paperboy.web.wayback import cdx_timestamp_to_iso, parse_cdx_rows
 # Safety bound on `?before=` pagination depth and the pacing delay between
 # HTTP requests — code constants (spec: not user config), like the allow-list.
 _MAX_TME_PAGES = 50
+_WAYBACK_CDX_LIMIT = 10000  # cap the CDX response (durov has ~775k captures = 112MB unbounded)
 _DEFAULT_MIN_INTERVAL_SECONDS = 1.0
 
 
@@ -209,7 +210,15 @@ class WebCollector:
             counts["deleted_recovered"] += 1
 
     def _collect_wayback(self, ctx: CollectContext, client: WebClient, username: str) -> int:
-        url = f"https://web.archive.org/cdx/search/cdx?url=t.me/s/{username}*&output=json"
+        # Bound the query: an unbounded `url=t.me/s/<name>*` CDX search on a
+        # heavily-archived channel returns hundreds of thousands of rows (a
+        # 100+ MB response that arrives truncated and fails to parse). Cap it,
+        # collapse consecutive identical-content captures, and keep only real
+        # page captures (200s).
+        url = (
+            f"https://web.archive.org/cdx/search/cdx?url=t.me/s/{username}*"
+            f"&output=json&filter=statuscode:200&collapse=digest&limit={_WAYBACK_CDX_LIMIT}"
+        )
         response = self._paced_get(client, url)
         fetched_at = utc_now_iso()
         ctx.store.add_raw(

--- a/src/paperboy/collectors/web.py
+++ b/src/paperboy/collectors/web.py
@@ -1,0 +1,236 @@
+"""The `web` collector: `t.me/s/<name>` feed capture + Wayback CDX index
+enumeration into `web_snapshots` (spec §2.8, §6). Pure HTTP via `WebClient`
+— no MTProto, no `Gateway`/`Budget` involvement; `web.client.ALLOWED_HOSTS`
+is this collector's only outbound-request guardrail.
+
+Deleted-post recovery: every parsed `t.me/s/` post whose id is already
+tombstoned in `message_tombstones` gets `meta_json.tombstoned_in_store =
+true` and counts toward `deleted_recovered` — the web page can still be
+serving text the MTProto API no longer will.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from collections.abc import Callable
+
+import httpx
+
+from paperboy.budget import SkipAndRecord
+from paperboy.collectors.base import CollectContext, CollectResult
+from paperboy.ids import msg_uri, utc_now_iso
+from paperboy.store.sync import get_state, set_state
+from paperboy.store.web import insert_tme_snapshot, insert_wayback_snapshot
+from paperboy.targets import Target, TargetKind
+from paperboy.web.client import WebClient
+from paperboy.web.tme_parser import TmePost, parse_tme_page
+from paperboy.web.wayback import cdx_timestamp_to_iso, parse_cdx_rows
+
+# Safety bound on `?before=` pagination depth and the pacing delay between
+# HTTP requests — code constants (spec: not user config), like the allow-list.
+_MAX_TME_PAGES = 50
+_DEFAULT_MIN_INTERVAL_SECONDS = 1.0
+
+
+def _text_content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _resolve_username(ctx: CollectContext) -> str:
+    """The `t.me/s/<name>` username: from the target if it's username-shaped,
+    else looked up in `channels` by `ctx.channel_id` (set when `channel` ran
+    earlier in this recipe run). Raises `SkipAndRecord` if neither yields
+    one — invite-hash/peer-id/msg-link targets and private channels have no
+    public `t.me/s/` page at all.
+    """
+    if ctx.target.kind is TargetKind.USERNAME:
+        return ctx.target.value
+    if ctx.channel_id is not None:
+        row = ctx.store.conn.execute(
+            "SELECT username FROM channels WHERE id=?", (ctx.channel_id,)
+        ).fetchone()
+        if row and row["username"]:
+            return str(row["username"])
+    raise SkipAndRecord(
+        f"web: no public username available for target {ctx.target.raw!r} "
+        "— t.me/s/ requires one"
+    )
+
+
+def _resolve_channel_id(ctx: CollectContext, username: str) -> int | None:
+    if ctx.channel_id is not None:
+        return ctx.channel_id
+    row = ctx.store.conn.execute(
+        "SELECT id FROM channels WHERE username=?", (username,)
+    ).fetchone()
+    return row["id"] if row else None
+
+
+def _is_tombstoned(ctx: CollectContext, channel_id: int | None, msg_id: int | None) -> bool:
+    if channel_id is None or msg_id is None:
+        return False
+    uri = msg_uri(channel_id, msg_id)
+    row = ctx.store.conn.execute(
+        "SELECT 1 FROM message_tombstones WHERE message_uri=? LIMIT 1", (uri,)
+    ).fetchone()
+    return row is not None
+
+
+class WebCollector:
+    """`t.me/s/<name>` feed capture + Wayback CDX enumeration into `web_snapshots`.
+
+    `client` is injectable (tests build a `WebClient` over an
+    `httpx.MockTransport`); left `None`, one is built lazily from
+    `ctx.settings.proxy` on first use. `sleep` is injectable for the same
+    reason `Budget` makes its sleeper injectable — tests never actually
+    block on the polite inter-request pacing.
+    """
+
+    name = "web"
+
+    def __init__(
+        self,
+        *,
+        client: WebClient | None = None,
+        min_interval: float = _DEFAULT_MIN_INTERVAL_SECONDS,
+        sleep: Callable[[float], None] | None = None,
+    ) -> None:
+        self._client = client
+        self._min_interval = min_interval
+        self._sleep: Callable[[float], None] = sleep or time.sleep
+
+    def applies_to(self, target: Target) -> bool:
+        return target.is_channel_like
+
+    def _get_client(self, ctx: CollectContext) -> WebClient:
+        if self._client is None:
+            self._client = WebClient(proxy=ctx.settings.proxy)
+        return self._client
+
+    def _paced_get(self, client: WebClient, url: str) -> httpx.Response:
+        self._sleep(self._min_interval)
+        return client.get(url)
+
+    async def collect(self, ctx: CollectContext) -> CollectResult:
+        username = _resolve_username(ctx)
+        client = self._get_client(ctx)
+        channel_id = _resolve_channel_id(ctx, username)
+
+        counts = self._collect_tme(ctx, client, username, channel_id)
+        counts["wayback_rows"] = self._collect_wayback(ctx, client, username)
+
+        return CollectResult(name=self.name, counts=counts)
+
+    def _collect_tme(
+        self, ctx: CollectContext, client: WebClient, username: str, channel_id: int | None
+    ) -> dict[str, int]:
+        counts = {"tme_posts": 0, "deleted_recovered": 0}
+        resume = get_state(ctx.store, "web_tme", username) or {}
+        before_cursor: int | None = resume.get("before")
+
+        for _ in range(_MAX_TME_PAGES):
+            url = f"https://t.me/s/{username}"
+            if before_cursor is not None:
+                url += f"?before={before_cursor}"
+
+            response = self._paced_get(client, url)
+            fetched_at = utc_now_iso()
+            ctx.store.add_raw(
+                "tme_page",
+                {"url": url, "status_code": response.status_code, "text": response.text},
+                ctx.tier,
+                {"channel_username": username},
+            )
+
+            posts = parse_tme_page(response.text)
+            if not posts:
+                break
+
+            new_min: int | None = None
+            for post in posts:
+                self._store_post(ctx, fetched_at, username, channel_id, post, counts)
+                if post.msg_id is not None:
+                    new_min = post.msg_id if new_min is None else min(new_min, post.msg_id)
+
+            if new_min is None or (before_cursor is not None and new_min >= before_cursor):
+                break
+            before_cursor = new_min
+            set_state(ctx.store, "web_tme", username, {"before": before_cursor})
+
+        return counts
+
+    def _store_post(
+        self,
+        ctx: CollectContext,
+        fetched_at: str,
+        username: str,
+        channel_id: int | None,
+        post: TmePost,
+        counts: dict[str, int],
+    ) -> None:
+        tombstoned = _is_tombstoned(ctx, channel_id, post.msg_id)
+        meta = {
+            "views": post.views,
+            "author_signature": post.author_signature,
+            "forwarded_from": post.forwarded_from,
+            "tombstoned_in_store": tombstoned,
+        }
+        insert_tme_snapshot(
+            ctx.store,
+            url=f"https://t.me/{post.post_id}",
+            fetched_at=fetched_at,
+            channel_username=username,
+            msg_id=post.msg_id,
+            timestamp=post.datetime,
+            content_hash=_text_content_hash(post.text),
+            raw={
+                "post_id": post.post_id,
+                "text": post.text,
+                "datetime": post.datetime,
+                "views": post.views,
+                "author_signature": post.author_signature,
+                "forwarded_from": post.forwarded_from,
+            },
+            meta=meta,
+        )
+        counts["tme_posts"] += 1
+        if tombstoned:
+            counts["deleted_recovered"] += 1
+
+    def _collect_wayback(self, ctx: CollectContext, client: WebClient, username: str) -> int:
+        url = f"https://web.archive.org/cdx/search/cdx?url=t.me/s/{username}*&output=json"
+        response = self._paced_get(client, url)
+        fetched_at = utc_now_iso()
+        ctx.store.add_raw(
+            "wayback_cdx",
+            {"url": url, "status_code": response.status_code, "text": response.text},
+            ctx.tier,
+            {"channel_username": username},
+        )
+
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = []
+        rows = parse_cdx_rows(payload) if isinstance(payload, list) else []
+
+        n = 0
+        for row in rows:
+            timestamp = row.get("timestamp", "")
+            insert_wayback_snapshot(
+                ctx.store,
+                url=row.get("original", url),
+                fetched_at=fetched_at,
+                channel_username=username,
+                timestamp=cdx_timestamp_to_iso(timestamp) or (timestamp or None),
+                content_hash=row.get("digest"),
+                raw=row,
+                meta={
+                    "statuscode": row.get("statuscode"),
+                    "length": row.get("length"),
+                    "mimetype": row.get("mimetype"),
+                },
+            )
+            n += 1
+        return n

--- a/src/paperboy/errors.py
+++ b/src/paperboy/errors.py
@@ -39,6 +39,7 @@ def _skip_error_classes() -> tuple[type[Exception], ...]:
         BroadcastForbiddenError,
         ChannelPrivateError,
         ChatAdminRequiredError,
+        ChatNotModifiedError,
         MsgIdInvalidError,
         PremiumAccountRequiredError,
     )
@@ -49,6 +50,11 @@ def _skip_error_classes() -> tuple[type[Exception], ...]:
         MsgIdInvalidError,
         BroadcastForbiddenError,
         PremiumAccountRequiredError,
+        # `graph`'s getChannelRecommendations/getSponsoredMessages/
+        # checkChatInvite each land here in the documented "nothing to
+        # return" case (no recommendations, ads disabled, invite already
+        # known unchanged) — skip that one RPC, the phase continues.
+        ChatNotModifiedError,
     )
 
 

--- a/src/paperboy/gateway.py
+++ b/src/paperboy/gateway.py
@@ -10,7 +10,7 @@ call routed through `Budget.call`).
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 if TYPE_CHECKING:
     from telethon import TelegramClient
@@ -59,6 +59,14 @@ class Gateway(Protocol):
         """`account.getPrivacy` for one key (`phone`/`lastseen`/`photo`) — `{"rules": [...]}`."""
         ...
 
+    async def download_media(self, input_channel: dict, message: dict) -> bytes | None:
+        """Download one message's media (`upload.getFile`, via Telethon's own
+        `download_media` helper) as raw bytes — `None` if the media is gone/
+        unavailable server-side. `message` need only carry enough to
+        re-resolve the live message (its `id`); read-only, never mutates
+        anything on Telegram's side."""
+        ...
+
 
 class FakeGateway:
     """Replays recorded fixture dicts — no network, no `Budget` involved.
@@ -66,11 +74,17 @@ class FakeGateway:
     `fixtures` keys: `resolve`, `full_channel`, `self`, `history` (a flat
     list, newest-first), `get_messages` (a `{id: message_dict}` lookup),
     `channel_difference`, `authorizations`, `password_state`, `privacy` (a
-    `{key: rules_dict}` lookup keyed by `"phone"`/`"lastseen"`/`"photo"`).
+    `{key: rules_dict}` lookup keyed by `"phone"`/`"lastseen"`/`"photo"`),
+    `media` (a `{msg_id: bytes}` lookup for `download_media`).
     """
 
     def __init__(self, fixtures: dict) -> None:
         self._fx = fixtures
+        # Test introspection: every msg id `download_media` was actually
+        # asked to fetch, in call order — lets a dedup test assert a
+        # duplicate never reaches the gateway at all, not just that its
+        # result was discarded.
+        self.download_media_calls: list[int] = []
 
     async def resolve(self, target_value: str) -> dict:
         del target_value
@@ -111,6 +125,12 @@ class FakeGateway:
 
     async def get_privacy(self, key: str) -> dict:
         return self._fx["privacy"][key]
+
+    async def download_media(self, input_channel: dict, message: dict) -> bytes | None:
+        del input_channel
+        self.download_media_calls.append(message["id"])
+        table: dict[int, bytes] = self._fx.get("media", {})
+        return table.get(message["id"])
 
 
 def _input_channel(input_channel: dict) -> InputChannel:
@@ -308,3 +328,71 @@ class TelethonGateway:
             ),
         )
         return result.to_dict()
+
+    async def download_media(self, input_channel: dict, message: dict) -> bytes | None:
+        """Re-fetch the live message (`channels.getMessages`) and download its
+        media in-memory (`file=bytes` tells Telethon to return bytes instead
+        of writing to disk). A fresh fetch carries a fresh `file_reference`;
+        if the download still races an expiry (`FileReferenceExpiredError`
+        isn't in `errors.classify`'s tables, so `Budget.call` re-raises it
+        verbatim rather than converting it), re-fetch once more and retry
+        exactly once. A second consecutive expiry is converted to
+        `SkipAndRecord` here — skip this one file, spec §8's "no exception
+        is swallowed" honored by recording *why*, not by crashing the run.
+        """
+        from telethon.errors import FileReferenceExpiredError
+        from telethon.tl.functions.channels import GetMessagesRequest
+        from telethon.tl.types import InputMessageID, Message
+        from telethon.tl.types.messages import Messages
+
+        from paperboy.budget import SkipAndRecord
+
+        channel = _input_channel(input_channel)
+        msg_id = message["id"]
+
+        async def _fetch_message() -> Message | None:
+            result = cast(
+                Messages,
+                await self.budget.call(
+                    "channels.getMessages",
+                    lambda: self.client(
+                        GetMessagesRequest(channel=channel, id=[InputMessageID(id=msg_id)])
+                    ),
+                ),
+            )
+            # `channels.getMessages` returning a non-`Message` (e.g.
+            # `MessageEmpty`, for an id that's since been deleted) is
+            # possible but not media-bearing; the `cast` here matches every
+            # other Telethon-response cast in this module (ADR-0001) — a
+            # typing aid verified against the installed layer, not a
+            # runtime behavior change.
+            return cast(Message, result.messages[0]) if result.messages else None
+
+        async def _download(tl_message: Message) -> bytes | None:
+            # `file=bytes` is Telethon's own documented idiom for "download
+            # in-memory and return it as a bytestring" — untyped in its
+            # stubs (`hints.FileLike` has no meta-type case for it), so the
+            # `Any` cast is a stub gap, not a real type mismatch.
+            return cast(
+                bytes | None,
+                await self.budget.call(
+                    "upload.getFile",
+                    lambda: self.client.download_media(tl_message, file=cast(Any, bytes)),
+                ),
+            )
+
+        tl_message = await _fetch_message()
+        if tl_message is None:
+            return None
+        try:
+            return await _download(tl_message)
+        except FileReferenceExpiredError:
+            tl_message = await _fetch_message()
+            if tl_message is None:
+                return None
+            try:
+                return await _download(tl_message)
+            except FileReferenceExpiredError as exc:
+                raise SkipAndRecord(
+                    f"media download skipped: file_reference expired twice for msg {msg_id}"
+                ) from exc

--- a/src/paperboy/gateway.py
+++ b/src/paperboy/gateway.py
@@ -59,6 +59,24 @@ class Gateway(Protocol):
         """`account.getPrivacy` for one key (`phone`/`lastseen`/`photo`) — `{"rules": [...]}`."""
         ...
 
+    async def get_channel_recommendations(self, input_channel: dict) -> dict:
+        """`channels.getChannelRecommendations` — a `Chats`/`ChatsSlice` dict
+        (the latter's `count` is the true total, even though at most ~10 `chats` come
+        back). May raise `SkipAndRecord` (e.g. `CHAT_NOT_MODIFIED`, `PREMIUM_ACCOUNT_REQUIRED`)."""
+        ...
+
+    async def check_chat_invite(self, hash_: str) -> dict:
+        """`messages.checkChatInvite` — never joins. Returns a `ChatInvite` dict
+        (unjoined preview: title/photo/participants_count, no chat id) or a
+        `ChatInviteAlready`/`ChatInvitePeek` dict (a real `Chat`, if already known)."""
+        ...
+
+    async def get_sponsored_messages(self, input_channel: dict) -> dict:
+        """`messages.getSponsoredMessages` — a `SponsoredMessages` or
+        `SponsoredMessagesEmpty` dict. May raise `SkipAndRecord` (e.g.
+        `CHAT_ADMIN_REQUIRED`, `PREMIUM_ACCOUNT_REQUIRED` on some accounts)."""
+        ...
+
 
 class FakeGateway:
     """Replays recorded fixture dicts — no network, no `Budget` involved.
@@ -66,7 +84,12 @@ class FakeGateway:
     `fixtures` keys: `resolve`, `full_channel`, `self`, `history` (a flat
     list, newest-first), `get_messages` (a `{id: message_dict}` lookup),
     `channel_difference`, `authorizations`, `password_state`, `privacy` (a
-    `{key: rules_dict}` lookup keyed by `"phone"`/`"lastseen"`/`"photo"`).
+    `{key: rules_dict}` lookup keyed by `"phone"`/`"lastseen"`/`"photo"`),
+    `channel_recommendations`, `sponsored_messages`, `chat_invite` (a
+    `{hash: dict}` lookup). Any of these three graph-collector fixture
+    values may instead be a `BaseException` instance (e.g. a `SkipAndRecord`)
+    to simulate `Budget.call`'s classification without going through it —
+    `FakeGateway` never touches `Budget`.
     """
 
     def __init__(self, fixtures: dict) -> None:
@@ -111,6 +134,27 @@ class FakeGateway:
 
     async def get_privacy(self, key: str) -> dict:
         return self._fx["privacy"][key]
+
+    async def get_channel_recommendations(self, input_channel: dict) -> dict:
+        del input_channel
+        return self._fx_or_raise("channel_recommendations")
+
+    async def check_chat_invite(self, hash_: str) -> dict:
+        table: dict[str, dict] = self._fx.get("chat_invite", {})
+        value = table[hash_]
+        if isinstance(value, BaseException):
+            raise value
+        return value
+
+    async def get_sponsored_messages(self, input_channel: dict) -> dict:
+        del input_channel
+        return self._fx_or_raise("sponsored_messages")
+
+    def _fx_or_raise(self, key: str) -> dict:
+        value = self._fx[key]
+        if isinstance(value, BaseException):
+            raise value
+        return value
 
 
 def _input_channel(input_channel: dict) -> InputChannel:
@@ -305,6 +349,47 @@ class TelethonGateway:
             await self.budget.call(
                 f"account.getPrivacy:{key}",
                 lambda: self.client(GetPrivacyRequest(key=input_key)),
+            ),
+        )
+        return result.to_dict()
+
+    async def get_channel_recommendations(self, input_channel: dict) -> dict:
+        from telethon.tl.functions.channels import GetChannelRecommendationsRequest
+        from telethon.tl.tlobject import TLObject
+
+        channel = _input_channel(input_channel)
+        result = cast(
+            TLObject,
+            await self.budget.call(
+                "channels.getChannelRecommendations",
+                lambda: self.client(GetChannelRecommendationsRequest(channel=channel)),
+            ),
+        )
+        return result.to_dict()
+
+    async def check_chat_invite(self, hash_: str) -> dict:
+        from telethon.tl.functions.messages import CheckChatInviteRequest
+        from telethon.tl.tlobject import TLObject
+
+        result = cast(
+            TLObject,
+            await self.budget.call(
+                "messages.checkChatInvite",
+                lambda: self.client(CheckChatInviteRequest(hash=hash_)),
+            ),
+        )
+        return result.to_dict()
+
+    async def get_sponsored_messages(self, input_channel: dict) -> dict:
+        from telethon.tl.functions.messages import GetSponsoredMessagesRequest
+        from telethon.tl.tlobject import TLObject
+
+        peer = _input_peer_channel(input_channel)
+        result = cast(
+            TLObject,
+            await self.budget.call(
+                "messages.getSponsoredMessages",
+                lambda: self.client(GetSponsoredMessagesRequest(peer=peer)),
             ),
         )
         return result.to_dict()

--- a/src/paperboy/gateway.py
+++ b/src/paperboy/gateway.py
@@ -157,20 +157,31 @@ class FakeGateway:
 
     async def get_channel_recommendations(self, input_channel: dict) -> dict:
         del input_channel
-        return self._fx_or_raise("channel_recommendations")
+        return self._fx_or_raise(
+            "channel_recommendations", {"_": "messages.chats", "chats": []}
+        )
 
     async def check_chat_invite(self, hash_: str) -> dict:
         table: dict[str, dict] = self._fx.get("chat_invite", {})
-        value = table[hash_]
+        value = table.get(hash_)
+        if value is None:
+            return {"_": "chatInvite", "title": "", "participants_count": 0}
         if isinstance(value, BaseException):
             raise value
         return value
 
     async def get_sponsored_messages(self, input_channel: dict) -> dict:
         del input_channel
-        return self._fx_or_raise("sponsored_messages")
+        return self._fx_or_raise(
+            "sponsored_messages", {"_": "messages.sponsoredMessagesEmpty"}
+        )
 
-    def _fx_or_raise(self, key: str) -> dict:
+    def _fx_or_raise(self, key: str, default: dict | None = None) -> dict:
+        # Missing fixture => a benign, correctly-shaped empty (a channel may
+        # genuinely have no recommendations/sponsored messages), unless the test
+        # configured a BaseException to simulate Budget.call's classification.
+        if key not in self._fx:
+            return {} if default is None else default
         value = self._fx[key]
         if isinstance(value, BaseException):
             raise value

--- a/src/paperboy/gateway.py
+++ b/src/paperboy/gateway.py
@@ -152,8 +152,10 @@ class FakeGateway:
     async def download_media(self, input_channel: dict, message: dict) -> bytes | None:
         del input_channel
         self.download_media_calls.append(message["id"])
-        table: dict[int, bytes] = self._fx.get("media", {})
-        return table.get(message["id"])
+        value = self._fx.get("media", {}).get(message["id"])
+        if isinstance(value, BaseException):
+            raise value
+        return value
 
     async def get_channel_recommendations(self, input_channel: dict) -> dict:
         del input_channel

--- a/src/paperboy/ids.py
+++ b/src/paperboy/ids.py
@@ -31,6 +31,22 @@ def msg_uri(channel_id: int, msg_id: int) -> str:
     return f"{_SCHEME}:msg:{channel_id}/{msg_id}"
 
 
+def username_uri(name: str) -> str:
+    """A pseudo-URI for a bare `@name`/`t.me/name` reference that hasn't been
+    resolved to a numeric peer id (the `graph` collector's mention scan does
+    not spend an RPC resolving these — see its module docstring). Not one of
+    `parse_uri`'s numeric-id kinds — construct-only, never parsed back."""
+    return f"{_SCHEME}:username:{name}"
+
+
+def invite_uri(hash_: str) -> str:
+    """A pseudo-URI for a `t.me/+<hash>`/`t.me/joinchat/<hash>` invite link,
+    keyed by the hash itself rather than a numeric id (unjoined invite
+    previews carry no chat id — see the `graph` collector). Not one of
+    `parse_uri`'s numeric-id kinds — construct-only, never parsed back."""
+    return f"{_SCHEME}:invite:{hash_}"
+
+
 def primary_username(obj: dict) -> str | None:
     """Extract the canonical username from a TL `Channel`/`Chat`/`User` dict.
 
@@ -95,6 +111,60 @@ def parse_uri(uri: str) -> tuple[str, tuple[int, ...]]:
     except ValueError as e:
         raise ValueError(f"malformed paperboy URI: {uri!r}") from e
     return kind, ids
+
+
+def utf16_slice(text: str, offset: int, length: int) -> str:
+    """Slice `text` by UTF-16 code-unit offset/length, the unit Telegram's
+    `MessageEntity.offset`/`length` are always expressed in (not Python
+    `str` index, which counts codepoints) — matters once `text` contains any
+    character outside the Basic Multilingual Plane (most emoji), which
+    Python encodes as one codepoint but UTF-16 as a surrogate pair.
+    `errors="ignore"` guards a slice that lands mid-pair rather than raising.
+    """
+    encoded = text.encode("utf-16-le")
+    start, end = offset * 2, (offset + length) * 2
+    return encoded[start:end].decode("utf-16-le", errors="ignore")
+
+
+_TME_HOSTS = {"t.me", "telegram.me", "telegram.dog"}
+
+
+def parse_tme_link(url: str) -> tuple[str, str] | None:
+    """Parse a `t.me`/`telegram.me`/`telegram.dog` URL into `("username", name)`
+    or `("invite", hash)`, or `None` if `url` isn't a recognized Telegram link.
+
+    Handles `t.me/name` (and its `t.me/name/123` message-link / `t.me/s/name`
+    preview variants, both reduced to the bare username — resolving the
+    specific message is out of scope for this pass), `t.me/+hash`, and the
+    older `t.me/joinchat/hash` invite form. Not exhaustive: reserved paths
+    Telegram serves off `t.me` for other purposes (`t.me/share/...`,
+    `t.me/addstickers/...`, `t.me/proxy?...`, ...) are not denylisted, so
+    (username, "share") etc. is possible for those, a known limitation left
+    as a follow-up rather than a hand-maintained keyword list.
+    """
+    from urllib.parse import urlsplit
+
+    candidate = url if "://" in url else f"//{url}"
+    try:
+        parts = urlsplit(candidate)
+    except ValueError:
+        return None
+    host = (parts.hostname or "").lower()
+    if host not in _TME_HOSTS:
+        return None
+    segments = [s for s in parts.path.split("/") if s]
+    if not segments:
+        return None
+    first = segments[0]
+    if first.startswith("+") and len(first) > 1:
+        return ("invite", first[1:])
+    if first == "joinchat" and len(segments) > 1:
+        return ("invite", segments[1])
+    if first == "s" and len(segments) > 1:
+        first = segments[1]
+    if not first or first.startswith("+"):
+        return None
+    return ("username", first)
 
 
 def to_iso(dt: datetime | int) -> str:

--- a/src/paperboy/recipes.py
+++ b/src/paperboy/recipes.py
@@ -4,9 +4,11 @@ Runs `channel` (which populates `CollectContext.input_channel`/`channel_id`/
 `tier` for everything after it), then `history` (backfill, immediately
 followed by one `pts` catch-up so the channel's sync state is current as of
 *now*, not as of whenever backfill started — both folded into one `history`
-CollectResult). `SkipAndRecord` and `PhaseStop` are each recorded and that phase's result is
-marked stopped, but later phases still run; `HardStop` is recorded and the
-whole run ends there (spec §8). A `run_events` row is written for every phase.
+CollectResult), then `web` (`t.me/s/` + Wayback CDX capture, pure HTTP — no
+`Gateway`/`Budget` involvement). `SkipAndRecord` and `PhaseStop` are each
+recorded and that phase's result is marked stopped, but later phases still
+run; `HardStop` is recorded and the whole run ends there (spec §8). A
+`run_events` row is written for every phase.
 """
 
 from __future__ import annotations
@@ -19,6 +21,7 @@ from paperboy.budget import HardStop, PhaseStop, SkipAndRecord
 from paperboy.collectors.base import CollectContext, CollectResult
 from paperboy.collectors.channel import ChannelCollector
 from paperboy.collectors.history import HistoryCollector
+from paperboy.collectors.web import WebCollector
 from paperboy.ids import utc_now_iso
 from paperboy.store.db import dumps
 
@@ -31,7 +34,7 @@ if TYPE_CHECKING:
 
 
 def _default_collectors() -> list[Collector]:
-    return [ChannelCollector(), HistoryCollector()]
+    return [ChannelCollector(), HistoryCollector(), WebCollector()]
 
 
 def _record_run_event(

--- a/src/paperboy/recipes.py
+++ b/src/paperboy/recipes.py
@@ -4,7 +4,10 @@ Runs `channel` (which populates `CollectContext.input_channel`/`channel_id`/
 `tier` for everything after it), then `history` (backfill, immediately
 followed by one `pts` catch-up so the channel's sync state is current as of
 *now*, not as of whenever backfill started — both folded into one `history`
-CollectResult). `SkipAndRecord` and `PhaseStop` are each recorded and that phase's result is
+CollectResult), then `graph` (similar-channel recommendations, entity-derived
+mentions, invite-link previews, sponsored-message provenance — all consume
+`history`'s stored messages/`channel`'s context, so they run last).
+`SkipAndRecord` and `PhaseStop` are each recorded and that phase's result is
 marked stopped, but later phases still run; `HardStop` is recorded and the
 whole run ends there (spec §8). A `run_events` row is written for every phase.
 """
@@ -18,6 +21,7 @@ from typing import TYPE_CHECKING
 from paperboy.budget import HardStop, PhaseStop, SkipAndRecord
 from paperboy.collectors.base import CollectContext, CollectResult
 from paperboy.collectors.channel import ChannelCollector
+from paperboy.collectors.graph import GraphCollector
 from paperboy.collectors.history import HistoryCollector
 from paperboy.ids import utc_now_iso
 from paperboy.store.db import dumps
@@ -31,7 +35,7 @@ if TYPE_CHECKING:
 
 
 def _default_collectors() -> list[Collector]:
-    return [ChannelCollector(), HistoryCollector()]
+    return [ChannelCollector(), HistoryCollector(), GraphCollector()]
 
 
 def _record_run_event(

--- a/src/paperboy/recipes.py
+++ b/src/paperboy/recipes.py
@@ -81,12 +81,12 @@ async def collect_channel(
     *,
     collectors: Sequence[Collector] | None = None,
 ) -> list[CollectResult]:
-    """Run `channel` then `history` (+ its `catch_up`) against `target`.
+    """Run `channel`, then `history` (+ its `catch_up`), then `graph`, against `target`.
 
     `phases` filters which collectors run by name (`None` runs all).
-    `collectors` overrides the default `[ChannelCollector(), HistoryCollector()]`
-    list — used by tests to inject a stub that raises `HardStop`/`PhaseStop`
-    without needing a real gateway failure to trigger one.
+    `collectors` overrides the default `[ChannelCollector(), HistoryCollector(),
+    GraphCollector()]` list — used by tests to inject a stub that raises
+    `HardStop`/`PhaseStop` without needing a real gateway failure to trigger one.
     """
     ctx = CollectContext(gateway, store, settings, target, None, None, "stranger", log)
     active = collectors if collectors is not None else _default_collectors()

--- a/src/paperboy/recipes.py
+++ b/src/paperboy/recipes.py
@@ -4,7 +4,10 @@ Runs `channel` (which populates `CollectContext.input_channel`/`channel_id`/
 `tier` for everything after it), then `history` (backfill, immediately
 followed by one `pts` catch-up so the channel's sync state is current as of
 *now*, not as of whenever backfill started — both folded into one `history`
-CollectResult). `SkipAndRecord` and `PhaseStop` are each recorded and that phase's result is
+CollectResult). `media` (download+content-address every stored message's
+media) is opt-in — off by default, on via `collect_channel(..., media=True)`
+or `phases=[..., "media"]` — and runs after `history` so it has messages to
+walk. `SkipAndRecord` and `PhaseStop` are each recorded and that phase's result is
 marked stopped, but later phases still run; `HardStop` is recorded and the
 whole run ends there (spec §8). A `run_events` row is written for every phase.
 """
@@ -19,6 +22,7 @@ from paperboy.budget import HardStop, PhaseStop, SkipAndRecord
 from paperboy.collectors.base import CollectContext, CollectResult
 from paperboy.collectors.channel import ChannelCollector
 from paperboy.collectors.history import HistoryCollector
+from paperboy.collectors.media import MediaCollector
 from paperboy.ids import utc_now_iso
 from paperboy.store.db import dumps
 
@@ -30,8 +34,15 @@ if TYPE_CHECKING:
     from paperboy.targets import Target
 
 
-def _default_collectors() -> list[Collector]:
-    return [ChannelCollector(), HistoryCollector()]
+def _default_collectors(*, include_media: bool) -> list[Collector]:
+    # `media` is opt-in (spec §6): a plain `collect` with no `--media` flag
+    # and no explicit `--phases media` stays metadata+history only, since
+    # downloading every file in a channel is a much bigger bandwidth/disk
+    # commitment than the rest of core v1.
+    collectors: list[Collector] = [ChannelCollector(), HistoryCollector()]
+    if include_media:
+        collectors.append(MediaCollector())
+    return collectors
 
 
 def _record_run_event(
@@ -76,16 +87,25 @@ async def collect_channel(
     log: logging.Logger,
     *,
     collectors: Sequence[Collector] | None = None,
+    media: bool = False,
+    profile: str = "default",
 ) -> list[CollectResult]:
-    """Run `channel` then `history` (+ its `catch_up`) against `target`.
+    """Run `channel` then `history` (+ its `catch_up`), against `target`.
 
-    `phases` filters which collectors run by name (`None` runs all).
-    `collectors` overrides the default `[ChannelCollector(), HistoryCollector()]`
-    list — used by tests to inject a stub that raises `HardStop`/`PhaseStop`
-    without needing a real gateway failure to trigger one.
+    `phases` filters which collectors run by name (`None` runs all of the
+    *active* set). `media` (or naming `"media"` in `phases`) opts the
+    `media` collector into the active set — it's excluded by default (see
+    `_default_collectors`). `profile` is threaded into `CollectContext` only
+    for `media`'s content-addressed download path. `collectors` overrides
+    the default active list entirely — used by tests to inject a stub that
+    raises `HardStop`/`PhaseStop`/`SkipAndRecord` without needing a real
+    gateway failure to trigger one.
     """
-    ctx = CollectContext(gateway, store, settings, target, None, None, "stranger", log)
-    active = collectors if collectors is not None else _default_collectors()
+    ctx = CollectContext(gateway, store, settings, target, None, None, "stranger", log, profile)
+    include_media = media or (phases is not None and "media" in phases)
+    active = collectors if collectors is not None else _default_collectors(
+        include_media=include_media
+    )
     selected = set(phases) if phases is not None else {c.name for c in active}
 
     results: list[CollectResult] = []

--- a/src/paperboy/store/migrations/0002_web.sql
+++ b/src/paperboy/store/migrations/0002_web.sql
@@ -1,0 +1,22 @@
+-- 0002_web: `web_snapshots` — the `web` collector's `t.me/s/<name>` post
+-- captures (source='tme') and Wayback CDX index rows (source='wayback').
+--
+-- Distinct filename from 0001_init (spec: migrations apply by unique stem,
+-- so this coexists with any other Phase-2 feature's own 0002_*.sql).
+
+CREATE TABLE IF NOT EXISTS web_snapshots (
+    id                INTEGER PRIMARY KEY,
+    source            TEXT NOT NULL CHECK (source IN ('tme', 'wayback')),
+    url               TEXT NOT NULL,
+    fetched_at        TEXT NOT NULL,
+    channel_username  TEXT NOT NULL,
+    msg_id            INTEGER,
+    timestamp         TEXT,
+    content_hash      TEXT,
+    raw               TEXT,
+    meta_json         TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_web_snapshots_channel
+    ON web_snapshots(channel_username, msg_id);
+CREATE INDEX IF NOT EXISTS idx_web_snapshots_source
+    ON web_snapshots(source, fetched_at);

--- a/src/paperboy/store/web.py
+++ b/src/paperboy/store/web.py
@@ -1,0 +1,63 @@
+"""`web_snapshots` projection (migration `0002_web`): `t.me/s/` post captures
+and Wayback CDX index rows, both written by `paperboy.collectors.web`.
+"""
+
+from __future__ import annotations
+
+from paperboy.store.db import Store, dumps
+
+
+def insert_tme_snapshot(
+    store: Store,
+    *,
+    url: str,
+    fetched_at: str,
+    channel_username: str,
+    msg_id: int | None,
+    timestamp: str | None,
+    content_hash: str | None,
+    raw: dict,
+    meta: dict | None,
+) -> int:
+    """Insert one `t.me/s/<name>` post capture. Append-only (not upserted) —
+    `web_snapshots` is an observation log, like `channel_snapshots`, not
+    current-state; the same post fetched on a later run gets its own row.
+    """
+    cur = store.conn.execute(
+        "INSERT INTO web_snapshots "
+        "(source, url, fetched_at, channel_username, msg_id, timestamp, content_hash, "
+        "raw, meta_json) VALUES ('tme', ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            url, fetched_at, channel_username, msg_id, timestamp, content_hash,
+            dumps(raw), dumps(meta) if meta is not None else None,
+        ),
+    )
+    assert cur.lastrowid is not None
+    return cur.lastrowid
+
+
+def insert_wayback_snapshot(
+    store: Store,
+    *,
+    url: str,
+    fetched_at: str,
+    channel_username: str,
+    timestamp: str | None,
+    content_hash: str | None,
+    raw: dict,
+    meta: dict | None,
+) -> int:
+    """Insert one Wayback CDX index row (no `msg_id` — this indexes whole-page
+    snapshots of `t.me/s/<name>*`, not individual posts).
+    """
+    cur = store.conn.execute(
+        "INSERT INTO web_snapshots "
+        "(source, url, fetched_at, channel_username, msg_id, timestamp, content_hash, "
+        "raw, meta_json) VALUES ('wayback', ?, ?, ?, NULL, ?, ?, ?, ?)",
+        (
+            url, fetched_at, channel_username, timestamp, content_hash,
+            dumps(raw), dumps(meta) if meta is not None else None,
+        ),
+    )
+    assert cur.lastrowid is not None
+    return cur.lastrowid

--- a/src/paperboy/web/__init__.py
+++ b/src/paperboy/web/__init__.py
@@ -1,0 +1,5 @@
+"""No-account web vectors (spec §2.8, §6): `t.me/s/<name>` + Wayback CDX.
+
+`paperboy.web.client` is the allow-listed HTTP seam (issue #1); the
+`web` collector (`paperboy.collectors.web`) is its only caller.
+"""

--- a/src/paperboy/web/client.py
+++ b/src/paperboy/web/client.py
@@ -1,0 +1,90 @@
+"""`WebClient`: the only seam through which paperboy makes outbound HTTP.
+
+Spec §2 guardrail (issue #1): outbound HTTP is allowed to exactly three
+hosts — `t.me`, `www.t.me`, `web.archive.org` — through the configured
+proxy when one is set, and paperboy must never dereference a URL found
+*inside* collected content (only URLs this codebase itself constructs from
+a known username/query are ever fetched).
+
+`WebClient.get` enforces the allow-list on the initial URL *and* on every
+redirect hop: the underlying `httpx.Client` is built with
+`follow_redirects=False` and this class walks the redirect chain itself,
+checking each `Location` target's host before ever issuing that next
+request. A disallowed host — initial or redirected-to — raises
+`DisallowedHostError` instead of being followed.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+import httpx
+
+# Deliberately a code constant, not user config (spec: the allow-list host
+# set is not configurable).
+ALLOWED_HOSTS = frozenset({"t.me", "www.t.me", "web.archive.org"})
+
+_DEFAULT_TIMEOUT_SECONDS = 30.0
+_MAX_REDIRECTS = 5
+
+
+class DisallowedHostError(Exception):
+    """Raised for a URL (initial or a redirect target) whose host isn't allow-listed."""
+
+
+def _host_of(url: str) -> str:
+    return (urlsplit(url).hostname or "").lower()
+
+
+def _check_allowed(url: str) -> None:
+    host = _host_of(url)
+    if host not in ALLOWED_HOSTS:
+        raise DisallowedHostError(f"host not allow-listed: {host!r} (url={url!r})")
+
+
+class WebClient:
+    """A thin `httpx.Client` wrapper that enforces `ALLOWED_HOSTS` on every hop."""
+
+    def __init__(
+        self,
+        *,
+        proxy: str | None = None,
+        transport: httpx.BaseTransport | None = None,
+        timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        kwargs: dict = {"follow_redirects": False, "timeout": timeout}
+        if transport is not None:
+            kwargs["transport"] = transport
+        if proxy:
+            kwargs["proxy"] = proxy
+        self._client = httpx.Client(**kwargs)
+
+    def get(self, url: str, *, max_redirects: int = _MAX_REDIRECTS) -> httpx.Response:
+        """GET `url`, manually following redirects so every hop is host-checked.
+
+        Never call this with a URL sourced from collected message/page
+        content (spec §2) — only with a URL this module built itself from a
+        known username or CDX query.
+        """
+        _check_allowed(url)
+        current = url
+        for _ in range(max_redirects + 1):
+            response = self._client.get(current)
+            if not response.is_redirect:
+                return response
+            location = response.headers.get("location")
+            if not location:
+                return response
+            next_url = str(httpx.URL(current).join(location))
+            _check_allowed(next_url)
+            current = next_url
+        raise DisallowedHostError(f"too many redirects starting at {url!r}")
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> WebClient:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()

--- a/src/paperboy/web/tme_parser.py
+++ b/src/paperboy/web/tme_parser.py
@@ -1,0 +1,142 @@
+"""Parse a `t.me/s/<name>` server-rendered feed page (spec §2.8, §6 `web`).
+
+Deliberately stdlib-only (`html.parser.HTMLParser`) — no HTML/CSS-selector
+dependency is added for this. `TmeParser` walks the known, verified-live
+markup (`docs/research/sources/prior-art.md` §3.7):
+
+    <div class="tgme_widget_message ..." data-post="name/523" ...>
+      ...
+      <div class="tgme_widget_message_text ...">post text</div>
+      ...
+      <a class="tgme_widget_message_date" ...>
+        <time datetime="2026-08-20T12:00:00+00:00" class="time">...</time>
+      </a>
+      <span class="tgme_widget_message_views">1.42M</span>
+      <span class="tgme_widget_message_author_signature">Jane</span>
+      <div class="tgme_widget_message_forwarded_from">
+        <span class="tgme_widget_message_forwarded_from_name">Other Channel</span>
+      </div>
+    </div>
+
+Each post's own wrapping `div` (the one carrying `data-post`) is tracked by
+counting nested `<div>` opens/closes from that point, so a post is only
+finalized when *its own* div closes, not some inner one — matched purely
+on HTML class *tokens* (space-separated), so `tgme_widget_message_bubble`
+never matches the `tgme_widget_message` token check.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html.parser import HTMLParser
+
+
+@dataclass
+class TmePost:
+    post_id: str  # raw `data-post` value, e.g. "durov/523"
+    channel_username: str | None
+    msg_id: int | None
+    datetime: str | None = None
+    views: str | None = None
+    author_signature: str | None = None
+    forwarded_from: str | None = None
+    text: str = ""
+
+
+def _split_post_id(post_id: str) -> tuple[str | None, int | None]:
+    username, _, msg_id_s = post_id.rpartition("/")
+    if not username or not msg_id_s.isdigit():
+        return None, None
+    return username, int(msg_id_s)
+
+
+def _classes(attrs: dict[str, str | None]) -> set[str]:
+    return set((attrs.get("class") or "").split())
+
+
+class _TmeHTMLParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.posts: list[TmePost] = []
+        self._current: TmePost | None = None
+        self._post_div_depth = 0
+        self._collecting_text = False
+        self._text_buf: list[str] = []
+        self._awaiting_field: str | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = dict(attrs)
+        classes = _classes(attr_map)
+
+        if tag == "div":
+            if self._current is not None:
+                self._post_div_depth += 1
+            if "tgme_widget_message" in classes and attr_map.get("data-post"):
+                post_id = attr_map["data-post"]
+                assert post_id is not None
+                username, msg_id = _split_post_id(post_id)
+                self._current = TmePost(
+                    post_id=post_id, channel_username=username, msg_id=msg_id
+                )
+                self._post_div_depth = 1
+            elif "tgme_widget_message_text" in classes and self._current is not None:
+                self._collecting_text = True
+                self._text_buf = []
+            return
+
+        if self._current is None:
+            return
+
+        if tag == "time" and "datetime" in attr_map:
+            self._current.datetime = attr_map["datetime"]
+        elif tag == "br" and self._collecting_text:
+            self._text_buf.append("\n")
+        elif tag in ("span", "a"):
+            if "tgme_widget_message_views" in classes:
+                self._awaiting_field = "views"
+            elif "tgme_widget_message_author_signature" in classes:
+                self._awaiting_field = "author_signature"
+            elif "tgme_widget_message_forwarded_from_name" in classes:
+                self._awaiting_field = "forwarded_from"
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "div" and self._current is not None:
+            if self._collecting_text:
+                self._current.text = "".join(self._text_buf).strip()
+                self._collecting_text = False
+            self._post_div_depth -= 1
+            if self._post_div_depth <= 0:
+                self.posts.append(self._current)
+                self._current = None
+        elif tag in ("span", "a"):
+            self._awaiting_field = None
+
+    def handle_data(self, data: str) -> None:
+        if self._current is None:
+            return
+        if self._collecting_text:
+            self._text_buf.append(data)
+        elif self._awaiting_field is not None:
+            field_name = self._awaiting_field
+            current_value = getattr(self._current, field_name) or ""
+            setattr(self._current, field_name, current_value + data)
+
+    def close(self) -> None:
+        super().close()
+        for post in self.posts:
+            if post.author_signature is not None:
+                post.author_signature = post.author_signature.strip()
+            if post.forwarded_from is not None:
+                post.forwarded_from = post.forwarded_from.strip()
+            if post.views is not None:
+                post.views = post.views.strip()
+
+
+def parse_tme_page(html: str) -> list[TmePost]:
+    """Parse one `t.me/s/<name>` (or `?before=`/`?after=`-paged) HTML page
+    into its posts, in document order (Telegram renders newest-first).
+    """
+    parser = _TmeHTMLParser()
+    parser.feed(html)
+    parser.close()
+    return parser.posts

--- a/src/paperboy/web/wayback.py
+++ b/src/paperboy/web/wayback.py
@@ -1,0 +1,39 @@
+"""Parse a Wayback Machine CDX `output=json` response (spec §2.8, §6 `web`).
+
+`GET https://web.archive.org/cdx/search/cdx?url=t.me/s/<name>*&output=json`
+returns a JSON array whose *first* row is the field-name header and every
+row after it is a same-shaped array of string values — not a JSON array of
+objects — e.g.::
+
+    [
+      ["urlkey","timestamp","original","mimetype","statuscode","digest","length"],
+      ["...", "20190101000000", "http://t.me/s/telegram", "text/html", "200", "AB12", "12345"]
+    ]
+
+An index with zero snapshots is `[]` (no header row at all).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def parse_cdx_rows(payload: list[list[str]]) -> list[dict[str, str]]:
+    """Zip the header row onto every following row; `[]`/header-only -> `[]`."""
+    if len(payload) < 2:
+        return []
+    header, *rows = payload
+    return [dict(zip(header, row, strict=True)) for row in rows]
+
+
+def cdx_timestamp_to_iso(timestamp: str) -> str | None:
+    """Wayback's 14-digit `YYYYMMDDHHMMSS` (always UTC) -> ISO-8601 UTC text.
+
+    Returns `None` rather than raising on a malformed/short timestamp — a
+    CDX row this shattered on is still stored (raw + content_hash are
+    enough provenance); it just gets no parsed `timestamp` column value.
+    """
+    try:
+        return datetime.strptime(timestamp, "%Y%m%d%H%M%S").replace(tzinfo=UTC).isoformat()
+    except ValueError:
+        return None

--- a/src/paperboy/web/wayback.py
+++ b/src/paperboy/web/wayback.py
@@ -19,11 +19,20 @@ from datetime import UTC, datetime
 
 
 def parse_cdx_rows(payload: list[list[str]]) -> list[dict[str, str]]:
-    """Zip the header row onto every following row; `[]`/header-only -> `[]`."""
-    if len(payload) < 2:
+    """Zip the header row onto every following row; `[]`/header-only -> `[]`.
+
+    A row whose length doesn't match the header (a malformed/truncated CDX
+    line) is skipped rather than crashing the whole `web` phase — the CDX
+    endpoint is a best-effort bonus vector, not worth aborting a collect over.
+    """
+    if not isinstance(payload, list) or len(payload) < 2:
         return []
     header, *rows = payload
-    return [dict(zip(header, row, strict=True)) for row in rows]
+    out: list[dict[str, str]] = []
+    for row in rows:
+        if isinstance(row, list) and len(row) == len(header):
+            out.append(dict(zip(header, row, strict=True)))
+    return out
 
 
 def cdx_timestamp_to_iso(timestamp: str) -> str | None:

--- a/tests/fixtures/tl/chat_invite_already.json
+++ b/tests/fixtures/tl/chat_invite_already.json
@@ -1,0 +1,7 @@
+{
+  "_": "ChatInviteAlready",
+  "chat": {
+    "_": "Channel", "id": 777, "access_hash": 555, "title": "Known Group",
+    "username": "knowngroup", "megagroup": true
+  }
+}

--- a/tests/fixtures/tl/chat_invite_preview.json
+++ b/tests/fixtures/tl/chat_invite_preview.json
@@ -1,0 +1,9 @@
+{
+  "_": "ChatInvite",
+  "title": "Cool Group",
+  "photo": {"_": "PhotoEmpty", "id": 0},
+  "participants_count": 250,
+  "broadcast": false,
+  "megagroup": true,
+  "color": 0
+}

--- a/tests/fixtures/tl/recommendations.json
+++ b/tests/fixtures/tl/recommendations.json
@@ -1,0 +1,14 @@
+{
+  "_": "ChatsSlice",
+  "count": 37,
+  "chats": [
+    {
+      "_": "Channel", "id": 501, "access_hash": 1001, "title": "Similar One",
+      "username": "similarone", "broadcast": true
+    },
+    {
+      "_": "Channel", "id": 502, "access_hash": 1002, "title": "Similar Two",
+      "username": "similartwo", "broadcast": true
+    }
+  ]
+}

--- a/tests/fixtures/tl/sponsored_messages.json
+++ b/tests/fixtures/tl/sponsored_messages.json
@@ -1,0 +1,17 @@
+{
+  "_": "SponsoredMessages",
+  "messages": [
+    {
+      "_": "SponsoredMessage",
+      "random_id": "AAAAAAAA",
+      "url": "https://t.me/sponsorchannel",
+      "title": "Sponsor Title",
+      "message": "Check this out",
+      "button_text": "View",
+      "sponsor_info": "Acme Corp",
+      "additional_info": "Promoted"
+    }
+  ],
+  "chats": [],
+  "users": []
+}

--- a/tests/fixtures/web/tme_durov_page1.html
+++ b/tests/fixtures/web/tme_durov_page1.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head><title>Durov</title></head>
+<body>
+<div class="tgme_channel_info">
+  <span class="tgme_channel_info_counter">
+    <span class="counter_value">11.1M</span>
+    <span class="counter_type">subscribers</span>
+  </span>
+</div>
+<div class="tgme_widget_message_wrap js-widget_message_wrap">
+  <div class="tgme_widget_message js-widget_message" data-post="durov/523" data-view="1420000">
+    <div class="tgme_widget_message_bubble">
+      <div class="tgme_widget_message_text js-message_text" dir="auto">First post text with <a href="https://example.com">a link</a>.</div>
+      <div class="tgme_widget_message_footer">
+        <span class="tgme_widget_message_author_signature">Pavel</span>
+        <span class="tgme_widget_message_meta">
+          <a class="tgme_widget_message_date" href="https://t.me/durov/523">
+            <time datetime="2026-08-20T12:00:00+00:00" class="time">12:00</time>
+          </a>
+        </span>
+        <span class="tgme_widget_message_views">1.42M</span>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="tgme_widget_message_wrap js-widget_message_wrap">
+  <div class="tgme_widget_message js-widget_message" data-post="durov/524" data-view="12345">
+    <div class="tgme_widget_message_bubble">
+      <div class="tgme_widget_message_forwarded_from js-message_forwarded">
+        <span class="tgme_widget_message_forwarded_from_name">Telegram News</span>
+      </div>
+      <div class="tgme_widget_message_text js-message_text" dir="auto">Second post text<br>with a line break.</div>
+      <div class="tgme_widget_message_footer">
+        <span class="tgme_widget_message_meta">
+          <a class="tgme_widget_message_date" href="https://t.me/durov/524">
+            <time datetime="2026-08-19T10:15:00+00:00" class="time">10:15</time>
+          </a>
+        </span>
+        <span class="tgme_widget_message_views">982K</span>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/fixtures/web/wayback_cdx.json
+++ b/tests/fixtures/web/wayback_cdx.json
@@ -1,0 +1,5 @@
+[
+  ["urlkey", "timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+  ["me,t)/s/durov", "20190301120000", "http://t.me/s/durov", "text/html", "200", "AAAABBBBCCCCDDDD", "142000"],
+  ["me,t)/s/durov", "20200615093000", "https://t.me/s/durov", "text/html", "200", "EEEEFFFFGGGGHHHH", "150300"]
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -93,6 +93,68 @@ def test_collect_history_alone_rejected_with_clear_message(tmp_path, monkeypatch
     assert "AssertionError" not in result.stdout
 
 
+def test_collect_media_alone_rejected_with_clear_message(tmp_path, monkeypatch):
+    # Same rule as `history`: `media` also depends on `channel_id`/
+    # `input_channel`, so `--phases media` without `channel` must fail fast.
+    async def fake_build_gateway(settings, secrets, profile, store):
+        del settings, secrets, profile, store
+        return FakeGateway(_fixtures())
+
+    monkeypatch.setattr(composition, "build_gateway", fake_build_gateway)
+
+    result = runner.invoke(
+        app,
+        ["collect", "@x", "--profile", "clitest_media_only", "--phases", "media", "--unsafe"],
+        env={"PAPERBOY_DATA_DIR": str(tmp_path)},
+    )
+    assert result.exit_code != 0
+    assert "channel" in result.stdout
+    assert "AssertionError" not in result.stdout
+
+
+def test_collect_media_flag_downloads_and_stays_off_without_it(tmp_path, monkeypatch):
+    fx = _fixtures()
+    fx["history"] = [
+        {
+            "_": "message", "id": 1, "message": "", "date": 1767322445,
+            "media": {
+                "_": "MessageMediaDocument",
+                "document": {
+                    "_": "Document", "id": 1, "access_hash": 1, "mime_type": "text/plain",
+                    "attributes": [{"_": "DocumentAttributeFilename", "file_name": "a.txt"}],
+                },
+            },
+        }
+    ]
+    fx["media"] = {1: b"hello"}
+
+    async def fake_build_gateway(settings, secrets, profile, store):
+        del settings, secrets, profile, store
+        return FakeGateway(fx)
+
+    monkeypatch.setattr(composition, "build_gateway", fake_build_gateway)
+
+    result = runner.invoke(
+        app,
+        ["collect", "@x", "--profile", "clitest_nomedia", "--phases", "channel,history",
+         "--unsafe"],
+        env={"PAPERBOY_DATA_DIR": str(tmp_path)},
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "media" not in result.stdout
+
+    result2 = runner.invoke(
+        app,
+        ["collect", "@x", "--profile", "clitest_withmedia", "--media", "--unsafe"],
+        env={"PAPERBOY_DATA_DIR": str(tmp_path)},
+    )
+    assert result2.exit_code == 0, result2.stdout
+    assert "media" in result2.stdout
+    downloaded_path = tmp_path / "clitest_withmedia" / "media"
+    assert downloaded_path.exists()
+    assert any(downloaded_path.rglob("*.txt"))
+
+
 def test_doctor_noncompliant_exits_nonzero(tmp_path, monkeypatch):
     async def fake_run_doctor(gateway, settings):
         del gateway, settings

--- a/tests/test_collector_graph.py
+++ b/tests/test_collector_graph.py
@@ -1,0 +1,266 @@
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from paperboy.budget import PhaseStop, SkipAndRecord
+from paperboy.collectors.base import CollectContext
+from paperboy.collectors.graph import GraphCollector
+from paperboy.config import load_settings
+from paperboy.store.db import Store
+from paperboy.store.messages import upsert_message
+from paperboy.targets import parse_target
+from tests.fakes import FakeGateway
+
+FX = Path("tests/fixtures/tl")
+
+
+def _load(name: str) -> dict:
+    return json.loads((FX / name).read_text())
+
+
+def _ctx(st, gw, channel_id=5, tier="stranger"):
+    return CollectContext(
+        gw, st, load_settings("default", {}), parse_target("@x"),
+        {"channel_id": channel_id, "access_hash": 9}, channel_id, tier, logging.getLogger("t"),
+    )
+
+
+def _seed_message(st: Store, channel_id: int, msg_id: int, text: str, entities: list[dict]) -> None:
+    raw_id = st.add_raw("message", {"id": msg_id}, "stranger", None)
+    msg = {
+        "_": "message", "id": msg_id, "message": text, "entities": entities,
+        "date": 1767322445, "peer_id": {"channel_id": channel_id},
+    }
+    upsert_message(st, channel_id, msg, raw_id, "2026-01-01T00:00:00+00:00", "stranger")
+
+
+def _base_fixtures() -> dict:
+    return {
+        "channel_recommendations": {"_": "Chats", "chats": []},
+        "sponsored_messages": {"_": "SponsoredMessagesEmpty"},
+    }
+
+
+def test_applies_to_channel_like_targets():
+    assert GraphCollector().applies_to(parse_target("@durov"))
+    assert not GraphCollector().applies_to(parse_target("#osint"))
+
+
+@pytest.mark.asyncio
+async def test_graph_requires_channel_context(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        ctx = CollectContext(
+            FakeGateway(_base_fixtures()), st, load_settings("default", {}), parse_target("@x"),
+            None, None, "stranger", logging.getLogger("t"),
+        )
+        with pytest.raises(PhaseStop):
+            await GraphCollector().collect(ctx)
+
+
+@pytest.mark.asyncio
+async def test_recommendations_produce_edges_peers_and_true_count(tmp_path):
+    fx = _base_fixtures()
+    fx["channel_recommendations"] = _load("recommendations.json")
+    with Store.open(tmp_path / "p.sqlite") as st:
+        res = await GraphCollector().collect(_ctx(st, FakeGateway(fx)))
+        assert res.counts["edges"] >= 2
+        assert res.counts["peers"] == 2
+
+        edges = st.conn.execute(
+            "select subject_uri, object_uri, evidence_json from edges "
+            "where predicate='recommended_with' order by object_uri"
+        ).fetchall()
+        assert [e["subject_uri"] for e in edges] == ["tg:channel:5", "tg:channel:5"]
+        assert [e["object_uri"] for e in edges] == ["tg:channel:501", "tg:channel:502"]
+        for e in edges:
+            assert json.loads(e["evidence_json"])["total_count"] == 37
+
+        peer = st.conn.execute("select username from peers where uri='tg:channel:501'").fetchone()
+        assert peer["username"] == "similarone"
+
+
+@pytest.mark.asyncio
+async def test_recommendations_chat_not_modified_is_skipped_without_crashing(tmp_path):
+    fx = _base_fixtures()
+    fx["channel_recommendations"] = SkipAndRecord("CHAT_NOT_MODIFIED")
+    with Store.open(tmp_path / "p.sqlite") as st:
+        res = await GraphCollector().collect(_ctx(st, FakeGateway(fx)))
+        assert res.counts["skipped"] >= 1
+        assert res.counts["edges"] == 0
+        assert st.conn.execute("select count(*) as n from edges").fetchone()["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_mention_name_entity_produces_mentions_edge(tmp_path):
+    fx = _base_fixtures()
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_message(
+            st, 5, 10, "hi @friend",
+            [{"_": "MessageEntityMentionName", "offset": 3, "length": 7, "user_id": 99}],
+        )
+        await GraphCollector().collect(_ctx(st, FakeGateway(fx)))
+        row = st.conn.execute(
+            "select subject_uri, predicate, object_uri from edges where predicate='mentions'"
+        ).fetchone()
+        assert row["subject_uri"] == "tg:msg:5/10"
+        assert row["object_uri"] == "tg:user:99"
+
+
+@pytest.mark.asyncio
+async def test_text_url_tme_username_link_produces_mentions_edge(tmp_path):
+    fx = _base_fixtures()
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_message(
+            st, 5, 11, "check this out",
+            [{
+                "_": "MessageEntityTextUrl", "offset": 0, "length": 15,
+                "url": "https://t.me/coolchannel",
+            }],
+        )
+        await GraphCollector().collect(_ctx(st, FakeGateway(fx)))
+        row = st.conn.execute(
+            "select subject_uri, predicate, object_uri from edges where predicate='mentions'"
+        ).fetchone()
+        assert row["subject_uri"] == "tg:msg:5/11"
+        assert row["object_uri"] == "tg:username:coolchannel"
+
+
+@pytest.mark.asyncio
+async def test_bare_url_entity_sliced_from_text_produces_mentions_edge(tmp_path):
+    fx = _base_fixtures()
+    with Store.open(tmp_path / "p.sqlite") as st:
+        text = "join https://t.me/anotherone now"
+        offset = text.index("https://")
+        length = len("https://t.me/anotherone")
+        _seed_message(
+            st, 5, 12, text,
+            [{"_": "MessageEntityUrl", "offset": offset, "length": length}],
+        )
+        await GraphCollector().collect(_ctx(st, FakeGateway(fx)))
+        row = st.conn.execute(
+            "select object_uri from edges where predicate='mentions'"
+        ).fetchone()
+        assert row["object_uri"] == "tg:username:anotherone"
+
+
+@pytest.mark.asyncio
+async def test_bare_mention_entity_is_not_resolved(tmp_path):
+    # MessageEntityMention (@name, no id) is a deliberate non-goal for this
+    # pass — it must not crash and must not produce an edge.
+    fx = _base_fixtures()
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_message(
+            st, 5, 13, "hi @friend",
+            [{"_": "MessageEntityMention", "offset": 3, "length": 7}],
+        )
+        res = await GraphCollector().collect(_ctx(st, FakeGateway(fx)))
+        assert res.counts["edges"] == 0
+
+
+@pytest.mark.asyncio
+async def test_invite_link_produces_mentions_edge_and_unjoined_preview(tmp_path):
+    fx = _base_fixtures()
+    fx["chat_invite"] = {"AbCdEf123": _load("chat_invite_preview.json")}
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_message(
+            st, 5, 14, "join us",
+            [{
+                "_": "MessageEntityTextUrl", "offset": 0, "length": 7,
+                "url": "https://t.me/+AbCdEf123",
+            }],
+        )
+        res = await GraphCollector().collect(_ctx(st, FakeGateway(fx)))
+
+        mention = st.conn.execute(
+            "select object_uri from edges where predicate='mentions'"
+        ).fetchone()
+        assert mention["object_uri"] == "tg:invite:AbCdEf123"
+
+        invited = st.conn.execute(
+            "select subject_uri, object_uri, evidence_json from edges "
+            "where predicate='invited_via'"
+        ).fetchone()
+        assert invited["subject_uri"] == "tg:msg:5/14"
+        assert invited["object_uri"] == "tg:invite:AbCdEf123"
+        evidence = json.loads(invited["evidence_json"])
+        assert evidence["resolved"] is False
+        assert evidence["title"] == "Cool Group"
+        assert evidence["participants_count"] == 250
+
+        raw_kinds = {r["kind"] for r in st.conn.execute("select kind from raw_records")}
+        assert "ChatInvite" in raw_kinds
+        assert res.counts["raw"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_invite_link_resolves_to_real_peer_when_already_known(tmp_path):
+    fx = _base_fixtures()
+    fx["chat_invite"] = {"knownhash": _load("chat_invite_already.json")}
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_message(
+            st, 5, 15, "x",
+            [{
+                "_": "MessageEntityTextUrl", "offset": 0, "length": 1,
+                "url": "https://t.me/+knownhash",
+            }],
+        )
+        await GraphCollector().collect(_ctx(st, FakeGateway(fx)))
+
+        invited = st.conn.execute(
+            "select object_uri, evidence_json from edges where predicate='invited_via'"
+        ).fetchone()
+        assert invited["object_uri"] == "tg:channel:777"
+        assert json.loads(invited["evidence_json"])["resolved"] is True
+
+        peer = st.conn.execute("select username from peers where uri='tg:channel:777'").fetchone()
+        assert peer["username"] == "knowngroup"
+
+
+@pytest.mark.asyncio
+async def test_sponsored_message_raw_logged_and_edge_added_for_tme_url(tmp_path):
+    fx = _base_fixtures()
+    fx["sponsored_messages"] = _load("sponsored_messages.json")
+    with Store.open(tmp_path / "p.sqlite") as st:
+        res = await GraphCollector().collect(_ctx(st, FakeGateway(fx)))
+        assert res.counts["raw"] >= 1
+
+        raw = st.conn.execute(
+            "select payload_json from raw_records where kind='SponsoredMessage'"
+        ).fetchone()
+        payload = json.loads(raw["payload_json"])
+        assert payload["sponsor_info"] == "Acme Corp"
+
+        edge = st.conn.execute(
+            "select subject_uri, object_uri, evidence_json from edges where predicate='mentions' "
+            "and subject_uri='tg:channel:5'"
+        ).fetchone()
+        assert edge["object_uri"] == "tg:username:sponsorchannel"
+        evidence = json.loads(edge["evidence_json"])
+        assert evidence["sponsor_info"] == "Acme Corp"
+
+
+@pytest.mark.asyncio
+async def test_sponsored_messages_empty_is_a_noop(tmp_path):
+    fx = _base_fixtures()
+    with Store.open(tmp_path / "p.sqlite") as st:
+        res = await GraphCollector().collect(_ctx(st, FakeGateway(fx)))
+        # `channel_recommendations` (also empty in the base fixture) still
+        # raw-logs its own envelope, so `raw` isn't 0 overall — assert
+        # specifically that `SponsoredMessagesEmpty` produced no per-message
+        # raw record or edge of its own.
+        assert "SponsoredMessage" not in {
+            r["kind"] for r in st.conn.execute("select kind from raw_records")
+        }
+        assert res.counts["edges"] == 0
+
+
+@pytest.mark.asyncio
+async def test_sponsored_messages_admin_only_error_is_skipped_without_crashing(tmp_path):
+    fx = _base_fixtures()
+    fx["sponsored_messages"] = SkipAndRecord("CHAT_ADMIN_REQUIRED")
+    with Store.open(tmp_path / "p.sqlite") as st:
+        res = await GraphCollector().collect(_ctx(st, FakeGateway(fx)))
+        assert res.counts["skipped"] >= 1
+        assert res.counts["edges"] == 0

--- a/tests/test_collector_media.py
+++ b/tests/test_collector_media.py
@@ -3,7 +3,7 @@ import logging
 
 import pytest
 
-from paperboy.budget import PhaseStop
+from paperboy.budget import PhaseStop, SkipAndRecord
 from paperboy.collectors.base import CollectContext
 from paperboy.collectors.media import MediaCollector
 from paperboy.config import load_settings
@@ -267,3 +267,20 @@ async def test_collect_raises_phase_stop_when_channel_context_unset(tmp_path):
         )
         with pytest.raises(PhaseStop):
             await MediaCollector().collect(ctx)
+
+
+@pytest.mark.asyncio
+async def test_media_skip_and_record_skips_one_file_and_continues(tmp_path):
+    # A per-file SkipAndRecord (e.g. file_reference expired twice) must skip
+    # just that file, not abort the whole media phase.
+    settings = _settings(tmp_path)
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed(st, _doc_msg(1, doc_id=1001))
+        _seed(st, _doc_msg(2, doc_id=1002))
+        gw = FakeGateway(
+            {"media": {1: SkipAndRecord("file_reference expired twice"), 2: b"good bytes"}}
+        )
+        res = await MediaCollector().collect(_ctx(st, gw, settings))
+        assert res.counts["skipped"] == 1
+        assert res.counts["downloaded"] == 1
+        assert st.conn.execute("select count(*) as n from media").fetchone()["n"] == 1

--- a/tests/test_collector_media.py
+++ b/tests/test_collector_media.py
@@ -1,0 +1,269 @@
+import hashlib
+import logging
+
+import pytest
+
+from paperboy.budget import PhaseStop
+from paperboy.collectors.base import CollectContext
+from paperboy.collectors.media import MediaCollector
+from paperboy.config import load_settings
+from paperboy.ids import utc_now_iso
+from paperboy.store.db import Store
+from paperboy.store.messages import upsert_message
+from paperboy.targets import parse_target
+from tests.fakes import FakeGateway
+
+CHANNEL_ID = 5
+
+
+def _doc_msg(msg_id, *, doc_id=111, mime="application/pdf", file_name="report.pdf", **extra):
+    m = {
+        "_": "message",
+        "id": msg_id,
+        "message": "",
+        "date": 1767322445,
+        "media": {
+            "_": "MessageMediaDocument",
+            "document": {
+                "_": "Document",
+                "id": doc_id,
+                "access_hash": 222,
+                "mime_type": mime,
+                "attributes": [{"_": "DocumentAttributeFilename", "file_name": file_name}],
+            },
+        },
+    }
+    m.update(extra)
+    return m
+
+
+def _photo_msg(msg_id, *, photo_id=333):
+    return {
+        "_": "message",
+        "id": msg_id,
+        "message": "",
+        "date": 1767322445,
+        "media": {
+            "_": "MessageMediaPhoto",
+            "photo": {"_": "Photo", "id": photo_id, "access_hash": 444},
+        },
+    }
+
+
+def _text_msg(msg_id):
+    return {"_": "message", "id": msg_id, "message": f"m{msg_id}", "date": 1767322445}
+
+
+def _seed(store, msg, channel_id=CHANNEL_ID, tier="stranger"):
+    raw_id = store.add_raw(msg.get("_", "Message"), msg, tier, {"channel_id": channel_id})
+    return upsert_message(store, channel_id, msg, raw_id, utc_now_iso(), tier)
+
+
+def _settings(tmp_path):
+    return load_settings("default", {"data_dir": tmp_path})
+
+
+def _ctx(st, gw, settings, channel_id=CHANNEL_ID, tier="stranger", profile="p"):
+    return CollectContext(
+        gw, st, settings, parse_target("@x"),
+        {"channel_id": channel_id, "access_hash": 9}, channel_id, tier,
+        logging.getLogger("t"), profile,
+    )
+
+
+@pytest.mark.asyncio
+async def test_document_downloads_hashes_and_records_media_and_custody(tmp_path):
+    data = b"%PDF-1.4 fake document bytes"
+    sha = hashlib.sha256(data).hexdigest()
+    settings = _settings(tmp_path)
+    gw = FakeGateway({"media": {1: data}})
+
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed(st, _doc_msg(1))
+        res = await MediaCollector().collect(_ctx(st, gw, settings))
+
+        assert res.counts["downloaded"] == 1
+        assert gw.download_media_calls == [1]
+
+        expected_path = tmp_path / "p" / "media" / sha[:2] / f"{sha}.pdf"
+        assert expected_path.exists()
+        assert expected_path.read_bytes() == data
+
+        row = st.conn.execute("SELECT * FROM media WHERE sha256=?", (sha,)).fetchone()
+        assert row is not None
+        assert row["message_uri"] == "tg:msg:5/1"
+        assert row["kind"] == "document"
+        assert row["mime_type"] == "application/pdf"
+        assert row["file_name"] == "report.pdf"
+        assert row["size"] == len(data)
+        assert row["path"] == str(expected_path)
+        assert row["downloaded_at"] is not None
+        assert row["exif_json"] is None
+
+        custody = st.conn.execute(
+            "SELECT * FROM custody_log WHERE sha256=?", (sha,)
+        ).fetchall()
+        assert len(custody) == 1
+        assert custody[0]["source_message_uri"] == "tg:msg:5/1"
+        assert custody[0]["path"] == str(expected_path)
+
+        raw_kinds = [
+            r["kind"] for r in st.conn.execute("SELECT kind FROM raw_records").fetchall()
+        ]
+        assert "MediaDownload" in raw_kinds
+
+
+@pytest.mark.asyncio
+async def test_photo_recorded_as_kind_photo_with_jpg_extension(tmp_path):
+    data = b"\xff\xd8\xff fake jpeg bytes"
+    sha = hashlib.sha256(data).hexdigest()
+    settings = _settings(tmp_path)
+    gw = FakeGateway({"media": {1: data}})
+
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed(st, _photo_msg(1))
+        res = await MediaCollector().collect(_ctx(st, gw, settings))
+
+        assert res.counts["downloaded"] == 1
+        row = st.conn.execute("SELECT * FROM media WHERE sha256=?", (sha,)).fetchone()
+        assert row["kind"] == "photo"
+        assert row["mime_type"] == "image/jpeg"
+        assert row["path"].endswith(".jpg")
+
+
+@pytest.mark.asyncio
+async def test_message_with_no_media_is_skipped(tmp_path):
+    settings = _settings(tmp_path)
+    gw = FakeGateway({"media": {}})
+
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed(st, _text_msg(1))
+        res = await MediaCollector().collect(_ctx(st, gw, settings))
+
+        assert res.counts["downloaded"] == 0
+        assert gw.download_media_calls == []
+        assert st.conn.execute("SELECT count(*) AS n FROM media").fetchone()["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_non_downloadable_media_kind_is_skipped(tmp_path):
+    settings = _settings(tmp_path)
+    gw = FakeGateway({"media": {}})
+    webpage_msg = {
+        "_": "message", "id": 1, "message": "link", "date": 1767322445,
+        "media": {"_": "MessageMediaWebPage", "webpage": {"_": "WebPage", "id": 9}},
+    }
+
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed(st, webpage_msg)
+        res = await MediaCollector().collect(_ctx(st, gw, settings))
+
+        assert res.counts["downloaded"] == 0
+        assert res.counts["skipped_kind"] == 1
+        assert gw.download_media_calls == []
+
+
+@pytest.mark.asyncio
+async def test_duplicate_content_id_not_redownloaded(tmp_path):
+    # Two different messages, same underlying Telegram document id (a
+    # repost/forward of the identical file) — the second should be
+    # recognized as a duplicate *before* any network call, purely from the
+    # document id already embedded in its stored `media_json`.
+    data = b"shared file bytes"
+    sha = hashlib.sha256(data).hexdigest()
+    settings = _settings(tmp_path)
+    gw = FakeGateway({"media": {1: data}})
+
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed(st, _doc_msg(1, doc_id=999, file_name="a.bin"))
+        _seed(st, _doc_msg(2, doc_id=999, file_name="a.bin"))
+        res = await MediaCollector().collect(_ctx(st, gw, settings))
+
+        assert res.counts["downloaded"] == 1
+        assert res.counts["duplicates"] == 1
+        assert gw.download_media_calls == [1]  # msg 2 never reached the gateway
+
+        assert st.conn.execute("SELECT count(*) AS n FROM media").fetchone()["n"] == 1
+        custody = st.conn.execute(
+            "SELECT source_message_uri FROM custody_log WHERE sha256=? ORDER BY id", (sha,)
+        ).fetchall()
+        assert [c["source_message_uri"] for c in custody] == ["tg:msg:5/1", "tg:msg:5/2"]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_sha_across_distinct_content_ids_is_safety_netted(tmp_path):
+    # Two messages with *different* document ids whose bytes happen to hash
+    # identically — the content-id fast path misses this, but the
+    # post-download sha256 check still catches it and dedupes.
+    data = b"identical bytes despite different document ids"
+    settings = _settings(tmp_path)
+    gw = FakeGateway({"media": {1: data, 2: data}})
+
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed(st, _doc_msg(1, doc_id=111, file_name="a.bin"))
+        _seed(st, _doc_msg(2, doc_id=222, file_name="b.bin"))
+        res = await MediaCollector().collect(_ctx(st, gw, settings))
+
+        assert res.counts["downloaded"] == 1
+        assert res.counts["duplicates"] == 1
+        assert gw.download_media_calls == [1, 2]  # both were fetched...
+        n_media = st.conn.execute("SELECT count(*) AS n FROM media").fetchone()["n"]
+        assert n_media == 1  # ...but deduped by sha256 afterward
+
+
+@pytest.mark.asyncio
+async def test_unavailable_media_is_counted_not_errored(tmp_path):
+    settings = _settings(tmp_path)
+    gw = FakeGateway({"media": {}})  # download_media returns None for msg 1
+
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed(st, _doc_msg(1))
+        res = await MediaCollector().collect(_ctx(st, gw, settings))
+
+        assert res.counts["downloaded"] == 0
+        assert res.counts["unavailable"] == 1
+        assert st.conn.execute("SELECT count(*) AS n FROM media").fetchone()["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_cross_run_dedup_uses_persisted_media_table(tmp_path):
+    # A second, separate `collect()` call (simulating a fresh CLI run) must
+    # not re-download a file already recorded in `media` for a *different*
+    # message with the same document id.
+    data = b"already downloaded last run"
+    settings = _settings(tmp_path)
+    gw = FakeGateway({"media": {1: data}})
+
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed(st, _doc_msg(1, doc_id=555, file_name="a.bin"))
+        await MediaCollector().collect(_ctx(st, gw, settings))
+
+        _seed(st, _doc_msg(2, doc_id=555, file_name="a.bin"))
+        gw2 = FakeGateway({"media": {2: data}})
+        res2 = await MediaCollector().collect(_ctx(st, gw2, settings))
+
+        assert res2.counts["downloaded"] == 0
+        # Both msg 1 (an idempotent re-check of its own already-downloaded
+        # file) and msg 2 (the new repost sharing its document id) resolve
+        # via the persisted content-index, never touching the gateway.
+        assert res2.counts["duplicates"] == 2
+        assert gw2.download_media_calls == []
+        assert st.conn.execute("SELECT count(*) AS n FROM media").fetchone()["n"] == 1
+
+
+def test_applies_to_channel_like_targets():
+    assert MediaCollector().applies_to(parse_target("@durov"))
+    assert not MediaCollector().applies_to(parse_target("#osint"))
+
+
+@pytest.mark.asyncio
+async def test_collect_raises_phase_stop_when_channel_context_unset(tmp_path):
+    settings = _settings(tmp_path)
+    gw = FakeGateway({"media": {}})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        ctx = CollectContext(
+            gw, st, settings, parse_target("@x"), None, None, "stranger",
+            logging.getLogger("t"), "p",
+        )
+        with pytest.raises(PhaseStop):
+            await MediaCollector().collect(ctx)

--- a/tests/test_collector_web.py
+++ b/tests/test_collector_web.py
@@ -124,8 +124,15 @@ async def test_web_collector_paginates_with_before_and_stops_on_empty_page(tmp_p
         await collector.collect(_ctx(st))
         tme_calls = [c for c in calls if c.startswith("https://t.me/s/durov")]
         assert len(tme_calls) == 2
+        # first call fetches the NEWEST posts (no ?before=), then pages backward
+        assert "?before" not in tme_calls[0]
         assert "before=523" in tme_calls[1]
-        assert get_state(st, "web_tme", "durov") == {"before": 523}
+        # state is a newest-seen high-water mark, not a backward resume cursor —
+        # so a later run re-fetches the newest posts rather than only continuing
+        # deeper into the past.
+        state = get_state(st, "web_tme", "durov")
+        assert state is not None
+        assert "before" not in state and "newest_seen" in state
 
 
 def test_applies_to_channel_like_targets():

--- a/tests/test_collector_web.py
+++ b/tests/test_collector_web.py
@@ -1,0 +1,144 @@
+import logging
+from pathlib import Path
+
+import httpx
+import pytest
+
+from paperboy.budget import SkipAndRecord
+from paperboy.collectors.base import CollectContext
+from paperboy.collectors.web import WebCollector
+from paperboy.config import load_settings
+from paperboy.ids import msg_uri, utc_now_iso
+from paperboy.store.db import Store
+from paperboy.store.sync import get_state
+from paperboy.targets import parse_target
+from paperboy.web.client import WebClient
+from tests.fakes import FakeGateway
+
+FX = Path("tests/fixtures/web")
+
+
+def _mock_client(handler) -> WebClient:
+    return WebClient(transport=httpx.MockTransport(handler))
+
+
+def _ctx(store, target_str="@durov", channel_id=None):
+    return CollectContext(
+        FakeGateway({}), store, load_settings("default", {}), parse_target(target_str),
+        None, channel_id, "stranger", logging.getLogger("t"),
+    )
+
+
+def _handler_factory(tme_html: str, cdx_json: str, calls: list[str]):
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(str(request.url))
+        if request.url.host in ("t.me", "www.t.me"):
+            if request.url.params.get("before") is not None:
+                return httpx.Response(200, text="<html><body>no more posts</body></html>")
+            return httpx.Response(200, text=tme_html)
+        if request.url.host == "web.archive.org":
+            return httpx.Response(200, text=cdx_json)
+        return httpx.Response(404)
+
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_web_collector_stores_tme_posts(tmp_path):
+    tme_html = (FX / "tme_durov_page1.html").read_text()
+    calls: list[str] = []
+    client = _mock_client(_handler_factory(tme_html, "[]", calls))
+    with Store.open(tmp_path / "p.sqlite") as st:
+        collector = WebCollector(client=client, sleep=lambda s: None)
+        res = await collector.collect(_ctx(st))
+        assert res.counts["tme_posts"] == 2
+        rows = st.conn.execute(
+            "SELECT url, channel_username, msg_id, timestamp, content_hash "
+            "FROM web_snapshots WHERE source='tme' ORDER BY msg_id"
+        ).fetchall()
+        assert [r["msg_id"] for r in rows] == [523, 524]
+        assert rows[0]["channel_username"] == "durov"
+        assert rows[0]["url"] == "https://t.me/durov/523"
+        assert rows[0]["timestamp"] == "2026-08-20T12:00:00+00:00"
+        assert rows[0]["content_hash"]
+
+
+@pytest.mark.asyncio
+async def test_web_collector_stores_wayback_rows(tmp_path):
+    cdx_json = (FX / "wayback_cdx.json").read_text()
+    calls: list[str] = []
+    client = _mock_client(_handler_factory("<html><body>no feed</body></html>", cdx_json, calls))
+    with Store.open(tmp_path / "p.sqlite") as st:
+        collector = WebCollector(client=client, sleep=lambda s: None)
+        res = await collector.collect(_ctx(st))
+        assert res.counts["wayback_rows"] == 2
+        rows = st.conn.execute(
+            "SELECT url, timestamp, content_hash, meta_json FROM web_snapshots "
+            "WHERE source='wayback' ORDER BY timestamp"
+        ).fetchall()
+        assert rows[0]["timestamp"] == "2019-03-01T12:00:00+00:00"
+        assert rows[0]["url"] == "http://t.me/s/durov"
+        assert rows[0]["content_hash"] == "AAAABBBBCCCCDDDD"
+        assert '"statuscode": "200"' in rows[0]["meta_json"]
+
+
+@pytest.mark.asyncio
+async def test_web_collector_flags_deleted_post_recovery(tmp_path):
+    tme_html = (FX / "tme_durov_page1.html").read_text()
+    calls: list[str] = []
+    client = _mock_client(_handler_factory(tme_html, "[]", calls))
+    with Store.open(tmp_path / "p.sqlite") as st:
+        channel_id = 5
+        st.conn.execute(
+            "INSERT INTO channels (id, uri, username, first_seen, last_seen) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (channel_id, "tg:channel:5", "durov", utc_now_iso(), utc_now_iso()),
+        )
+        # post 523 is tombstoned (deleted per the MTProto side) but still
+        # visible on the t.me/s/ page -> deleted-post recovery.
+        st.conn.execute(
+            "INSERT INTO message_tombstones (message_uri, observed_at, evidence) "
+            "VALUES (?, ?, ?)",
+            (msg_uri(channel_id, 523), utc_now_iso(), "update"),
+        )
+        collector = WebCollector(client=client, sleep=lambda s: None)
+        res = await collector.collect(_ctx(st, channel_id=channel_id))
+        assert res.counts["deleted_recovered"] == 1
+        tombstoned = st.conn.execute(
+            "SELECT meta_json FROM web_snapshots WHERE source='tme' AND msg_id=523"
+        ).fetchone()
+        assert '"tombstoned_in_store": true' in tombstoned["meta_json"]
+        not_tombstoned = st.conn.execute(
+            "SELECT meta_json FROM web_snapshots WHERE source='tme' AND msg_id=524"
+        ).fetchone()
+        assert '"tombstoned_in_store": false' in not_tombstoned["meta_json"]
+
+
+@pytest.mark.asyncio
+async def test_web_collector_paginates_with_before_and_stops_on_empty_page(tmp_path):
+    tme_html = (FX / "tme_durov_page1.html").read_text()
+    calls: list[str] = []
+    client = _mock_client(_handler_factory(tme_html, "[]", calls))
+    with Store.open(tmp_path / "p.sqlite") as st:
+        collector = WebCollector(client=client, sleep=lambda s: None)
+        await collector.collect(_ctx(st))
+        tme_calls = [c for c in calls if c.startswith("https://t.me/s/durov")]
+        assert len(tme_calls) == 2
+        assert "before=523" in tme_calls[1]
+        assert get_state(st, "web_tme", "durov") == {"before": 523}
+
+
+def test_applies_to_channel_like_targets():
+    assert WebCollector().applies_to(parse_target("@durov"))
+    assert not WebCollector().applies_to(parse_target("#osint"))
+
+
+@pytest.mark.asyncio
+async def test_web_collector_skips_target_with_no_public_username(tmp_path):
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("no HTTP request should be made for an unresolvable target")
+
+    with Store.open(tmp_path / "p.sqlite") as st:
+        collector = WebCollector(client=_mock_client(handler), sleep=lambda s: None)
+        with pytest.raises(SkipAndRecord):
+            await collector.collect(_ctx(st, target_str="-100123456789"))

--- a/tests/test_collector_web.py
+++ b/tests/test_collector_web.py
@@ -72,6 +72,10 @@ async def test_web_collector_stores_wayback_rows(tmp_path):
         collector = WebCollector(client=client, sleep=lambda s: None)
         res = await collector.collect(_ctx(st))
         assert res.counts["wayback_rows"] == 2
+        # the CDX query must be BOUNDED (unbounded returns 100+ MB on a
+        # heavily-archived channel and fails to parse)
+        cdx_calls = [c for c in calls if "web.archive.org/cdx" in c]
+        assert cdx_calls and "limit=" in cdx_calls[0] and "collapse=" in cdx_calls[0]
         rows = st.conn.execute(
             "SELECT url, timestamp, content_hash, meta_json FROM web_snapshots "
             "WHERE source='wayback' ORDER BY timestamp"

--- a/tests/test_gateway_fake.py
+++ b/tests/test_gateway_fake.py
@@ -57,3 +57,11 @@ async def test_fake_channel_difference():
     diff = {"_": "updates.channelDifference", "pts": 50}
     gw = FakeGateway({"channel_difference": diff})
     assert await gw.get_channel_difference({"channel_id": 5}, pts=40, limit=100) == diff
+
+
+@pytest.mark.asyncio
+async def test_fake_download_media_returns_fixture_bytes_by_msg_id():
+    gw = FakeGateway({"media": {7: b"file bytes"}})
+    assert await gw.download_media({"channel_id": 5}, {"id": 7}) == b"file bytes"
+    assert await gw.download_media({"channel_id": 5}, {"id": 8}) is None
+    assert gw.download_media_calls == [7, 8]

--- a/tests/test_gateway_fake.py
+++ b/tests/test_gateway_fake.py
@@ -1,5 +1,6 @@
 import pytest
 
+from paperboy.budget import SkipAndRecord
 from tests.fakes import FakeGateway
 
 
@@ -57,3 +58,31 @@ async def test_fake_channel_difference():
     diff = {"_": "updates.channelDifference", "pts": 50}
     gw = FakeGateway({"channel_difference": diff})
     assert await gw.get_channel_difference({"channel_id": 5}, pts=40, limit=100) == diff
+
+
+@pytest.mark.asyncio
+async def test_fake_channel_recommendations():
+    fx = {"channel_recommendations": {"_": "messages.ChatsSlice", "count": 5, "chats": []}}
+    gw = FakeGateway(fx)
+    assert await gw.get_channel_recommendations({"channel_id": 5}) == fx["channel_recommendations"]
+
+
+@pytest.mark.asyncio
+async def test_fake_channel_recommendations_raises_configured_skip():
+    gw = FakeGateway({"channel_recommendations": SkipAndRecord("CHAT_NOT_MODIFIED")})
+    with pytest.raises(SkipAndRecord):
+        await gw.get_channel_recommendations({"channel_id": 5})
+
+
+@pytest.mark.asyncio
+async def test_fake_check_chat_invite_keyed_by_hash():
+    preview = {"_": "ChatInvite", "title": "X", "participants_count": 3}
+    gw = FakeGateway({"chat_invite": {"abc123": preview}})
+    assert await gw.check_chat_invite("abc123") == preview
+
+
+@pytest.mark.asyncio
+async def test_fake_sponsored_messages():
+    fx = {"sponsored_messages": {"_": "messages.SponsoredMessagesEmpty"}}
+    gw = FakeGateway(fx)
+    assert await gw.get_sponsored_messages({"channel_id": 5}) == fx["sponsored_messages"]

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -1,6 +1,18 @@
 from datetime import UTC, datetime
 
-from paperboy.ids import channel_uri, chat_uri, msg_uri, parse_uri, to_iso, user_uri, utc_now_iso
+from paperboy.ids import (
+    channel_uri,
+    chat_uri,
+    invite_uri,
+    msg_uri,
+    parse_tme_link,
+    parse_uri,
+    to_iso,
+    user_uri,
+    username_uri,
+    utc_now_iso,
+    utf16_slice,
+)
 
 
 def test_uris():
@@ -8,6 +20,8 @@ def test_uris():
     assert chat_uri(456) == "tg:chat:456"
     assert user_uri(789) == "tg:user:789"
     assert msg_uri(123, 45) == "tg:msg:123/45"
+    assert username_uri("durov") == "tg:username:durov"
+    assert invite_uri("AbCdEf") == "tg:invite:AbCdEf"
     assert parse_uri("tg:msg:123/45") == ("msg", (123, 45))
     assert parse_uri("tg:user:9") == ("user", (9,))
     assert parse_uri("tg:channel:5") == ("channel", (5,))
@@ -41,3 +55,33 @@ def test_utc_now_iso_is_iso_utc():
     assert s.endswith("+00:00")
     # round-trips through fromisoformat
     datetime.fromisoformat(s)
+
+
+def test_utf16_slice_ascii():
+    assert utf16_slice("hello world", 6, 5) == "world"
+
+
+def test_utf16_slice_handles_astral_prefix():
+    # U+1F600 (grinning face) is one Python codepoint but 2 UTF-16 code
+    # units, so "world" starts at UTF-16 offset 8, not Python-index 7.
+    text = "\U0001f600 world"
+    assert utf16_slice(text, 3, 5) == "world"
+
+
+def test_parse_tme_link_username():
+    assert parse_tme_link("https://t.me/durov") == ("username", "durov")
+    assert parse_tme_link("t.me/durov") == ("username", "durov")
+    assert parse_tme_link("https://telegram.me/durov") == ("username", "durov")
+    # message-link and preview-link variants reduce to the bare username
+    assert parse_tme_link("https://t.me/durov/123") == ("username", "durov")
+    assert parse_tme_link("https://t.me/s/durov") == ("username", "durov")
+
+
+def test_parse_tme_link_invite():
+    assert parse_tme_link("https://t.me/+AbCdEf123") == ("invite", "AbCdEf123")
+    assert parse_tme_link("https://t.me/joinchat/AbCdEf123") == ("invite", "AbCdEf123")
+
+
+def test_parse_tme_link_rejects_non_telegram_urls():
+    assert parse_tme_link("https://example.com/durov") is None
+    assert parse_tme_link("not a url at all") is None

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -7,7 +7,7 @@ import pytest
 from paperboy.budget import HardStop, PhaseStop, SkipAndRecord
 from paperboy.collectors.base import CollectContext, CollectResult
 from paperboy.config import load_settings
-from paperboy.recipes import collect_channel
+from paperboy.recipes import _default_collectors, collect_channel
 from paperboy.store.db import Store
 from paperboy.targets import parse_target
 from tests.fakes import FakeGateway
@@ -50,6 +50,14 @@ async def test_collect_channel_honors_phases_filter(tmp_path):
         )
         assert [r.name for r in results] == ["channel"]
         assert st.conn.execute("select count(*) as n from messages").fetchone()["n"] == 0
+
+
+def test_default_collectors_registers_web_after_history():
+    # `web` is pure HTTP (no gateway/Budget) — this only checks it's wired
+    # into the default recipe; running it end to end needs a mocked
+    # WebClient (see tests/test_collector_web.py), not a real network call.
+    names = [c.name for c in _default_collectors()]
+    assert names == ["channel", "history", "web"]
 
 
 class _StubCollector:

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -75,7 +75,8 @@ async def test_collect_channel_media_flag_opts_in(tmp_path):
             gw, st, load_settings("default", {"data_dir": tmp_path}), parse_target("@durov"),
             phases=None, log=logging.getLogger("t"), media=True, profile="mediarecipe",
         )
-        assert [r.name for r in results] == ["channel", "history", "media"]
+        # graph is in the default set now (opt-in media appends after it)
+        assert [r.name for r in results] == ["channel", "history", "graph", "media"]
         media_result = next(r for r in results if r.name == "media")
         assert media_result.counts["downloaded"] == 1
         assert st.conn.execute("select count(*) as n from media").fetchone()["n"] == 1

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -21,9 +21,20 @@ def _fixtures():
         "full_channel": json.loads((FX / "full_channel.json").read_text()),
         "self": {"_": "user", "id": 1, "self": True},
         "history": [
-            {"_": "message", "id": i, "message": f"m{i}", "date": 1767322445} for i in (2, 1)
+            {
+                "_": "message", "id": 2, "message": "", "date": 1767322445,
+                "media": {
+                    "_": "MessageMediaDocument",
+                    "document": {
+                        "_": "Document", "id": 1, "access_hash": 1, "mime_type": "text/plain",
+                        "attributes": [{"_": "DocumentAttributeFilename", "file_name": "a.txt"}],
+                    },
+                },
+            },
+            {"_": "message", "id": 1, "message": "m1", "date": 1767322445},
         ],
         "channel_difference": {"_": "updates.channelDifferenceEmpty", "final": True, "pts": 42},
+        "media": {2: b"file contents"},
     }
 
 
@@ -38,6 +49,49 @@ async def test_collect_channel_runs_channel_then_history(tmp_path):
         assert [r.name for r in results] == ["channel", "history"]
         assert st.conn.execute("select count(*) as n from channels").fetchone()["n"] == 1
         assert st.conn.execute("select count(*) as n from messages").fetchone()["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_collect_channel_media_is_opt_out_by_default(tmp_path):
+    # `media` is opt-in (spec §6): a plain run with no `media=True` and no
+    # `--phases media` must never touch the network for downloads, even
+    # though `history` populated a message with downloadable media above.
+    gw = FakeGateway(_fixtures())
+    with Store.open(tmp_path / "p.sqlite") as st:
+        results = await collect_channel(
+            gw, st, load_settings("default", {"data_dir": tmp_path}), parse_target("@durov"),
+            phases=["channel", "history"], log=logging.getLogger("t"),
+        )
+        assert [r.name for r in results] == ["channel", "history"]
+        assert gw.download_media_calls == []
+        assert st.conn.execute("select count(*) as n from media").fetchone()["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_collect_channel_media_flag_opts_in(tmp_path):
+    gw = FakeGateway(_fixtures())
+    with Store.open(tmp_path / "p.sqlite") as st:
+        results = await collect_channel(
+            gw, st, load_settings("default", {"data_dir": tmp_path}), parse_target("@durov"),
+            phases=None, log=logging.getLogger("t"), media=True, profile="mediarecipe",
+        )
+        assert [r.name for r in results] == ["channel", "history", "media"]
+        media_result = next(r for r in results if r.name == "media")
+        assert media_result.counts["downloaded"] == 1
+        assert st.conn.execute("select count(*) as n from media").fetchone()["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_collect_channel_phases_media_opts_in_without_flag(tmp_path):
+    gw = FakeGateway(_fixtures())
+    with Store.open(tmp_path / "p.sqlite") as st:
+        results = await collect_channel(
+            gw, st, load_settings("default", {"data_dir": tmp_path}), parse_target("@durov"),
+            phases=["channel", "history", "media"], log=logging.getLogger("t"),
+            profile="mediarecipe2",
+        )
+        assert [r.name for r in results] == ["channel", "history", "media"]
+        assert st.conn.execute("select count(*) as n from media").fetchone()["n"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_store_migrations.py
+++ b/tests/test_store_migrations.py
@@ -32,10 +32,11 @@ def test_add_raw_without_context(tmp_path):
 def test_reopen_does_not_reapply_migrations(tmp_path):
     path = tmp_path / "p.sqlite"
     with Store.open(path) as st:
+        first_open_count = st.conn.execute("select count(*) from schema_migrations").fetchone()[0]
         st.add_raw("x", {}, tier="stranger", context=None)
     with Store.open(path) as st:
         count = st.conn.execute("select count(*) from schema_migrations").fetchone()[0]
-        assert count == 1  # not reapplied / duplicated
+        assert count == first_open_count  # not reapplied / duplicated
         rows = st.conn.execute("select count(*) from raw_records").fetchone()[0]
         assert rows == 1
 
@@ -63,8 +64,17 @@ def test_expected_tables_exist(tmp_path):
             "custody_log",
             "run_events",
             "schema_migrations",
+            "web_snapshots",
         ):
             assert expected in names, f"missing table {expected}"
+
+
+def test_0002_web_migration_applied(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        applied = {
+            r["name"] for r in st.conn.execute("select name from schema_migrations")
+        }
+        assert "0002_web" in applied
 
 
 def test_messages_fts_tracks_inserts(tmp_path):

--- a/tests/test_store_web.py
+++ b/tests/test_store_web.py
@@ -1,0 +1,67 @@
+from paperboy.ids import utc_now_iso
+from paperboy.store.db import Store
+from paperboy.store.web import insert_tme_snapshot, insert_wayback_snapshot
+
+
+def test_insert_tme_snapshot_round_trips(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        rid = insert_tme_snapshot(
+            st,
+            url="https://t.me/durov/523",
+            fetched_at=utc_now_iso(),
+            channel_username="durov",
+            msg_id=523,
+            timestamp="2026-08-20T12:00:00+00:00",
+            content_hash="abc123",
+            raw={"text": "hi"},
+            meta={"views": "1.42M"},
+        )
+        row = st.conn.execute(
+            "SELECT source, url, msg_id, channel_username, meta_json FROM web_snapshots WHERE id=?",
+            (rid,),
+        ).fetchone()
+        assert row["source"] == "tme"
+        assert row["msg_id"] == 523
+        assert row["channel_username"] == "durov"
+        assert '"views": "1.42M"' in row["meta_json"]
+
+
+def test_insert_tme_snapshot_is_append_only(tmp_path):
+    """Two observations of the same post are two rows (an observation log,
+    like `channel_snapshots`), not upserted current-state.
+    """
+    with Store.open(tmp_path / "p.sqlite") as st:
+        for _ in range(2):
+            insert_tme_snapshot(
+                st,
+                url="https://t.me/durov/523",
+                fetched_at=utc_now_iso(),
+                channel_username="durov",
+                msg_id=523,
+                timestamp=None,
+                content_hash=None,
+                raw={},
+                meta=None,
+            )
+        n = st.conn.execute("SELECT count(*) AS n FROM web_snapshots").fetchone()["n"]
+        assert n == 2
+
+
+def test_insert_wayback_snapshot_has_no_msg_id(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        rid = insert_wayback_snapshot(
+            st,
+            url="http://t.me/s/durov",
+            fetched_at=utc_now_iso(),
+            channel_username="durov",
+            timestamp="2019-03-01T12:00:00+00:00",
+            content_hash="digest123",
+            raw={"timestamp": "20190301120000"},
+            meta={"statuscode": "200"},
+        )
+        row = st.conn.execute(
+            "SELECT source, msg_id, content_hash FROM web_snapshots WHERE id=?", (rid,)
+        ).fetchone()
+        assert row["source"] == "wayback"
+        assert row["msg_id"] is None
+        assert row["content_hash"] == "digest123"

--- a/tests/test_web_client.py
+++ b/tests/test_web_client.py
@@ -1,0 +1,88 @@
+"""`WebClient` allow-list enforcement — the tested invariant from issue #1.
+
+No real network anywhere here: every case uses `httpx.MockTransport`.
+"""
+
+import httpx
+import pytest
+
+from paperboy.web.client import ALLOWED_HOSTS, DisallowedHostError, WebClient
+
+
+def test_allowed_hosts_is_exactly_the_three_hosts():
+    assert {"t.me", "www.t.me", "web.archive.org"} == ALLOWED_HOSTS
+
+
+def test_get_rejects_a_non_allowlisted_host():
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return httpx.Response(200, text="should never be reached")
+
+    client = WebClient(transport=httpx.MockTransport(handler))
+    with pytest.raises(DisallowedHostError):
+        client.get("https://evil.example.com/steal")
+    assert calls == []  # rejected before any request was sent
+
+
+def test_get_allows_an_allowlisted_host():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="ok")
+
+    client = WebClient(transport=httpx.MockTransport(handler))
+    response = client.get("https://t.me/s/durov")
+    assert response.status_code == 200
+    assert response.text == "ok"
+
+
+def test_get_rejects_a_redirect_to_a_non_allowlisted_host():
+    """t.me answering 302 to an external host must not be followed."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "t.me":
+            return httpx.Response(302, headers={"location": "https://evil.example.com/phish"})
+        return httpx.Response(200, text="should never be reached")
+
+    client = WebClient(transport=httpx.MockTransport(handler))
+    with pytest.raises(DisallowedHostError):
+        client.get("https://t.me/s/durov")
+
+
+def test_get_follows_a_redirect_to_an_allowlisted_host():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "t.me":
+            return httpx.Response(302, headers={"location": "https://www.t.me/s/durov"})
+        return httpx.Response(200, text="landed")
+
+    client = WebClient(transport=httpx.MockTransport(handler))
+    response = client.get("https://t.me/s/durov")
+    assert response.status_code == 200
+    assert response.text == "landed"
+
+
+def test_get_rejects_a_relative_redirect_resolving_off_allowlisted_host():
+    """A redirect chain: t.me -> www.t.me (ok) -> evil host (rejected), each
+    hop checked independently — allowing the first hop must not grant the
+    second a free pass.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "t.me":
+            return httpx.Response(302, headers={"location": "https://www.t.me/s/durov"})
+        if request.url.host == "www.t.me":
+            return httpx.Response(302, headers={"location": "https://evil.example.com/x"})
+        return httpx.Response(200, text="should never be reached")
+
+    client = WebClient(transport=httpx.MockTransport(handler))
+    with pytest.raises(DisallowedHostError):
+        client.get("https://t.me/s/durov")
+
+
+def test_too_many_redirects_raises():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(302, headers={"location": "https://t.me/s/durov"})
+
+    client = WebClient(transport=httpx.MockTransport(handler))
+    with pytest.raises(DisallowedHostError):
+        client.get("https://t.me/s/durov", max_redirects=2)

--- a/tests/test_web_tme_parser.py
+++ b/tests/test_web_tme_parser.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+from paperboy.web.tme_parser import parse_tme_page
+
+FX = Path("tests/fixtures/web/tme_durov_page1.html")
+
+
+def test_parses_expected_post_count_and_order():
+    posts = parse_tme_page(FX.read_text())
+    assert [p.post_id for p in posts] == ["durov/523", "durov/524"]
+
+
+def test_parses_data_post_into_channel_username_and_msg_id():
+    posts = parse_tme_page(FX.read_text())
+    first = posts[0]
+    assert first.channel_username == "durov"
+    assert first.msg_id == 523
+
+
+def test_parses_datetime_attribute_exactly():
+    posts = parse_tme_page(FX.read_text())
+    assert posts[0].datetime == "2026-08-20T12:00:00+00:00"
+    assert posts[1].datetime == "2026-08-19T10:15:00+00:00"
+
+
+def test_parses_abbreviated_views():
+    posts = parse_tme_page(FX.read_text())
+    assert posts[0].views == "1.42M"
+    assert posts[1].views == "982K"
+
+
+def test_parses_author_signature():
+    posts = parse_tme_page(FX.read_text())
+    assert posts[0].author_signature == "Pavel"
+    assert posts[1].author_signature is None
+
+
+def test_parses_forwarded_from():
+    posts = parse_tme_page(FX.read_text())
+    assert posts[0].forwarded_from is None
+    assert posts[1].forwarded_from == "Telegram News"
+
+
+def test_parses_text_with_inline_link_and_br_as_newline():
+    posts = parse_tme_page(FX.read_text())
+    assert posts[0].text == "First post text with a link."
+    assert posts[1].text == "Second post text\nwith a line break."
+
+
+def test_empty_page_parses_to_no_posts():
+    assert parse_tme_page("<html><body>no feed here</body></html>") == []

--- a/tests/test_web_wayback.py
+++ b/tests/test_web_wayback.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+from paperboy.web.wayback import cdx_timestamp_to_iso, parse_cdx_rows
+
+FX = Path("tests/fixtures/web/wayback_cdx.json")
+
+
+def test_parses_recorded_fixture_into_rows():
+    payload = json.loads(FX.read_text())
+    rows = parse_cdx_rows(payload)
+    assert len(rows) == 2
+    assert rows[0]["timestamp"] == "20190301120000"
+    assert rows[0]["original"] == "http://t.me/s/durov"
+    assert rows[0]["statuscode"] == "200"
+    assert rows[0]["digest"] == "AAAABBBBCCCCDDDD"
+
+
+def test_header_only_or_empty_payload_yields_no_rows():
+    assert parse_cdx_rows([]) == []
+    assert parse_cdx_rows([["urlkey", "timestamp", "original"]]) == []
+
+
+def test_cdx_timestamp_to_iso():
+    assert cdx_timestamp_to_iso("20190301120000") == "2019-03-01T12:00:00+00:00"
+
+
+def test_cdx_timestamp_to_iso_returns_none_on_malformed_input():
+    assert cdx_timestamp_to_iso("not-a-timestamp") is None
+    assert cdx_timestamp_to_iso("2019") is None


### PR DESCRIPTION
Phase 2 wave 1 — the `media`, `graph`, and `web` collectors (closes part of #13).

**How this was built:** the custom **wave-review workflow** — 3 Sonnet implementers (worktree-isolated, TDD, no live Telegram), then **3 Opus reviewers (adversarial / correctness / security) each sweeping all three diffs** (the flat 3-reviewer wave, not 3×N clusters). All three features passed all three lenses in **one round, zero rework**. I then integrated the branches on the main thread (resolving the shared-file merges), applied the reviewers' findings, and ran the live @durov smoke myself (the Keychain isn't reachable from sandboxed agents).

**Directly closes two things from the last review:** the sparse `edges` (graph adds 188 mentions + 10 recommended_with on @durov → edges 1→199) and the empty `web_snapshots`/`custody_log` (web + media).

---

## Changes
Phase 2 wave 1 — three new collectors, built by the wave-review workflow (Sonnet implementers, 3 Opus reviewers), integrated + fixed + live-smoked on the main thread. +2713 lines / 35 files over `main`.

- **`media`** (opt-in `--media`) — downloads each stored message's media, content-addresses it at `<data_dir>/<profile>/media/<sha[:2]>/<sha><ext>`, dedupes by Telegram document/photo id (pre-download) + SHA-256 (post-download), and records `custody_log`. `collectors/media.py`, gateway `download_media`.
- **`graph`** (default-on) — `getChannelRecommendations` (similar channels + true degree → `recommended_with` edges + peers), entity-derived `mentions` edges, `checkChatInvite` previews (no join), `getSponsoredMessages` (`sponsor_info`). `collectors/graph.py`, 3 gateway methods, `ids.parse_tme_link`.
- **`web`** (opt-in `--web`) — `t.me/s/<name>` server-rendered feed (stdlib parser) + Wayback CDX enumeration into `web_snapshots`, deleted-post recovery, allow-listed HTTP client (t.me / web.archive.org only, redirect-checked — issue #1). `web/{client,tme_parser,wayback}.py`, `store/web.py`, migration `0002_web.sql`.

Policy: `graph` runs by default (cheap, same MTProto session); `media` and `web` are opt-in (heavy / external-HTTP trust boundary), so a plain `collect` stays Telegram-only.

## Tests
- unit + integration: **194 passed** (`uv run pytest -q`)
- lint: **pass** (`uv run ruff check`)
- type-check: **pass** (`uv run pyright` — 0 errors)

## Live smoke transcript (main thread, read-only, against @durov)
Sandboxed workflow agents cannot reach the Keychain, so the live smoke runs on the main thread.

**graph + web** (`collect @durov --web --unsafe`):
```
channel  {'channels': 1, 'peers': 2}
history  {'messages': 476, 'revisions': 476, 'tombstones': 67, 'edges': 1}
graph    {'edges': 198, 'peers': 10, 'raw': 1, 'skipped': 0}
web      {'tme_posts': 423, 'deleted_recovered': 0, 'wayback_rows': 10000}
```
DB after: edges 1 → **199** (mentions 188, recommended_with 10, forwarded_from 1); peers 3 → **13**; web_snapshots **10,423** (tme 423 + wayback 10,000, oldest 2019-05-16). This directly fills the sparse-edges/empty-web gaps.

**media** (`collect @durov --media --phases channel,media --unsafe`, stopped early after proving the path):
```
media rows: 17 (13 photo + 4 document) · custody_log: 17 (all join to media) ·
files on disk content-addressed at <sha[:2]>/<sha>.ext, path SHA == stored SHA
```

### Bugs found + fixed during the live smoke / review (no-shed)
- **web/wayback was silently non-functional on real channels** — the unbounded CDX query returned a 112 MB (~775k-row) response for @durov that arrived truncated → 0 rows. Fixed with `filter=statuscode:200&collapse=digest&limit=10000`; re-confirmed live (10,000 snapshots). 
- **media** did not catch `SkipAndRecord` from a double file_reference expiry (would abort the whole media phase) — now skips just that file; +test.
- **web t.me/s pagination** persisted a backward-only cursor and never re-fetched newer posts on a re-run — now always starts from the newest.
- **web/wayback** `parse_cdx_rows` crashed on a length-mismatched CDX row — now skips malformed rows.

## Docs updated
- `docs/data-model.md` (web_snapshots table, from the web branch).

## Follow-ups (filed)
- #11 fwd-target peer, #12 self-pollution (pre-existing).
- #14 graph edge idempotency on re-run, #15 parse_tme_link reserved paths, #16 media EXIF extraction.

## Reviewer verdicts (wave)
All three features passed all three Opus lenses (adversarial / correctness / security) in **one round, zero rework**. The findings above were their minor/major notes, addressed here on the main thread.

---
CI remains billing-blocked (Actions spending limit) — local green + the live smoke are the validation gate. `graph` runs by default; `media`/`web` are opt-in (`--media`/`--web`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
