### PR TITLE
fix(history): a MessageEmpty must never blank a stored message row

### DIFF
--- a/src/paperboy/collectors/history.py
+++ b/src/paperboy/collectors/history.py
@@ -170,6 +170,23 @@ class HistoryCollector:
     def _observe_message(
         self, ctx: CollectContext, channel_id: int, m: dict, counts: dict[str, int]
     ) -> None:
+        # `MessageEmpty` is Telegram's placeholder for an id that no longer
+        # resolves (empirically only ever seen via `_probe_gaps`'s explicit
+        # `get_messages` call, never inline from `iter_history` — but nothing
+        # in the TL contract guarantees that stays true). `upsert_message`'s
+        # `ON CONFLICT DO UPDATE` has no concept of "unknown"; it would write
+        # `text=""`/`media=NULL` over a previously-stored populated row,
+        # blanking the queryable copy of a post captured before the channel
+        # served an empty for it. Route it through the same tombstone path
+        # `_probe_gaps` uses instead, and stop before the peer/edge
+        # projection below, which has nothing to project for a placeholder.
+        if m.get("_", "").lower() == "messageempty":
+            observed_at = utc_now_iso()
+            ctx.store.add_raw("MessageEmpty", m, ctx.tier, {"channel_id": channel_id})
+            mark_deleted(ctx.store, channel_id, m["id"], "empty", observed_at)
+            counts["tombstones"] += 1
+            return
+
         observed_at = utc_now_iso()
         raw_id = ctx.store.add_raw(
             m.get("_", "Message"), m, ctx.tier, {"channel_id": channel_id}

--- a/tests/test_collector_history.py
+++ b/tests/test_collector_history.py
@@ -396,3 +396,82 @@ async def test_page_budget_phase_stop_carries_the_counts_collected_so_far(tmp_pa
             await HistoryCollector().collect(_ctx(st, gw), probe_gaps=False, page_budget=1)
         assert excinfo.value.counts["messages"] == 100
         assert st.conn.execute("select count(*) c from messages").fetchone()["c"] == 100
+
+
+# --- a MessageEmpty reaching the backfill loop must never blank a stored row
+#
+# `iter_history` empirically never yields `MessageEmpty` inline (deletes are
+# just omitted; `_probe_gaps`'s explicit-id `get_messages` call is the only
+# place they're seen today) — but nothing in the TL contract guarantees that,
+# and `_observe_message` had no guard against it. If one ever arrived here,
+# `upsert_message`'s `ON CONFLICT DO UPDATE` would write `text=""`,
+# `media=NULL` over a previously-stored populated row, silently downgrading
+# the queryable `messages` copy of a post captured before the channel served
+# a MessageEmpty for it. A re-observation must never do that.
+
+
+@pytest.mark.asyncio
+async def test_message_empty_does_not_blank_a_previously_stored_message(tmp_path):
+    gw1 = FakeGateway({"history": [_m(1)]})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        await HistoryCollector().collect(_ctx(st, gw1))
+        stored = st.conn.execute(
+            "select text, deleted_at from messages where uri='tg:msg:5/1'"
+        ).fetchone()
+        assert stored["text"] == "m1"
+        assert stored["deleted_at"] is None
+
+        # A later sweep observes a MessageEmpty for the same id — the
+        # placeholder Telegram serves for a message that no longer resolves.
+        gw2 = FakeGateway({"history": [{"_": "messageEmpty", "id": 1}]})
+        res = await HistoryCollector().collect(_ctx(st, gw2))
+
+        stored = st.conn.execute(
+            "select text, media_json, deleted_at from messages where uri='tg:msg:5/1'"
+        ).fetchone()
+        assert stored["text"] == "m1"  # NOT blanked
+        assert stored["media_json"] is None  # unchanged (was already None)
+        assert stored["deleted_at"] is not None
+        tomb = st.conn.execute(
+            "select evidence from message_tombstones where message_uri='tg:msg:5/1'"
+        ).fetchone()
+        assert tomb is not None
+        assert tomb["evidence"] == "empty"
+        assert res.counts["tombstones"] == 1
+        assert res.counts["messages"] == 0
+
+
+@pytest.mark.asyncio
+async def test_message_empty_for_never_seen_id_tombstones_without_a_blank_row(tmp_path):
+    gw = FakeGateway({"history": [{"_": "messageEmpty", "id": 7}]})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        res = await HistoryCollector().collect(_ctx(st, gw))
+        assert res.counts["tombstones"] == 1
+        assert res.counts["messages"] == 0
+        assert st.conn.execute(
+            "select count(*) c from messages where uri='tg:msg:5/7'"
+        ).fetchone()["c"] == 0
+        tomb = st.conn.execute(
+            "select evidence from message_tombstones where message_uri='tg:msg:5/7'"
+        ).fetchone()
+        assert tomb is not None
+        assert tomb["evidence"] == "empty"
+
+
+@pytest.mark.asyncio
+async def test_message_service_and_normal_message_still_upsert(tmp_path):
+    """The guard must divert ONLY `MessageEmpty` — a `MessageService` (a join/
+    pin/title-change notice, still a real row) and a normal message must still
+    upsert normally in the same page."""
+    svc = _m(2, _="messageService")
+    gw = FakeGateway({"history": [svc, _m(1)], "get_messages": {}})
+    with Store.open(tmp_path / "p.sqlite") as st:
+        res = await HistoryCollector().collect(_ctx(st, gw))
+        assert res.counts["messages"] == 2
+        assert res.counts["tombstones"] == 0
+        rows = {r["uri"] for r in st.conn.execute("select uri from messages")}
+        assert rows == {"tg:msg:5/1", "tg:msg:5/2"}
+        is_service = st.conn.execute(
+            "select is_service from messages where uri='tg:msg:5/2'"
+        ).fetchone()["is_service"]
+        assert is_service == 1


### PR DESCRIPTION
## Data-safety hardening (found while evaluating re-collection risk)

`history._observe_message` called `upsert_message` unconditionally on every item from `iter_history`, with no guard against a `MessageEmpty` — Telegram's placeholder for a deleted id. If one ever reached `upsert_message`, its `ON CONFLICT DO UPDATE` would write `text=""`/`media=NULL` over a previously-stored populated row, blanking the queryable copy of a post captured *before* it was deleted. (The raw record and prior revisions preserve the content, so nothing is truly lost, but the projected `messages` row goes blank.)

Empirically this never fires today — `getHistory` omits deletes rather than returning `MessageEmpty` inline (0 of 5,496 live messages were sourced from a MessageEmpty; all 258 came from the explicit-id gap-probe). So this hardens an unguarded assumption, not a live bug — relevant because re-collection on top of existing data is exactly when it would matter.

## Change

`_observe_message` now diverts a `MessageEmpty` to the same tombstone path `_probe_gaps` already uses — `add_raw` + `mark_deleted(..., "empty", ...)`, count a tombstone (not a message), and return before `upsert_message` and the peer/edge projection. The guard is precise: only the `messageEmpty` discriminator is diverted; `MessageService` and media-only messages still upsert. Both backfill and catch-up are hardened uniformly (both route through `_observe_message`).

## Tests (TDD, failing-first)

- `test_message_empty_does_not_blank_a_previously_stored_message` — the core regression: a populated row survives a later `MessageEmpty` observation with its content intact and a tombstone recorded. Fails pre-fix (`assert '' == 'm1'`).
- `test_message_empty_for_never_seen_id_tombstones_without_a_blank_row`.
- `test_message_service_and_normal_message_still_upsert` — the guard is not over-broad.

332 tests pass; ruff + pyright clean. Implemented by a sonnet subagent, reviewed and independently re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)