### PR TITLE
feat: reproject — rebuild projections from the raw log, offline (ADR-0005)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ transcript). `watch` and `lookup` are Phase 2 stubs. `paperboy reproject`
 (rebuild every projection from `raw_records`, offline, zero network/
 credentials — see `docs/features/reproject.md`) shipped on `feat/reproject`;
 its run-structure redesign (`raw_records.run_id`, replay once per historical
-run — `docs/adr/0005-run-structure.md`) shipped on `feat/reproject-run-structure`.
+run — see `docs/adr/0005-run-structure.md`) has landed on top of it.
 Phase 2 collectors: `discussion`/`graph`/`media`/`web` are implemented;
 `participants`/`profiles` are not started.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,9 @@ collect`/`status`/`export`/`doctor`/`auth` work end to end against live
 Telegram (see `docs/features/collect-channel.md` for the DoD smoke
 transcript). `watch` and `lookup` are Phase 2 stubs. `paperboy reproject`
 (rebuild every projection from `raw_records`, offline, zero network/
-credentials — see `docs/features/reproject.md`) shipped on `feat/reproject`.
+credentials — see `docs/features/reproject.md`) shipped on `feat/reproject`;
+its run-structure redesign (`raw_records.run_id`, replay once per historical
+run — `docs/adr/0005-run-structure.md`) shipped on `feat/reproject-run-structure`.
 Phase 2 collectors: `discussion`/`graph`/`media`/`web` are implemented;
 `participants`/`profiles` are not started.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,12 +12,14 @@ database for OSINT / investigative-journalism use. Architected as an entity
 graph so later recipes (user dossier, phone lookup, watchlists) are thin
 additions. See `README.md` for the user-facing summary and disclaimer.
 
-**Status (2026-08-21):** Phase 1 (core) shipped on `feat/core` — `paperboy
+**Status (2026-08-26):** Phase 1 (core) shipped on `feat/core` — `paperboy
 collect`/`status`/`export`/`doctor`/`auth` work end to end against live
 Telegram (see `docs/features/collect-channel.md` for the DoD smoke
-transcript). `watch` and `lookup` are Phase 2 stubs. Phase 2 collectors
-(`discussion`, `participants`, `profiles`, `media`, `graph`, `web`) are not
-started.
+transcript). `watch` and `lookup` are Phase 2 stubs. `paperboy reproject`
+(rebuild every projection from `raw_records`, offline, zero network/
+credentials — see `docs/features/reproject.md`) shipped on `feat/reproject`.
+Phase 2 collectors: `discussion`/`graph`/`media`/`web` are implemented;
+`participants`/`profiles` are not started.
 
 ## Read these first
 
@@ -74,8 +76,10 @@ started.
 [--phases channel,history] [--unsafe]`, `status [TARGET]`, `export TARGET
 --format jsonl --out DIR` — all read `api_id`/`api_hash`/session for
 `--profile` (default `default`) from the OS keychain via `keyring` (macOS/Windows/Linux; tested on macOS — see issue #10) (`scripts/store_api.py`,
-`scripts/login.py`, or `paperboy auth`). `watch`/`lookup` exit 1 with a
-"Phase 2" message — not implemented yet.
+`scripts/login.py`, or `paperboy auth`). `reproject [--profile P] [--out
+PATH] [--phases a,b,c]` needs none of that — it never touches the network or
+the keychain, only a source `paperboy.sqlite`'s `raw_records`. `watch`/
+`lookup` exit 1 with a "Phase 2" message — not implemented yet.
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ The collecting account's own record is scrubbed from exports.
 | `paperboy collect TARGET [--phases …] [--unsafe] [--profile P]` | Collect channel metadata + history. |
 | `paperboy status [TARGET] [--profile P]` | Summarize stored data. |
 | `paperboy export TARGET --format jsonl --out DIR [--profile P]` | Export to JSONL. |
+| `paperboy reproject [--out PATH] [--phases …] [--profile P]` | Rebuild every projection from `raw_records` into a fresh DB — offline, no network, no credentials. |
 | `paperboy watch` / `paperboy lookup` | Phase 2 — not implemented (exit with a notice). |
 
 `TARGET` accepts `@username`, `t.me/name`, `t.me/name/123`, an invite link, or a
@@ -244,6 +245,7 @@ uv run pyright            # type-check
 - [`docs/opsec.md`](docs/opsec.md) — operator security runbook.
 - [`docs/data-model.md`](docs/data-model.md) — the database codebook (every table and column).
 - [`docs/features/collect-channel.md`](docs/features/collect-channel.md) — the core feature, with the live smoke transcript.
+- [`docs/features/reproject.md`](docs/features/reproject.md) — rebuild projections from raw, offline, with the real-archive smoke transcript.
 - [`docs/research/telegram-extraction-surface.md`](docs/research/telegram-extraction-surface.md) — what the Telegram API does and does not expose, by access tier.
 - [`docs/superpowers/specs/2026-08-20-paperboy-design.md`](docs/superpowers/specs/2026-08-20-paperboy-design.md) — the design.
 - [`docs/adr/`](docs/adr/) — architecture decisions (library, storage, guardrails, sync).

--- a/docs/adr/0005-run-structure.md
+++ b/docs/adr/0005-run-structure.md
@@ -105,6 +105,13 @@ Option A, with structural-marker inference for legacy rows.
    complete there. All four peer cells must be tested in BOTH stamp
    orderings — a two-invariant merge has four cells and eight ordered
    cases, and testing fewer is how round 2's regression shipped.
+   *(Residual, found by round-3 review: even the composed lattice is not
+   fully order-independent when a `min` observation is stamped newer than
+   the NEWEST `full` observation of the peer — identity columns diverge in
+   the two-full sandwich (#38), and the `source_raw_id` lineage pointer
+   diverges with ≥1 full (#39, `source_raw_id`'s dual
+   identity-source/provenance-source role). Both filed; closing them needs
+   a richness-scoped timestamp benchmark distinct from `last_seen`.)*
 
 ## Consequences
 

--- a/docs/adr/0005-run-structure.md
+++ b/docs/adr/0005-run-structure.md
@@ -1,6 +1,11 @@
 # ADR-0005: Record run structure in the raw log (`raw_records.run_id`)
 
-**Status:** accepted (2026-08-26)
+**Status:** accepted (2026-08-26); verified (2026-08-26) — real-archive
+smoke re-run after implementation, `docs/features/reproject.md`'s "ADR-0005
+revision" section. `channel_snapshots`/`web_snapshots`/`message_metrics` all
+round-trip exactly (the headline defect this ADR fixes); two further bugs
+surfaced by that smoke run and fixed before landing — see that section's
+"Two bugs found and fixed by this smoke test."
 
 ## Context
 

--- a/docs/adr/0005-run-structure.md
+++ b/docs/adr/0005-run-structure.md
@@ -1,0 +1,101 @@
+# ADR-0005: Record run structure in the raw log (`raw_records.run_id`)
+
+**Status:** accepted (2026-08-26)
+
+## Context
+
+The raw-first thesis (ADR-0002, CLAUDE.md) says normalized tables are a
+projection that can be rebuilt from raw. Implementing `reproject` (#33)
+proved that claim **false as stated for any multi-run archive**: the
+projection is a function of the raw log *plus the run structure* — how many
+collect passes produced the records and which record belongs to which pass —
+and the run structure is nowhere in the raw log.
+`raw_records(kind, observed_at, tier, context_json, payload_json)` cannot
+distinguish "one run that observed the channel once" from "seven runs that
+observed it seven times", yet the projections differ (snapshot time series,
+`first_seen`/`last_seen` evolution, per-run web captures, custody entries).
+
+The first implementation modeled replay as a single run (`_latest()` per call
+site) and, when review rejected the resulting data loss, grew a parallel
+"backfill older observations" projection path outside the collectors. Three
+review rounds showed negative convergence — the shadow path kept violating
+invariants the collector path establishes for free (write ordering,
+self-exclusion preconditions, serve-coverage). Full diagnosis: #33.
+
+## Options considered
+
+- **A. Add a run identifier to `raw_records`; replay run-by-run.** Schema
+  change to the system of record; restores a single projection path (the
+  collectors), each historical pass replayed in capture order.
+- **B. Keep the one-run replay + hand-written backfills for older
+  observations.** No schema change, but duplicates projection logic outside
+  the collectors — empirically the defect generator #33 documents.
+- **C. Single-run scope: refuse or warn on multi-run sources.** Honest but
+  defers the feature's entire payoff — the real `default` archive is
+  multi-run (7 collect passes).
+- **Legacy-row segmentation:** (i) `observed_at` gap clustering — rejected:
+  a FLOOD_WAIT sleep inside one run produces gaps larger than the gap
+  between runs; (ii) join against `run_events` — rejected as the primary
+  rule: it is a projection-side table, so leaning on it weakens the very
+  "pure function of raw" contract being repaired (kept only as a manual
+  cross-check); (iii) structural marker — every collect pass's **first** raw
+  write is the redacted collecting-account `User` at `tier='self'`
+  (`collectors/channel.py` writes self before anything else, and the CLI
+  refuses dependent phases without `channel`), so a new `tier='self'` user
+  record marks a run boundary.
+
+## Decision
+
+Option A, with structural-marker inference for legacy rows.
+
+1. Migration `0003_run_id.sql`: `ALTER TABLE raw_records ADD COLUMN run_id
+   TEXT` (nullable — legacy rows stay NULL; never rewritten) plus an index.
+2. `Store.begin_run(run_id: str | None = None) -> str` generates an opaque
+   id (uuid4 hex) and every subsequent `add_raw` stamps it.
+   `recipes.collect_channel` begins a run at entry and accepts an injected
+   `run_id` so a replay stamps the target DB with the *source* run's
+   identity — a reprojected DB is itself faithfully re-reprojectable.
+3. Run **ordering is derived from the log** (ascending `MIN(rowid)` per
+   run), never encoded in the id. Runs are contiguous rowid ranges (one
+   sequential process per collect); `ReplaySource` asserts contiguity and
+   fails loudly if ever violated.
+4. Legacy rows (NULL `run_id`) are segmented **at replay time, read-only**
+   by the `tier='self'` marker rule; segments are labeled `legacy-0001…` in
+   capture order. The source DB is never mutated.
+5. `reproject` replays **once per run**: per-run targets (that run's
+   `ResolvedPeer` records), per-run phase detection, per-run-scoped gateway
+   queries (`id BETWEEN run.lo AND run.hi`). The target store carries
+   `sync_state` across replayed runs exactly as the live store did across
+   real runs. All `_backfill_older_*` shadow-projection code is deleted.
+6. Independently (defense-in-depth and a live-collect correctness fix):
+   `upsert_peer`/`upsert_channel` become order-independent —
+   `first_seen = MIN`, `last_seen = MAX`, current-state fields updated only
+   by an observation at least as new as the stored `last_seen`.
+
+## Consequences
+
+- One projection path again; replay ordering, self-exclusion, and serve
+  coverage are correct by construction instead of by re-implementation.
+- The round-trip identity contract (spec §7/D5) extends to **multi-run**
+  sources, and the gate test suite gains a two-run fixture — the missing
+  convergence signal from #33.
+- Schema change to the system of record; old paperboy versions ignore the
+  extra column (SQLite), new versions read old DBs via inference.
+- Legacy segmentation is best-effort: exact for every archive produced by
+  current collectors (self is always written first), inferential only in
+  that the rule is derived, not recorded. `run_events` counts serve as a
+  manual cross-check during the real-archive smoke.
+- Residual (narrowed, not closed, #36): a historical run whose media phase
+  ran but downloaded nothing new leaves no raw trace, so its
+  duplicate-custody rows are not reproduced — phase detection is
+  conservative by design (spec D4.5).
+- #35's double-replay of one channel under two target spellings disappears:
+  each spelling replays only within its own run(s).
+
+## Notes
+
+- Diagnosis and evidence: issue #33 (escalation comment, 2026-08-26).
+- Related: #34 (non-channel resolution must be a `SkipAndRecord`, not a
+  crash — surfaced by the same smoke), #36 (custody residual, above).
+- Spec: `docs/superpowers/specs/2026-08-25-reproject-design.md` §11.
+- Plan: `docs/superpowers/plans/2026-08-26-reproject.md`, revision R.

--- a/docs/adr/0005-run-structure.md
+++ b/docs/adr/0005-run-structure.md
@@ -5,7 +5,10 @@ smoke re-run after implementation, `docs/features/reproject.md`'s "ADR-0005
 revision" section. `channel_snapshots`/`web_snapshots`/`message_metrics` all
 round-trip exactly (the headline defect this ADR fixes); two further bugs
 surfaced by that smoke run and fixed before landing — see that section's
-"Two bugs found and fixed by this smoke test."
+"Two bugs found and fixed by this smoke test." A third, distinct legacy-
+segmentation bug in this same `runs()` algorithm was found and fixed in a
+later validation pass (still 2026-08-26) — see that doc's "A third bug found
+and fixed by a later real-archive re-run."
 
 ## Context
 
@@ -101,6 +104,20 @@ Option A, with structural-marker inference for legacy rows.
 
 - Diagnosis and evidence: issue #33 (escalation comment, 2026-08-26).
 - Related: #34 (non-channel resolution must be a `SkipAndRecord`, not a
-  crash — surfaced by the same smoke), #36 (custody residual, above).
+  crash — surfaced by the same smoke), #36 (custody residual, above — its
+  reported size was corrected downward by the fix below).
+- A third legacy-segmentation bug, found in a later validation pass over the
+  same `runs()` algorithm this decision introduced: point 4's "structural
+  marker" rule committed to a new-run boundary on ANY opening-kind row seen
+  after a substantive one, with no check that it was ever confirmed genuine
+  by a self marker — so a lone foreign row (nothing in this codebase
+  prevents two `collect` invocations racing on one profile) silently
+  orphaned every row after it into a segment with no self record, which
+  then failed replay entirely. Fixed by deferring a legacy boundary
+  decision until the candidate opening cluster is complete and confirmed to
+  contain its own self marker; a cluster with none folds into the run
+  already open instead of cutting a new one. Full diagnosis, fix, and the
+  corrected real-archive numbers: `docs/features/reproject.md`, "A third bug
+  found and fixed by a later real-archive re-run."
 - Spec: `docs/superpowers/specs/2026-08-25-reproject-design.md` §11.
 - Plan: `docs/superpowers/plans/2026-08-26-reproject.md`, revision R.

--- a/docs/adr/0005-run-structure.md
+++ b/docs/adr/0005-run-structure.md
@@ -76,9 +76,35 @@ Option A, with structural-marker inference for legacy rows.
    `sync_state` across replayed runs exactly as the live store did across
    real runs. All `_backfill_older_*` shadow-projection code is deleted.
 6. Independently (defense-in-depth and a live-collect correctness fix):
-   `upsert_peer`/`upsert_channel` become order-independent —
-   `first_seen = MIN`, `last_seen = MAX`, current-state fields updated only
-   by an observation at least as new as the stored `last_seen`.
+   `upsert_peer`/`upsert_channel` become order-independent.
+   *(Amended 2026-08-26, review round 2 finding A: the original one-line
+   rule here — "current-state fields updated only by an observation at
+   least as new as the stored `last_seen`" — was recency-only and silently
+   dropped `peers.py`'s pre-existing **richness** invariant ("a `min`
+   observation never clobbers the richer stored profile", stated only in
+   that module's docstring). Recency and richness are independent
+   orderings, and the peer projection is subject to BOTH; the composed
+   lattice, by stored×incoming cell, is:)*
+   - **full ← full:** recency — identity/profile columns (`kind`, `id`,
+     `access_hash`, `is_min`, `username`, `first_name`, `last_name`,
+     `title`, `flags_json`, `source_raw_id`) and provenance columns
+     (`seen_in_chat`, `seen_in_msg`) move iff
+     `excluded.last_seen >= stored.last_seen`.
+   - **full ← min:** richness — identity/profile columns NEVER move,
+     regardless of stamp order; provenance columns (plus their
+     `source_raw_id`, which records where the `min` reference was seen —
+     what `inputPeerFromMessage` later needs) move on recency alone.
+   - **min ← full:** richness — identity/profile columns ALWAYS move, even
+     when the full observation carries an OLDER stamp (the best profile
+     data known wins); provenance on recency.
+   - **min ← min:** recency for everything.
+   - **every cell:** `first_seen = MIN`, `last_seen = MAX` — the seen
+     window always widens and can never invert.
+   `upsert_channel` keeps the plain recency rule: `channels` has no `min`
+   concept (`_FLAG_EXCLUDE` strips the marker), so recency alone is
+   complete there. All four peer cells must be tested in BOTH stamp
+   orderings — a two-invariant merge has four cells and eight ordered
+   cases, and testing fewer is how round 2's regression shipped.
 
 ## Consequences
 

--- a/docs/features/reproject.md
+++ b/docs/features/reproject.md
@@ -173,7 +173,9 @@ the ADR-0005 run-structure revision:
   `try/except Exception` fallback (still present, for genuinely unexpected
   failures) is no longer what handles this case.
 
-One residual, narrowed but not closed by this revision:
+One residual, narrowed but not closed by this revision (and narrowed again
+by the segmentation fix below — see "Bug found and fixed by a later
+real-archive re-run"):
 
 - **A historical run whose media phase downloaded nothing NEW leaves no raw
   trace, so its duplicate-custody observations are not reproduced.**
@@ -183,14 +185,18 @@ One residual, narrowed but not closed by this revision:
   correctly infers "media didn't run" for that specific run and skips the
   phase there — which also means that run's `custody_log` entry (a real,
   historical observation: "this run saw this file again, attached to this
-  message") never gets replayed. On the real archive (below) this narrows
-  `media`/`custody_log` below the source's counts (`media` 451→293,
-  `custody_log` 607→443) — every row that IS present is correct and
-  complete; nothing beyond a media file's OWN raw trace round-trips.
-  Deliberately not attempted in this revision (fixing it properly means
-  detecting "ran but found nothing new" as distinct from "didn't run" from
-  raw kinds alone, without fabricating custody observations for runs that
-  genuinely never touched media) — tracked as
+  message") never gets replayed. On the real archive, after the segmentation
+  fix below, this narrows `media`/`custody_log` below the source's counts
+  (`media` 451→449, `custody_log` 607→599) — every row that IS present is
+  correct and complete; nothing beyond a media file's OWN raw trace
+  round-trips. (The first cut of this revision, before the segmentation fix,
+  measured a much larger gap — 451→293, 607→443 — but that number
+  conflated this residual with the distinct segmentation bug below; it did
+  not correctly isolate what #36 alone accounts for.) Deliberately not
+  attempted in this revision (fixing it properly means detecting "ran but
+  found nothing new" as distinct from "didn't run" from raw kinds alone,
+  without fabricating custody observations for runs that genuinely never
+  touched media) — tracked as
   [#36](https://github.com/SpencerNorris/paperboy/issues/36).
 - Deferred (spec §9, deliberately out of scope): an in-place `--force` mode,
   a `--verify`-only mode, incremental reproject of a single phase into an
@@ -417,6 +423,11 @@ similar; the archive's `ResolvedPeer` for it is the only trace), so it never
 wrote a `channel: complete` event, but it IS its own genuine historical
 collect pass and correctly gets its own run.
 
+**This 6-vs-7 mismatch turned out to be a real bug, not a benign
+discrepancy** — see "A third bug found and fixed by a later real-archive
+re-run" below, which also supersedes this transcript's `media`/`custody_log`/
+`raw_records` numbers.
+
 **The ADR's headline payoff, confirmed exactly:** `channel_snapshots` (6→6),
 `web_snapshots` (362→362), and `message_metrics` (4020→4020) all now
 round-trip **exactly** — these are the three tables that collapsed under
@@ -441,12 +452,11 @@ target would produce.
 a defect; every extra row is a legitimate current-projection fact the
 original archive's older collector code didn't capture.
 
-**`media`/`custody_log`/`raw_records` are the #36 residual** (see Known
-limitations): 293/443/6104 vs the source's 451/607/6258. Every row present
-is a faithful replay; what's missing is the custody trail for media a LATER
-historical run re-observed as already-downloaded (no gateway call, so no
-raw trace for a future replay to iterate over) — deliberately not attempted
-in this revision.
+**`media`/`custody_log`/`raw_records` were attributed to the #36 residual**
+(see Known limitations) at the time: 293/443/6104 vs. the source's
+451/607/6258 — **this attribution was wrong.** The 6-vs-7 segmentation
+mismatch noted above is the dominant cause; #36 alone accounts for a much
+smaller gap. See below.
 
 ### Two bugs found and fixed by this smoke test (no-shed)
 
@@ -489,3 +499,149 @@ free under replay (no network, no rate limit to economize on), and safe
 because idempotent projection upserts make any resulting re-processing of
 already-seen messages harmless. Pinned by
 `tests/test_reproject.py::test_reproject_does_not_truncate_a_backward_multi_run_backfill`.
+
+### A third bug found and fixed by a later real-archive re-run (2026-08-26)
+
+The two bugs above were caught before the ADR-0005 revision first landed.
+Re-running the exact same command against the real archive during a later
+validation pass surfaced a third, distinct legacy-segmentation defect that
+the round-trip test battery's synthetic fixtures — and the first re-run
+above — did not happen to exercise, because it needs a *foreign* row with no
+relationship to either run on either side of it, which no hand-built
+fixture had included.
+
+**Legacy run segmentation cut an unconditional new-run boundary on ANY
+opening-kind row seen after a substantive row — including a lone, foreign
+one with no self marker anywhere near it — silently discarding everything
+after it up to the next genuine opening cluster.** Nothing in this codebase
+stops two `collect` invocations from writing to the same profile
+concurrently (no file lock exists anywhere in `src/paperboy/`), and the real
+archive turned out to contain exactly that: a single stray `ResolvedPeer`
+for `@atom8388`, landing mid-run inside what was otherwise one continuous
+156-row `MediaDownload` loop for `national_resistance_movement` (msg ids
+ascending 585→801 straight through it). The opening-cluster rule (bug #1,
+above) correctly keeps a GENUINE new pass's `ResolvedPeer`/`ChatFull`/self
+trio together — but it committed to a new-run boundary the instant it saw
+ANY opening-kind row after a substantive one, with no check for whether a
+self marker ever showed up to confirm the cluster was a genuine new pass.
+The synthetic segment this cut then had no self record at all, so replay
+failed immediately at `get_self()` (`channel: skip · no self User
+recorded`) with `history`/`media` both `phase_stop` — silently dropping all
+157 rows in that segment (156 of them genuine historical `MediaDownload`
+observations) with no error and no warning. This is exactly the mismatch
+the previous transcript's "Segmentation" note flagged (`run_events`: 6
+`channel: complete` events; `runs()`: 7 legacy segments) without yet
+diagnosing it — the 7th "run" was this orphaned fragment, not `@atom8388`'s
+own genuine pass as first assumed.
+
+Fixed by not committing to a legacy boundary until the candidate opening
+cluster is known to be COMPLETE (bounded by the next substantive row, a
+stamped row, or the log's end) and confirmed to contain its own self
+marker; a cluster with none is folded into whichever run is already open
+instead of orphaning everything after it. `ReplaySource.runs()`'s docstring
+and the inline comments in `src/paperboy/replay.py` describe the buffering
+algorithm this required. Pinned by
+`tests/test_replay_gateway.py::test_runs_does_not_split_a_run_on_a_foreign_single_row_intrusion`
+(the minimal synthetic repro) and
+`test_runs_still_cuts_a_genuine_boundary_after_a_foreign_intrusion` (a
+genuine boundary elsewhere in the same log must still cut). Also added:
+`test_runs_raises_on_a_genuinely_interleaved_stamped_run_id`, closing a
+pre-existing gap — ADR-0005's stamped-run contiguity guarantee
+(`ReprojectSourceError`) had no test coverage at all before this pass.
+
+Re-running the smoke command after the fix:
+
+```
+$ PAPERBOY_DATA_DIR=.../data uv run paperboy reproject --profile default --out /tmp/reprojected.sqlite
+▶ channel
+✓ channel · channels=1 peers=2 · 0s
+▶ history
+✓ history · messages=543 revisions=543 tombstones=258 edges=238 · 0s
+▶ graph
+  graph invite preview skipped for LS-77p_pVyRiZDRk: replay: no ChatInvite recorded for hash 'LS-77p_pVyRiZDRk'
+✓ graph · edges=120 peers=21 raw=5 skipped=1 · 0s
+▶ web
+  web: wayback CDX returned HTTP 429 for national_resistance_movement — reporting failure, not zero
+✓ web · tme_posts=362 deleted_recovered=0 wayback_failed=429 · 0s
+▶ media
+  media: skipping msg 413: replay: media file missing for sha b006ec25...
+  media: skipping msg 414: replay: media file missing for sha 295dbde0...
+✓ media · downloaded=150 duplicates=0 unavailable=302 skipped_kind=27 skipped=2 · 5s
+▶ channel                                          [run 2 — now the MERGED legacy-0002: old legacy-0002 + old legacy-0003 (the orphan)]
+✓ channel · channels=1 peers=2 · 0s
+▶ history
+✓ history · messages=0 revisions=0 tombstones=0 edges=0 · 0s
+▶ media
+✓ media · downloaded=299 duplicates=150 unavailable=5 skipped_kind=27 skipped=0 · 10s
+
+  reproject @national_resistance_movement -> /tmp/reprojected.sqlite
+  [2-row table, as before]
+
+▶ channel                                          [@atom8388's stray resolve, now correctly a SECOND target within run 2 rather than its own orphaned run]
+⏹ channel · skip · 0s
+  phase channel skipped: target resolved to a non-channel peer (PeerUser)
+▶ history
+⏹ history · phase_stop · 0s
+▶ media
+⏹ media · phase_stop · 0s
+
+  reproject @atom8388 -> /tmp/reprojected.sqlite
+  [clean per-run skip, same shape as before — but now correctly attributed to run 2, not a phantom run 3]
+
+▶ channel                                          [runs 3-6 (was 4-7): 'national_resistance_movement', no leading @]
+✓ channel · channels=1 peers=2 · 0s
+▶ history
+✓ history · messages=0 revisions=0 tombstones=0 edges=0 · 0s
+▶ discussion
+✓ discussion · messages=300 revisions=300 tombstones=0 edges=256 backfilled_peers=31 unmapped=6 · 0s
+[... 3 more channel/history/discussion blocks: 300, 1200, 3153 discussion messages — unchanged from before ...]
+
+  reproject national_resistance_movement -> /tmp/reprojected.sqlite
+  [4-row table, one per run]
+
+     row counts — source vs reprojected
+┌────────────────────┬────────┬─────────────┐
+│ table               │ source │ reprojected │
+├────────────────────┼────────┼─────────────┤
+│ raw_records         │ 6258   │ 6262        │
+│ channels            │ 1      │ 1           │
+│ channel_snapshots   │ 6      │ 6           │
+│ peers               │ 158    │ 160         │
+│ messages            │ 5496   │ 5496        │
+│ message_revisions   │ 5496   │ 5496        │
+│ message_metrics     │ 4020   │ 4020        │
+│ message_tombstones  │ 258    │ 258         │
+│ edges               │ 2503   │ 2522        │
+│ media               │ 451    │ 449         │
+│ custody_log         │ 607    │ 599         │
+│ web_snapshots       │ 362    │ 362         │
+└────────────────────┴────────┴─────────────┘
+```
+
+**`ReplaySource.runs()` now finds exactly 6 legacy segments, matching
+`run_events`'s 6 `channel: complete` rows exactly** — the mismatch the
+previous transcript flagged and didn't yet explain is gone. `@atom8388`'s
+stray resolve now correctly appears as a SECOND target discovered within
+the merged run 2 (`resolve_targets` returns every distinct target seen
+within a run, in capture order) rather than manufacturing a phantom run of
+its own — still a clean `channel: skip` (#34's fix), just now attributed to
+the run that actually recorded it.
+
+**`raw_records` recovers from 6104 to 6262** — slightly ABOVE the source's
+6258, which is expected and correct: the previously-orphaned 156
+`MediaDownload` rows are now replayed as part of run 2, and a few messages
+legitimately re-served via both `getHistory` and `getChannelDifference`
+within that run produce byte-identical duplicate raw rows (real signal, per
+the round-trip contract's set-comparison note above — the identity contract
+counts these DEduplicated as a set, so they don't cost `test_round_trip_
+identity` anything). **`media` recovers from 293 to 449** (2 below the
+source's 451 — the pre-existing 2-file local-disk gap round 1 already
+documented, now the ONLY remaining `media` gap). **`custody_log` recovers
+from 443 to 599** (8 below the source's 607) — this residual 8-row gap is
+what #36 alone actually accounts for; the doc's "Known limitations" section
+above is updated to the corrected number. `messages`/`message_revisions`/
+`message_metrics`/`message_tombstones`/`web_snapshots`/`channel_snapshots`
+were already exact before this fix and remain exact after it — this bug
+never touched those tables' correctness, only which run `media`/`custody_
+log`/`raw_records` rows got attributed to (or dropped from) via the wrong
+segment boundary.

--- a/docs/features/reproject.md
+++ b/docs/features/reproject.md
@@ -17,31 +17,28 @@ the archive was captured, without re-scraping Telegram.
 
 ## How it works
 
-A `RawReplayGateway` (plus `RawReplayWebClient` for the `web` collector's
-plain-HTTP vector) implements the same `Gateway`/`WebGetter` seams the real
-collectors already depend on, but serves every response from a source DB's
-`raw_records` instead of the network. `recipes.collect_channel` then runs
-**unchanged** against the replay pair into a fresh target `Store` — same
-collector code path as a live collect, so the reprojection is provably
-identical to one (`tests/test_reproject.py::test_round_trip_identity`).
+Behavior statements below live in exactly one place — the code's own
+docstrings — this section only orients a reader toward them, it does not
+restate them (round 2 of #33's review found paraphrased narrative here going
+stale independently of the code; see "Documentation" in the ADR-0005 section
+below for what replaced that).
 
-**The clock seam.** Projections stamp `observed_at` at write time; a live
-collect wants "now", but a faithful reproject wants the *original* observation
-time, not reproject-time. `paperboy.clock.Clock` (`LiveClock`/`ReplayClock`)
-is threaded through every collector as `ctx.clock.for_payload(payload)`,
-looked up by the payload's own canonical JSON — payload-keyed, not
-call-order-keyed, because `history` consumes a whole page before projecting
-each message and `catch_up` projects messages nested inside a
-`ChannelDifference` envelope. `ReplayClock` is fed by the replay gateway as it
-serves each raw record.
-
-**Phase auto-detection.** `detect_phases(source, run)` infers which phases
-ONE historical run executed from which raw *kinds* it left behind (a run
-that never did `graph` has no `ChatsSlice`/`ChatInvite*`/`SponsoredMessage`
-raws for that run, so reproject doesn't invent `graph`-only projections it
-never had) — overridable with `--phases`. Detection is per-run (ADR-0005),
-not source-wide: a source whose early runs never did `discussion` and whose
-later runs did gets exactly that phase history back.
+- `src/paperboy/replay.py` — `ReplaySource` (read-only raw access + run
+  segmentation) and `RawReplayGateway`/`RawReplayWebClient` (the same
+  `Gateway`/`WebGetter` seams the real collectors depend on, served from
+  `raw_records` instead of the network). `recipes.collect_channel` runs
+  **unchanged** against the replay pair into a fresh target `Store` — same
+  collector code path as a live collect, so the reprojection is provably
+  identical to one (`tests/test_reproject.py::test_round_trip_identity`).
+- `src/paperboy/clock.py` — `Clock`/`LiveClock`/`ReplayClock`: where a
+  projection's `observed_at` comes from, so a reproject reproduces the
+  *original* observation time rather than stamping reproject-time.
+- `src/paperboy/reproject.py` — `detect_phases` (per-run phase
+  auto-detection from which raw kinds a run left behind, overridable with
+  `--phases`), target/run orchestration, the row-count diff summary.
+- `src/paperboy/store/peers.py` — `upsert_peer`'s composed richness ∘
+  recency merge (ADR-0005 §6); see "Peer projection composition" below for
+  the pointer, this doc does not restate the lattice.
 
 ## Run structure (ADR-0005)
 
@@ -69,13 +66,34 @@ via `collect_channel(run_id=...)` — so a reprojected DB carries the same
 pass structure as its source and is itself faithfully re-reprojectable.
 
 `HistoryCollector`'s live-collection incremental-vs-full-sweep bookkeeping
-(`sync_state` scopes `history`/`history_sweep`) is reset before every
-replayed run: under LIVE collection that state legitimately persists across
-re-runs (Telegram's history only grows forward, so "already fully swept" is
-permanent), but under per-run REPLAY a run's own raw window naturally
-running dry is a scope artifact, not a Telegram-side fact — left uncleared,
-that flag wrongly short-circuits a later run's OWN, entirely-older raw
-messages. See `src/paperboy/reproject.py::_reset_incremental_backfill_state`.
+(`sync_state` scopes `history`/`history_sweep`) needs *some* per-run reset
+before replaying, because a run's own raw window naturally running dry is a
+REPLAY scope artifact, not the Telegram-side "reached the true end of
+history" fact `history.py` would read it as under live collection — but not
+a *blanket* reset: `history_sweep`'s high-water-mark columns must keep
+widening monotonically across replayed runs the same way they would across
+live sessions, or a multi-run backward backfill silently truncates to its
+last run's own local window (found in round-2 review; #33). Exactly what
+resets and what survives is `_reset_incremental_backfill_state`'s docstring
+in `src/paperboy/reproject.py` — read that, not a paraphrase of it, since
+this is precisely the kind of statement round 2 found going stale here
+independently of the code.
+
+## Peer projection composition (ADR-0005 §6)
+
+`upsert_peer` (`src/paperboy/store/peers.py`) composes two independent
+orderings when merging an observation into the `peers` table — richness
+(a `full` peer object beats a `min` stub regardless of timestamp) and
+recency (a newer observation beats an older one) — because replay does not
+guarantee `observed_at`-order delivery even within one run. The lattice
+itself, cell by cell, is documented in ADR-0005 §6 (amended 2026-08-26) and
+pinned by `tests/test_store_peers.py::test_upsert_peer_composed_lattice`;
+this doc does not restate it. Known residual: the composed merge is not
+associative when a `min` observation's timestamp exceeds two `full`
+observations it is sandwiched between in arrival order — narrowed and
+tracked as [#38](https://github.com/SpencerNorris/paperboy/issues/38), not
+fixed in round 3 (needs a richness-scoped timestamp benchmark distinct from
+`last_seen`, a real design change, not this round's narrow scope).
 
 ## CLI
 
@@ -201,11 +219,32 @@ real-archive re-run"):
   the DoD smoke transcript below: two files are genuinely missing from this
   profile's local media directory on disk, so replay's own content-addressed
   lookup correctly reports them unavailable rather than fabricating bytes.)
+- **A replayed backfill sweep can absorb messages the live run captured via
+  catch-up**, because both write byte-identical raw shapes and
+  `iter_history` replay cannot tell them apart — inflating the replayed
+  `sync_state('history_sweep', …)`/`sync_ranges` bookkeeping relative to
+  the source's. Projection tables are unaffected (the same messages project
+  identically through either path) and sync bookkeeping is outside the
+  round-trip equality contract (D5); it matters only if a reprojected DB is
+  swapped in and then live-collected against. Tracked as
+  [#37](https://github.com/SpencerNorris/paperboy/issues/37).
+- **The composed peer merge is not associative in one corner** — a `min`
+  observation stamped newer than two `full` observations it lands between
+  can shield the older-stamped-but-newer `full` from applying. See "Peer
+  projection composition" above; tracked as
+  [#38](https://github.com/SpencerNorris/paperboy/issues/38).
 - Deferred (spec §9, deliberately out of scope): an in-place `--force` mode,
   a `--verify`-only mode, incremental reproject of a single phase into an
   existing DB.
 
 ## Definition-of-Done smoke transcript (2026-08-26, profile `default`, real archive)
+
+> **Historical record** (2026-08-26, commit `3d85519`). This transcript pins
+> the FIRST (single-pass) reproject implementation, superseded below by the
+> ADR-0005 run-structure revision. Kept as DoD evidence for that
+> implementation; for current behavior see the module docstrings pointed to
+> under "How it works" above, and the later transcripts below for the
+> current run-scoped replay.
 
 Read-only throughout: the source `<data_dir>/default/paperboy.sqlite` (the
 real, live-collected archive currently tracked in this repo's `data/`) was
@@ -334,6 +373,11 @@ happened to surface, not something reproject's replay introduced.
 ---
 
 ## ADR-0005 revision — multi-run real-archive smoke (2026-08-26)
+
+> **Historical record** (2026-08-26, commits `5990f93`/`2269372`). This
+> transcript is DoD evidence for the run-scoped replay as reviewed in
+> round 2 of #33. Numbers are that run's; behavior statements live in the
+> module docstrings pointed to under "How it works" above.
 
 The transcript above pins the FIRST implementation, which modeled replay as
 one undifferentiated pass over the whole raw log (`_latest()` per call
@@ -496,12 +540,20 @@ high-water mark) — and a real multi-session backward backfill (this
 archive's discussion group: msg-id bands 26955–34977, then 4525–26954, then
 3220–4524, then 1–3219, each a separate historical run extending further
 into the past) is exactly the shape that trips it, since every subsequent
-run's messages are entirely BELOW the high-water mark. Fixed by clearing the
-`history`/`history_sweep` `sync_state` scopes before every replayed run —
-free under replay (no network, no rate limit to economize on), and safe
-because idempotent projection upserts make any resulting re-processing of
-already-seen messages harmless. Pinned by
+run's messages are entirely BELOW the high-water mark. Fixed, at the time,
+by clearing the `history`/`history_sweep` `sync_state` scopes before every
+replayed run. Pinned by
 `tests/test_reproject.py::test_reproject_does_not_truncate_a_backward_multi_run_backfill`.
+
+> **Superseded.** The blanket `history_sweep` clear above was itself found
+> broken in round-2 review — it discarded a widened high-water mark along
+> with the per-run flags, truncating a two-run backward backfill to its
+> last run's own local window. `_reset_incremental_backfill_state` (in
+> `src/paperboy/reproject.py`) now clears only the two per-run-artifact
+> flags; the high-water-mark columns are read back unchanged and carried
+> forward. That docstring is canonical — the paragraph above is kept as the
+> historical record of what this smoke test originally found and fixed, not
+> a description of current behavior.
 
 ### A third bug found and fixed by a later real-archive re-run (2026-08-26)
 

--- a/docs/features/reproject.md
+++ b/docs/features/reproject.md
@@ -88,12 +88,17 @@ recency (a newer observation beats an older one) — because replay does not
 guarantee `observed_at`-order delivery even within one run. The lattice
 itself, cell by cell, is documented in ADR-0005 §6 (amended 2026-08-26) and
 pinned by `tests/test_store_peers.py::test_upsert_peer_composed_lattice`;
-this doc does not restate it. Known residual: the composed merge is not
-associative when a `min` observation's timestamp exceeds two `full`
-observations it is sandwiched between in arrival order — narrowed and
-tracked as [#38](https://github.com/SpencerNorris/paperboy/issues/38), not
-fixed in round 3 (needs a richness-scoped timestamp benchmark distinct from
-`last_seen`, a real design change, not this round's narrow scope).
+this doc does not restate it. Known residuals — the merge is **not** fully
+order-independent in two filed families, both triggered by a `min`
+observation stamped newer than the newest `full` observation of the peer:
+[#38](https://github.com/SpencerNorris/paperboy/issues/38) (a min
+sandwiched between two fulls — *identity* columns diverge by arrival
+order) and [#39](https://github.com/SpencerNorris/paperboy/issues/39)
+(≥1 full — the `source_raw_id` raw-evidence lineage pointer diverges while
+identity converges). Neither is fixed in round 3: closing them needs a
+richness-scoped timestamp benchmark distinct from `last_seen` plus a
+decision on `source_raw_id`'s dual identity-source/provenance-source role —
+real design changes, not that round's narrow scope.
 
 ## CLI
 
@@ -228,11 +233,14 @@ real-archive re-run"):
   round-trip equality contract (D5); it matters only if a reprojected DB is
   swapped in and then live-collected against. Tracked as
   [#37](https://github.com/SpencerNorris/paperboy/issues/37).
-- **The composed peer merge is not associative in one corner** — a `min`
-  observation stamped newer than two `full` observations it lands between
-  can shield the older-stamped-but-newer `full` from applying. See "Peer
-  projection composition" above; tracked as
-  [#38](https://github.com/SpencerNorris/paperboy/issues/38).
+- **The composed peer merge is not fully order-independent in two filed
+  families**, both triggered by a `min` observation stamped newer than the
+  newest `full` observation of the same peer: identity columns diverge in
+  the two-full sandwich
+  ([#38](https://github.com/SpencerNorris/paperboy/issues/38)), and the
+  `source_raw_id` raw-evidence lineage pointer diverges with ≥1 full
+  ([#39](https://github.com/SpencerNorris/paperboy/issues/39)). See "Peer
+  projection composition" above.
 - Deferred (spec §9, deliberately out of scope): an in-place `--force` mode,
   a `--verify`-only mode, incremental reproject of a single phase into an
   existing DB.

--- a/docs/features/reproject.md
+++ b/docs/features/reproject.md
@@ -1,7 +1,9 @@
 # Feature: `reproject`
 
-**Status:** shipped. **Spec:** `docs/superpowers/specs/2026-08-25-reproject-design.md`.
+**Status:** shipped, including the ADR-0005 run-structure revision (below).
+**Spec:** `docs/superpowers/specs/2026-08-25-reproject-design.md`.
 **Plan:** `docs/superpowers/plans/2026-08-26-reproject.md`.
+**ADR:** `docs/adr/0005-run-structure.md`.
 
 ## Purpose
 
@@ -33,12 +35,47 @@ each message and `catch_up` projects messages nested inside a
 `ChannelDifference` envelope. `ReplayClock` is fed by the replay gateway as it
 serves each raw record.
 
-**Phase auto-detection.** `detect_phases(source)` infers which phases the
-original run(s) executed from which raw *kinds* are present (a source that
-never ran `graph` has no `ChatsSlice`/`ChatInvite*`/`SponsoredMessage` raws,
-so reproject doesn't invent `graph`-only projections it never had) —
-overridable with `--phases`. Detection is currently **source-wide, not
-per-target** — see Known limitations.
+**Phase auto-detection.** `detect_phases(source, run)` infers which phases
+ONE historical run executed from which raw *kinds* it left behind (a run
+that never did `graph` has no `ChatsSlice`/`ChatInvite*`/`SponsoredMessage`
+raws for that run, so reproject doesn't invent `graph`-only projections it
+never had) — overridable with `--phases`. Detection is per-run (ADR-0005),
+not source-wide: a source whose early runs never did `discussion` and whose
+later runs did gets exactly that phase history back.
+
+## Run structure (ADR-0005)
+
+The design above models replay as ONE undifferentiated pass over the whole
+raw log. That is wrong for any archive built from more than one `collect`
+invocation (the ordinary shape — see `docs/adr/0005-run-structure.md` for
+the full diagnosis): per-call-site `_latest()` lookups silently collapse a
+multi-run archive's time series (`channel_snapshots`, `web_snapshots`,
+per-run `custody_log` entries, ...) down to whichever run happened to write
+last.
+
+**`raw_records.run_id`** (migration `0003_run_id.sql`) records which collect
+pass produced each raw record. `Store.begin_run()` mints an opaque id at the
+start of every `collect_channel` call; a source built before this migration
+has `NULL` run_id throughout, and `ReplaySource.runs()` infers pass
+boundaries for those rows from the OPENING CLUSTER every pass writes once —
+`resolve()`'s `ResolvedPeer`, `getFullChannel()`'s `ChatFull`, and the self
+`User` record — in whatever order the collector version that captured them
+used (current code writes self first; older archives predate that and wrote
+resolve/full before self). `reproject` then replays **once per run**:
+`RawReplayGateway`/`RawReplayWebClient` are constructed per run, every query
+scoped to that run's own `raw_records` rowid range, and each run's raw
+`run_id` (or inferred `legacy-NNNN` label) is stamped onto the target store
+via `collect_channel(run_id=...)` — so a reprojected DB carries the same
+pass structure as its source and is itself faithfully re-reprojectable.
+
+`HistoryCollector`'s live-collection incremental-vs-full-sweep bookkeeping
+(`sync_state` scopes `history`/`history_sweep`) is reset before every
+replayed run: under LIVE collection that state legitimately persists across
+re-runs (Telegram's history only grows forward, so "already fully swept" is
+permanent), but under per-run REPLAY a run's own raw window naturally
+running dry is a scope artifact, not a Telegram-side fact — left uncleared,
+that flag wrongly short-circuits a later run's OWN, entirely-older raw
+messages. See `src/paperboy/reproject.py::_reset_incremental_backfill_state`.
 
 ## CLI
 
@@ -118,27 +155,43 @@ excluded (operational/bookkeeping, not projections of raw content).
 
 ## Known limitations
 
-- **Phase detection is source-wide, not per-target.** If one source DB
-  contains raws from more than one resolved target — e.g. two historical
-  `collect` runs against slightly different spellings of the same channel's
-  handle — every target replays the *union* of phases seen anywhere in the
-  source, and (if those targets resolve to the same underlying channel)
-  redundantly re-projects it once per target-spelling. This does not produce
-  *incorrect* rows — every row is a faithful replay of a real historical
-  observation — but it inflates append-only time-series tables
-  (`web_snapshots`, `custody_log`, `message_metrics`, `message_tombstones`)
-  beyond the source's own counts. Found on the real archive (below); tracked
-  as [#35](https://github.com/SpencerNorris/paperboy/issues/35).
-- **A target that no longer resolves to a channel fails cleanly per-target,
-  not silently.** `channel.collect` raises a bare `ValueError` when a
-  resolved peer isn't a channel — the same crash a live `collect` against
-  that target would hit today. Reproject's multi-target loop catches it,
-  logs it, records it as a failed `target` phase in that target's own
-  results table, and continues with the other targets rather than losing
-  every already-committed target's projections to one bad historical entry.
-  The underlying `channel.py` crash-instead-of-skip behavior is itself
-  tracked as [#34](https://github.com/SpencerNorris/paperboy/issues/34)
-  (orthogonal to reproject — it's pre-existing live-collect behavior).
+Two limitations from the first (single-run) implementation are resolved by
+the ADR-0005 run-structure revision:
+
+- ~~Phase detection is source-wide, not per-target~~ — **resolved.** Phase
+  detection and target resolution are now per-run (`detect_phases(source,
+  run)`, `resolve_targets(run)`): two historical `collect` runs against
+  different spellings of the same channel's handle each replay only within
+  their own run(s), so there is no more redundant re-projection of one
+  channel under two target strings. Was
+  [#35](https://github.com/SpencerNorris/paperboy/issues/35).
+- ~~A target that no longer resolves to a channel fails cleanly per-target,
+  not silently~~ — **resolved.** `channel.py`'s `_resolved_channel_id` now
+  raises `SkipAndRecord` for a non-channel resolution (issue
+  [#34](https://github.com/SpencerNorris/paperboy/issues/34)), so it is a
+  normal per-run `channel: skip` phase result — reproject's multi-target
+  `try/except Exception` fallback (still present, for genuinely unexpected
+  failures) is no longer what handles this case.
+
+One residual, narrowed but not closed by this revision:
+
+- **A historical run whose media phase downloaded nothing NEW leaves no raw
+  trace, so its duplicate-custody observations are not reproduced.**
+  `detect_phases`'s `media` inclusion is raw-*kind*-based per run (spec
+  D4.5): a run that only re-encountered media already downloaded by an
+  earlier run writes no `MediaDownload` raw record for it, so reproject
+  correctly infers "media didn't run" for that specific run and skips the
+  phase there — which also means that run's `custody_log` entry (a real,
+  historical observation: "this run saw this file again, attached to this
+  message") never gets replayed. On the real archive (below) this narrows
+  `media`/`custody_log` below the source's counts (`media` 451→293,
+  `custody_log` 607→443) — every row that IS present is correct and
+  complete; nothing beyond a media file's OWN raw trace round-trips.
+  Deliberately not attempted in this revision (fixing it properly means
+  detecting "ran but found nothing new" as distinct from "didn't run" from
+  raw kinds alone, without fabricating custody observations for runs that
+  genuinely never touched media) — tracked as
+  [#36](https://github.com/SpencerNorris/paperboy/issues/36).
 - Deferred (spec §9, deliberately out of scope): an in-place `--force` mode,
   a `--verify`-only mode, incremental reproject of a single phase into an
   existing DB.
@@ -268,3 +321,171 @@ above). The underlying `channel.py` crash-instead-of-skip behavior is
 tracked separately as [#34](https://github.com/SpencerNorris/paperboy/issues/34)
 — orthogonal to reproject, since it's a live-collect defect this smoke test
 happened to surface, not something reproject's replay introduced.
+
+---
+
+## ADR-0005 revision — multi-run real-archive smoke (2026-08-26)
+
+The transcript above pins the FIRST implementation, which modeled replay as
+one undifferentiated pass over the whole raw log (`_latest()` per call
+site). Re-running it against the same real `default` archive after that
+implementation landed is what surfaced #35 and #36's evidence and the
+`channel_snapshots`/`web_snapshots`/`message_metrics` collapse the ADR-0005
+run-structure redesign exists to fix (`docs/adr/0005-run-structure.md`).
+This section pins the run-scoped replay instead: `reproject` now replays
+**once per historical run**, with `ReplaySource.runs()` segmenting this
+archive's raw log (captured entirely before migration `0003_run_id`, so
+every boundary is inferred, not stamped) into 7 legacy runs.
+
+Same guardrails as before: source opened read-only throughout, `--out`
+pointed outside the profile directory, no network/keychain access (asserted
+by the guardrail tests; consistent with total runtime for ~6,500 raw
+records / ~5,500 messages, which real Telegram pacing could not match).
+
+```
+$ PAPERBOY_DATA_DIR=.../data uv run paperboy reproject --profile default --out /tmp/reprojected.sqlite
+▶ channel
+✓ channel · channels=1 peers=2 · 0s
+▶ history
+✓ history · messages=543 revisions=543 tombstones=258 edges=238 · 1s
+▶ graph
+  graph invite preview skipped for LS-77p_pVyRiZDRk: replay: no ChatInvite recorded for hash 'LS-77p_pVyRiZDRk'
+✓ graph · edges=120 peers=21 raw=5 skipped=1 · 0s
+▶ web
+  web: wayback CDX returned HTTP 429 for national_resistance_movement — reporting failure, not zero
+✓ web · tme_posts=362 deleted_recovered=0 wayback_failed=429 · 0s
+▶ media
+  media: skipping msg 413: replay: media file missing for sha b006ec25...
+  media: skipping msg 414: replay: media file missing for sha 295dbde0...
+✓ media · downloaded=150 duplicates=0 unavailable=302 skipped_kind=27 skipped=2 · 7s
+▶ channel                                          [run 2, same target spelling]
+✓ channel · channels=1 peers=2 · 0s
+▶ history
+✓ history · messages=0 revisions=0 tombstones=0 edges=0 · 0s
+▶ media
+✓ media · downloaded=143 duplicates=150 unavailable=161 skipped_kind=27 skipped=0 · 7s
+
+  reproject @national_resistance_movement -> /tmp/reprojected.sqlite
+  [2-row table: run 1's channel/history/graph/web/media, run 2's channel/history/media]
+
+▶ channel                                          [run 3: @atom8388]
+⏹ channel · skip · 0s
+  phase channel skipped: replay: no self User recorded
+▶ history
+⏹ history · phase_stop · 0s
+▶ media
+⏹ media · phase_stop · 0s
+
+  reproject @atom8388 -> /tmp/reprojected.sqlite
+  [clean per-run skip — NOT an error row this time; #34's fix (below)]
+
+▶ channel                                          [runs 4-7: 'national_resistance_movement', no leading @]
+✓ channel · channels=1 peers=2 · 0s
+▶ history
+✓ history · messages=0 revisions=0 tombstones=0 edges=0 · 0s
+▶ discussion
+✓ discussion · messages=300 revisions=300 tombstones=0 edges=256 backfilled_peers=31 unmapped=6 · 2s
+[... 3 more channel/history/discussion blocks: 300, 1200, 3153 discussion messages ...]
+
+  reproject national_resistance_movement -> /tmp/reprojected.sqlite
+  [4-row table, one per run]
+
+     row counts — source vs reprojected
+┌────────────────────┬────────┬─────────────┐
+│ table               │ source │ reprojected │
+├────────────────────┼────────┼─────────────┤
+│ raw_records         │ 6258   │ 6104        │
+│ channels            │ 1      │ 1           │
+│ channel_snapshots   │ 6      │ 6           │
+│ peers               │ 158    │ 160         │
+│ messages            │ 5496   │ 5496        │
+│ message_revisions   │ 5496   │ 5496        │
+│ message_metrics     │ 4020   │ 4020        │
+│ message_tombstones  │ 258    │ 258         │
+│ edges               │ 2503   │ 2522        │
+│ media               │ 451    │ 293         │
+│ custody_log         │ 607    │ 443         │
+│ web_snapshots       │ 362    │ 362         │
+└────────────────────┴────────┴─────────────┘
+```
+
+**Segmentation.** `run_events` (a manual cross-check only, per ADR-0005 —
+it's a projection-side table, not raw) shows 6 `channel: complete` events;
+`ReplaySource.runs()` found 7 legacy segments. The extra one is `@atom8388`
+(run 3) — its channel phase never completed live (`ChannelPrivateError` or
+similar; the archive's `ResolvedPeer` for it is the only trace), so it never
+wrote a `channel: complete` event, but it IS its own genuine historical
+collect pass and correctly gets its own run.
+
+**The ADR's headline payoff, confirmed exactly:** `channel_snapshots` (6→6),
+`web_snapshots` (362→362), and `message_metrics` (4020→4020) all now
+round-trip **exactly** — these are the three tables that collapsed under
+the single-pass design (6→2, 362→724, 4020→4186 in the first transcript
+above). `messages`/`message_revisions` also match exactly (5496/5496).
+
+**Round-1's payoffs still hold:** `channels.flags_json` still corrects from
+the source's 10 pre-#20-fix flags to the full 48-flag set current code
+captures; the source's one pre-#12 self peer row still projects to zero in
+the reprojected copy (same verification queries as the first transcript,
+against `/tmp/reprojected.sqlite` from this run — unchanged, omitted here).
+
+**`@atom8388` now shows as a clean per-run skip, not an error row** — #34's
+fix (`_resolved_channel_id` raises `SkipAndRecord`, not a bare `ValueError`)
+landed in this revision (Task R4) and is exercised directly by the real
+archive: no ERROR line, no `stopped="error: ..."` row, just an ordinary
+`channel: skip` result like a live `collect` against a private/deleted
+target would produce.
+
+**`peers`/`edges` are up slightly** (158→160, 2503→2522) — the same kind of
+"current code corrects old code's projections" delta round 1 documented, not
+a defect; every extra row is a legitimate current-projection fact the
+original archive's older collector code didn't capture.
+
+**`media`/`custody_log`/`raw_records` are the #36 residual** (see Known
+limitations): 293/443/6104 vs the source's 451/607/6258. Every row present
+is a faithful replay; what's missing is the custody trail for media a LATER
+historical run re-observed as already-downloaded (no gateway call, so no
+raw trace for a future replay to iterate over) — deliberately not attempted
+in this revision.
+
+### Two bugs found and fixed by this smoke test (no-shed)
+
+Both were caught by re-running this exact command against the real archive
+BEFORE committing the run-structure implementation — the round-trip test
+battery's synthetic fixtures did not happen to exercise either shape.
+
+**1. Legacy run segmentation orphaned a real archive's pre-invariant leading
+rows, dropping whole runs.** `ReplaySource.runs()` infers legacy (pre-`0003_
+run_id`) run boundaries from the `tier='self'` marker every collect pass
+writes first — but THIS archive's earliest collector code wrote
+`resolve()`/`getFullChannel()` BEFORE `self`, and that ordering recurred at
+EVERY historical pass boundary, not just the first. The initial fix (cut a
+boundary at every self marker except the very first) still left every run's
+own leading `ResolvedPeer`/`ChatFull` attached to the PRECEDING run instead
+of the one they actually opened — silently dropping the archive's single
+largest run (3154 of 6258 raw records, discovered as `raw_records` /
+`messages` undercounting by roughly that amount on the first re-run).
+Fixed by anchoring a new legacy segment on the first row of the whole
+OPENING CLUSTER (`ResolvedPeer`/`ChatFull`/self, in whatever order) seen
+after at least one substantive row, so all three land together in the run
+they belong to regardless of order. Pinned by
+`tests/test_replay_gateway.py::test_runs_absorbs_resolve_before_self_at_every_boundary`.
+
+**2. `HistoryCollector`'s incremental-sync state leaked across replayed
+runs, silently dropping a later run's own older messages.** `iter_history`
+is scoped to one run's raw window (by design, ADR-0005) — so it naturally
+runs out the moment that window is exhausted, and `history.py` reads that as
+"reached the real end of the channel's history," persisting
+`backfill_complete=True`. That is correct for a LIVE gateway (Telegram's
+history only grows forward). Left uncleared across REPLAYED runs, it wrongly
+switches the NEXT run to incremental-only (ids above the previous run's
+high-water mark) — and a real multi-session backward backfill (this
+archive's discussion group: msg-id bands 26955–34977, then 4525–26954, then
+3220–4524, then 1–3219, each a separate historical run extending further
+into the past) is exactly the shape that trips it, since every subsequent
+run's messages are entirely BELOW the high-water mark. Fixed by clearing the
+`history`/`history_sweep` `sync_state` scopes before every replayed run —
+free under replay (no network, no rate limit to economize on), and safe
+because idempotent projection upserts make any resulting re-processing of
+already-seen messages harmless. Pinned by
+`tests/test_reproject.py::test_reproject_does_not_truncate_a_backward_multi_run_backfill`.

--- a/docs/features/reproject.md
+++ b/docs/features/reproject.md
@@ -1,0 +1,270 @@
+# Feature: `reproject`
+
+**Status:** shipped. **Spec:** `docs/superpowers/specs/2026-08-25-reproject-design.md`.
+**Plan:** `docs/superpowers/plans/2026-08-26-reproject.md`.
+
+## Purpose
+
+`paperboy reproject` rebuilds every normalized projection (`channels`,
+`peers`, `messages` + revisions/tombstones, `edges`, `media`, `web_snapshots`,
+...) from an already-captured archive's `raw_records` — **offline, zero
+network, zero credentials**. It realizes the raw-first thesis (raw is the
+system of record; normalized tables are a projection that can be rebuilt from
+it) as an actual command: apply every collector/projection fix shipped since
+the archive was captured, without re-scraping Telegram.
+
+## How it works
+
+A `RawReplayGateway` (plus `RawReplayWebClient` for the `web` collector's
+plain-HTTP vector) implements the same `Gateway`/`WebGetter` seams the real
+collectors already depend on, but serves every response from a source DB's
+`raw_records` instead of the network. `recipes.collect_channel` then runs
+**unchanged** against the replay pair into a fresh target `Store` — same
+collector code path as a live collect, so the reprojection is provably
+identical to one (`tests/test_reproject.py::test_round_trip_identity`).
+
+**The clock seam.** Projections stamp `observed_at` at write time; a live
+collect wants "now", but a faithful reproject wants the *original* observation
+time, not reproject-time. `paperboy.clock.Clock` (`LiveClock`/`ReplayClock`)
+is threaded through every collector as `ctx.clock.for_payload(payload)`,
+looked up by the payload's own canonical JSON — payload-keyed, not
+call-order-keyed, because `history` consumes a whole page before projecting
+each message and `catch_up` projects messages nested inside a
+`ChannelDifference` envelope. `ReplayClock` is fed by the replay gateway as it
+serves each raw record.
+
+**Phase auto-detection.** `detect_phases(source)` infers which phases the
+original run(s) executed from which raw *kinds* are present (a source that
+never ran `graph` has no `ChatsSlice`/`ChatInvite*`/`SponsoredMessage` raws,
+so reproject doesn't invent `graph`-only projections it never had) —
+overridable with `--phases`. Detection is currently **source-wide, not
+per-target** — see Known limitations.
+
+## CLI
+
+```
+paperboy reproject [--profile P] [--out PATH] [--phases a,b,c]
+```
+
+- `--profile` (default `default`): selects `<data_dir>/<profile>/paperboy.sqlite`
+  as the source. The source is opened `mode=ro` and never mutated.
+- `--out` (default `<data_dir>/<profile>/paperboy.reprojected.sqlite`):
+  refuses to overwrite an existing file — move it aside or pass a fresh path.
+- `--phases`: comma-separated override of the auto-detected phase set.
+
+On success: a per-target, per-phase counts table (mirroring `collect`'s own
+output), then a row-count diff — source vs. reprojected — per table, so the
+operator can eyeball the correction before swapping files.
+
+## Guardrails (spec §2, §8)
+
+- **Zero network.** `build_reproject` (the composition root) constructs only
+  `ReplaySource`/`RawReplayGateway`/`RawReplayWebClient` — never
+  `TelethonGateway`, a real `WebClient`, a Telethon session, or `Budget`.
+  Asserted in test by monkeypatching all three real constructors to raise.
+- **Zero credentials.** No keychain access anywhere on this path (asserted
+  by monkeypatching `keyring.get_password` to raise).
+- **No media re-download or re-write.** `download_media` reads bytes back
+  from the source profile's content-addressed store; a live collect's own
+  write-if-not-exists guard (added as part of this feature) makes the
+  guarantee free to verify by monkeypatching `Path.write_bytes` to raise.
+
+## Design deviations from the spec (D4, plan §"Locked design decisions")
+
+The approved spec's method-by-method table (§3) needed five refinements,
+forced by the round-trip identity test being the correctness contract:
+
+1. **`get_messages`** for an id with no raw record returns a
+   `{"_": "ReplayUnknownMessage", "id": i}` placeholder, not a synthetic
+   `messageEmpty` — a fabricated `messageEmpty` would manufacture deletion
+   evidence for ids the original run never actually observed as deleted.
+2. **`get_sponsored_messages`** reconstructs the `SponsoredMessages` envelope
+   from the individually-stored `SponsoredMessage` records (the original
+   collector never stores the envelope itself).
+3. **`join_channel`** is a synthetic no-op returning success; reproject always
+   runs with `allow_join=True` so a source whose original run used `--join`
+   still replays its discussion sweep, but nothing is ever actually joined —
+   no session exists to join with.
+4. **`get_channel_difference`** past the last stored page serves a synthetic
+   final `updates.channelDifferenceEmpty`, not `SkipAndRecord` — a
+   mid-catch_up `SkipAndRecord` would mark the whole `history` phase skipped
+   and discard the backfill counts already applied in that run.
+5. Phase-set reproduction is by raw-*kind* detection (`detect_phases`), not
+   per-method `SkipAndRecord` alone.
+
+A sixth, found while wiring the replay gateway against fixtures rather than a
+real archive: Telethon's `to_dict()` prefixes some RPC-result **envelope**
+types with their TL namespace (`contacts.resolvedPeer` for `ResolvedPeer`,
+`messages.chatFull` for `ChatFull`, `updates.channelDifference*` for
+`ChannelDifference*`) but not others (`Message`, `ChatInvite*`,
+`SponsoredMessage`, `MediaDownload`, ...) — collectors record
+`payload.get("_", ...)` verbatim, so every kind lookup in `replay.py` matches
+a bare kind *or* any `<namespace>.<kind>` suffix (`_kind_clause`), not an
+exact string.
+
+## Round-trip equality contract (D5)
+
+The correctness contract (`tests/test_reproject.py::test_round_trip_identity`,
+run with the real wall clock — no freezing): collect into DB1, reproject
+DB1's raw into DB2, then every projection table is equal **as a set of
+distinct rows**, modulo autoincrement primary keys and `source_raw_id` (whose
+*content* round-trips transitively via the `raw_records` comparison, which is
+itself part of the contract). Set, not multiset, comparison: a message
+delivered by both `getHistory` and `getChannelDifference` is legitimately
+served twice on replay, producing byte-identical duplicate raw/metrics rows —
+that duplication is real signal (two independent observations), not a bug.
+`run_events`/`sync_state`/`sync_ranges`/`flood_log`/`schema_migrations` are
+excluded (operational/bookkeeping, not projections of raw content).
+
+## Known limitations
+
+- **Phase detection is source-wide, not per-target.** If one source DB
+  contains raws from more than one resolved target — e.g. two historical
+  `collect` runs against slightly different spellings of the same channel's
+  handle — every target replays the *union* of phases seen anywhere in the
+  source, and (if those targets resolve to the same underlying channel)
+  redundantly re-projects it once per target-spelling. This does not produce
+  *incorrect* rows — every row is a faithful replay of a real historical
+  observation — but it inflates append-only time-series tables
+  (`web_snapshots`, `custody_log`, `message_metrics`, `message_tombstones`)
+  beyond the source's own counts. Found on the real archive (below); tracked
+  as [#35](https://github.com/SpencerNorris/paperboy/issues/35).
+- **A target that no longer resolves to a channel fails cleanly per-target,
+  not silently.** `channel.collect` raises a bare `ValueError` when a
+  resolved peer isn't a channel — the same crash a live `collect` against
+  that target would hit today. Reproject's multi-target loop catches it,
+  logs it, records it as a failed `target` phase in that target's own
+  results table, and continues with the other targets rather than losing
+  every already-committed target's projections to one bad historical entry.
+  The underlying `channel.py` crash-instead-of-skip behavior is itself
+  tracked as [#34](https://github.com/SpencerNorris/paperboy/issues/34)
+  (orthogonal to reproject — it's pre-existing live-collect behavior).
+- Deferred (spec §9, deliberately out of scope): an in-place `--force` mode,
+  a `--verify`-only mode, incremental reproject of a single phase into an
+  existing DB.
+
+## Definition-of-Done smoke transcript (2026-08-26, profile `default`, real archive)
+
+Read-only throughout: the source `<data_dir>/default/paperboy.sqlite` (the
+real, live-collected archive currently tracked in this repo's `data/`) was
+never opened for writing; `--out` pointed at a scratch path outside the
+profile directory so the existing archive was never at risk. No network, no
+keychain — confirmed by the guardrail tests, and consistent with this
+transcript's total runtime (under a minute for ~6,500 raw records / ~5,500
+messages, which would be impossible against live Telegram's pacing).
+
+```
+$ PAPERBOY_DATA_DIR=.../data uv run paperboy reproject --profile default --out /tmp/reprojected.sqlite
+▶ channel
+✓ channel · channels=1 peers=2 · 0s
+▶ history
+✓ history · messages=543 revisions=543 tombstones=258 edges=238 · 2s
+▶ discussion
+✓ discussion · messages=4953 revisions=4953 tombstones=0 edges=2067 backfilled_peers=31 unmapped=359 · 6s
+▶ graph
+  graph invite preview skipped for LS-77p_pVyRiZDRk: replay: no ChatInvite recorded for hash 'LS-77p_pVyRiZDRk'
+✓ graph · edges=120 peers=21 raw=5 skipped=1 · 0s
+▶ web
+  web: wayback CDX returned HTTP 429 for national_resistance_movement — reporting failure, not zero
+✓ web · tme_posts=362 deleted_recovered=0 wayback_failed=429 · 0s
+▶ media
+  media: skipping msg 413: replay: media file missing for sha b006ec25...
+  media: skipping msg 414: replay: media file missing for sha 295dbde0...
+✓ media · downloaded=449 duplicates=0 unavailable=3 skipped_kind=27 skipped=2 · 33s
+
+  reproject @atom8388 -> /tmp/reprojected.sqlite
+  ERROR reproject: target '@atom8388' failed: target resolved to a non-channel peer (PeerUser)
+┌────────┬────────┬───────────────────────────────────────────────────────┐
+│ phase  │ counts │ stopped                                                │
+├────────┼────────┼───────────────────────────────────────────────────────┤
+│ target │ {}     │ error: target resolved to a non-channel peer (PeerUser)│
+└────────┴────────┴───────────────────────────────────────────────────────┘
+
+  [national_resistance_movement, no leading @: full re-run, same shape as above]
+
+     row counts — source vs reprojected
+┌────────────────────┬────────┬─────────────┐
+│ table               │ source │ reprojected │
+├────────────────────┼────────┼─────────────┤
+│ raw_records         │ 6258   │ 6489        │
+│ channels            │ 1      │ 1           │
+│ channel_snapshots   │ 6      │ 2           │
+│ peers               │ 158    │ 160         │
+│ messages            │ 5496   │ 5496        │
+│ message_revisions   │ 5496   │ 5496        │
+│ message_metrics     │ 4020   │ 4186        │
+│ message_tombstones  │ 258    │ 268         │
+│ edges               │ 2503   │ 2630        │
+│ media               │ 451    │ 449         │
+│ custody_log         │ 607    │ 898         │
+│ web_snapshots       │ 362    │ 724         │
+└────────────────────┴────────┴─────────────┘
+```
+
+Verifying the spec §9 payoff directly (source vs. reprojected):
+
+```
+$ sqlite3 data/default/paperboy.sqlite \
+  "SELECT count(*) FROM json_each((SELECT flags_json FROM channels));"
+10
+$ sqlite3 /tmp/reprojected.sqlite \
+  "SELECT count(*) FROM json_each((SELECT flags_json FROM channels));"
+48
+
+$ sqlite3 data/default/paperboy.sqlite \
+  "SELECT count(*) FROM peers WHERE kind='user' AND id IN
+   (SELECT json_extract(value_json,'\$.id') FROM sync_state WHERE scope='account');"
+1
+$ sqlite3 /tmp/reprojected.sqlite \
+  "SELECT count(*) FROM peers WHERE uri IN
+   (SELECT json_extract(value_json,'\$.uri') FROM sync_state WHERE scope='account');"
+0
+```
+
+The source archive's `channels.flags_json` (written by pre-#20-fix code) has
+10 boolean flags; the reprojected copy has the full 48-flag set the current
+`_channel_flags` projection captures. The source still has one self peer row
+(pre-#12 fix); the reprojected copy has none — `is_self` is applied from raw
+alone, over data the live account never re-observed since.
+
+`messages`/`message_revisions` match the source **exactly** (5496/5496) even
+though the archive's raw log turned out to contain two historical resolves of
+the same channel (see Known limitations) — `upsert_message`'s
+`ON CONFLICT DO UPDATE` on a URI primary key deduplicated correctly across
+the redundant replay. `media` is one lower than the source (449 vs. 451): two
+of the archive's `MediaDownload` raw records point at sha256 hashes whose
+bytes are no longer present on disk under `data/default/media/` — a
+pre-existing gap in the archive's file store, not a reproject defect;
+`RawReplayGateway.download_media` correctly raises `SkipAndRecord` for each
+and `MediaCollector` skips them cleanly (`skipped=2` above) rather than
+fabricating a `media` row for bytes that don't exist.
+
+### Bug found and fixed by this smoke test (no-shed)
+
+**`reproject` crashed the entire multi-target run on one bad historical
+target.** The real archive's raw log turned out to contain a `ResolvedPeer`
+record for `@atom8388` (evidently an accidental `collect` invocation, at some
+point, against something that wasn't a channel) whose `peer` is a `PeerUser`.
+`channel.collect`'s `_resolved_channel_id` correctly raises `ValueError` for
+this (pre-existing behavior — the same crash would hit a live `collect`
+against that target too) — but `reproject`'s per-target loop had no
+try/except around `collect_channel`, so this one bad historical entry took
+down the *entire* reproject run, discarding the other targets'
+already-committed-to-`out_store` projections along with it (visible in the
+first smoke attempt, which crashed with an unhandled traceback right after
+the primary channel's `media` phase completed).
+
+Fixed in `reproject.py`: the per-target `collect_channel` call is wrapped in
+a `try/except Exception`, which logs the failure and records it as a failed
+`target` phase in that target's own results (`stopped="error: ..."`) rather
+than aborting the run — `collect_channel` was designed for exactly one
+target per invocation and has no notion of "this target, among several,
+turned out bad"; that safety net belongs at the multi-target orchestration
+layer reproject itself adds. Pinned by
+`tests/test_one_bad_historical_target_does_not_abort_other_targets` (a
+hand-seeded two-target source, one good and one PeerUser-resolving) before
+the fix, confirmed against the real archive after it (the second transcript
+above). The underlying `channel.py` crash-instead-of-skip behavior is
+tracked separately as [#34](https://github.com/SpencerNorris/paperboy/issues/34)
+— orthogonal to reproject, since it's a live-collect defect this smoke test
+happened to surface, not something reproject's replay introduced.

--- a/docs/features/reproject.md
+++ b/docs/features/reproject.md
@@ -186,18 +186,21 @@ real-archive re-run"):
   phase there — which also means that run's `custody_log` entry (a real,
   historical observation: "this run saw this file again, attached to this
   message") never gets replayed. On the real archive, after the segmentation
-  fix below, this narrows `media`/`custody_log` below the source's counts
-  (`media` 451→449, `custody_log` 607→599) — every row that IS present is
-  correct and complete; nothing beyond a media file's OWN raw trace
-  round-trips. (The first cut of this revision, before the segmentation fix,
-  measured a much larger gap — 451→293, 607→443 — but that number
-  conflated this residual with the distinct segmentation bug below; it did
-  not correctly isolate what #36 alone accounts for.) Deliberately not
-  attempted in this revision (fixing it properly means detecting "ran but
-  found nothing new" as distinct from "didn't run" from raw kinds alone,
-  without fabricating custody observations for runs that genuinely never
-  touched media) — tracked as
-  [#36](https://github.com/SpencerNorris/paperboy/issues/36).
+  fix below, this narrows `custody_log` below the source's count (607→599)
+  — every row that IS present is correct and complete; nothing beyond a
+  media file's OWN raw trace round-trips. (The first cut of this revision,
+  before the segmentation fix, measured a much larger gap — 607→443 — but
+  that number conflated this residual with the distinct segmentation bug
+  below; it did not correctly isolate what #36 alone accounts for.)
+  Deliberately not attempted in this revision (fixing it properly means
+  detecting "ran but found nothing new" as distinct from "didn't run" from
+  raw kinds alone, without fabricating custody observations for runs that
+  genuinely never touched media) — tracked as
+  [#36](https://github.com/SpencerNorris/paperboy/issues/36). (`media`
+  itself narrows too, 451→449, but that 2-file gap is unrelated to #36 — see
+  the DoD smoke transcript below: two files are genuinely missing from this
+  profile's local media directory on disk, so replay's own content-addressed
+  lookup correctly reports them unavailable rather than fabricating bytes.)
 - Deferred (spec §9, deliberately out of scope): an in-place `--force` mode,
   a `--verify`-only mode, incremental reproject of a single phase into an
   existing DB.

--- a/docs/features/reproject.md
+++ b/docs/features/reproject.md
@@ -700,3 +700,36 @@ were already exact before this fix and remain exact after it — this bug
 never touched those tables' correctness, only which run `media`/`custody_
 log`/`raw_records` rows got attributed to (or dropped from) via the wrong
 segment boundary.
+
+## Round-3 verification (2026-08-26, commits `d5acfd7`..HEAD)
+
+> **Historical record** (2026-08-26). DoD evidence for review round 3 of
+> #33: the ADR-0005 §6 lattice fix, the doc restructure, and the deferred
+> verification round 2's reviewer could not finish (its disk-space
+> casualty).
+
+- **Real-archive smoke re-run** (source md5 `ea97fc2b8ab297c77c2a816e3d3363cf`,
+  byte-unchanged): every count reproduced **digit-for-digit** against the
+  round-2 transcript above — `channel_snapshots` 6→6, `web_snapshots`
+  362→362, `message_metrics` 4020→4020, `messages`/`message_revisions`
+  5496→5496, `message_tombstones` 258→258, `peers` 158→160, `edges`
+  2503→2522, `media` 451→449, `custody_log` 607→599 (the last four exactly
+  as documented above). The `upsert_peer` lattice fix changed **no**
+  archive count — this archive's replay delivers each peer's observations
+  in ascending-stamp order, so the richness-overrides-recency cells never
+  fire differently from plain recency here; the fix matters for the
+  orderings the 8-case table and permutation tests pin.
+- **The 5-mutation battery** (each mutation applied, tested, reverted;
+  suite green before and after):
+
+  | Mutation (reverting) | Killed |
+  |---|---|
+  | `runs()` repeated-role sub-cluster split disabled | `test_runs_splits_consecutive_all_opening_passes`, `test_runs_splits_consecutive_resolve_full_self_passes`, `test_reproject_preserves_every_pass_of_consecutive_channel_only_runs` (3 failed) |
+  | `runs()` foreign-intrusion fold disabled (every cluster commits) | 2 failed in `test_replay_gateway.py` |
+  | zero-target warning demoted below WARNING | `test_reproject_warns_on_a_zero_target_run` |
+  | `_reset_incremental_backfill_state` reverted to blanket `history_sweep` delete | `test_reproject_does_not_truncate_a_backward_multi_run_backfill` |
+  | `upsert_peer` early-branch `first_seen` widening disabled | 5 failed in `test_store_peers.py` |
+
+  Every round-2 regression test is live signal; no mutation survived.
+- Full gates: 408 passed, ruff clean, pyright clean
+  (`TMPDIR=/Volumes/Storage/tmp`, per the round-2 disk-space confounder).

--- a/docs/superpowers/plans/2026-08-26-reproject.md
+++ b/docs/superpowers/plans/2026-08-26-reproject.md
@@ -1,0 +1,1972 @@
+# `reproject` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A `paperboy reproject` command that rebuilds every normalized projection from `raw_records` into a fresh SQLite DB by replaying the raw log through the real collectors — offline, zero network, zero credentials, original timestamps preserved.
+
+**Architecture:** A `RawReplayGateway` (plus `RawReplayWebClient`) implements the existing `Gateway` seam backed by a source DB's `raw_records`, so `recipes.collect_channel` runs *unchanged* against it into a fresh target DB. A new `Clock` seam threads each raw record's original `observed_at` into every projection site, making the projection a pure function of the raw log (the §7 round-trip identity test proves it).
+
+**Tech Stack:** Python ≥3.12, stdlib `sqlite3`, Typer, pytest + pytest-asyncio, ruff + pyright. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-reproject-design.md`
+
+## Global Constraints
+
+- **Zero network:** `reproject` constructs only the replay pair — never `TelethonGateway`, a real `WebClient`, a Telethon session, or `Budget` (spec §2). Asserted by test.
+- **Zero credentials:** no keychain access at all on the reproject path (spec §8). Asserted by test (keyring monkeypatched to raise).
+- **Source is read-only:** the source DB is opened `mode=ro`; only `raw_records` is consulted for *rebuilding*. (The CLI's diff summary counts source projection rows — a read-only report, spec §6 mandates it.)
+- **Timestamp fidelity:** projections in the target DB carry the original `observed_at` from the raw log, not reproject-time (spec §5).
+- **Media:** no file is re-downloaded or re-written; bytes are read back from the source profile's content-addressed store (spec §4).
+- The one write path (`join_channel`) is replay-simulated (synthetic success dict, zero side effects) — a reproject never joins anything.
+- `uv run pytest -q`, `uv run ruff check`, `uv run pyright` must all pass after every task.
+
+## Locked design decisions (read before implementing anything)
+
+These resolve everything spec §5/§3 leaves open. Do not re-derive them.
+
+**D1 — one timestamp per raw record, computed by the collector, passed into `add_raw`.**
+Today `Store.add_raw` stamps its own `utc_now_iso()` while collectors stamp a
+*separate* `utc_now_iso()` for projections — two different strings microseconds
+apart. `add_raw` gains an `observed_at: str | None = None` parameter (None →
+`utc_now_iso()`, so existing callers/tests are unaffected); every collector
+call site passes the timestamp it will also use for the projections of that
+record. Post-refactor invariant: **a raw record and every projection row
+derived from it carry the same `observed_at`** — which is what makes replay
+able to reproduce projection timestamps from raw alone.
+
+**D2 — the `Clock` seam is payload-keyed, not call-order-keyed.**
+`CollectContext` gains `clock: Clock` (default `LiveClock`). Collectors call
+`ctx.clock.for_payload(payload)` **immediately after the gateway call that
+produced `payload`** and reuse the captured variable for `add_raw` + every
+projection from it. `LiveClock.for_payload` ignores the payload and returns
+`utc_now_iso()` (live behavior unchanged). `ReplayClock` is a registry fed by
+the replay gateway as it serves records: it maps `dumps(payload)` → the source
+record's `observed_at`. Payload-keyed lookup (not a mutable "current" value) is
+what survives `history`'s pattern of consuming a whole page into a list before
+projecting each message, and `catch_up`'s nested messages inside a
+`ChannelDifference` envelope.
+
+**D3 — derived rows (no gateway payload) take their timestamp from the row they derive from, in live mode too.**
+Three producers stamp `utc_now_iso()` while deriving from *stored* rows, which
+makes the projection impure (unreproducible from raw):
+- `graph._write_mention_edges` / `discussion._write_thread_edges` → use the
+  source message's `messages.first_seen` (stable across re-runs; equals the
+  message's raw `observed_at` under D1).
+- `store.repliers.backfill_recent_repliers` → use each raw row's own
+  `observed_at` (it already reads `raw_records` directly).
+- `media` duplicate-custody rows (dedup hit, no download) → the message row's
+  `first_seen`. Fresh downloads use the timestamp captured for the
+  `MediaDownload` raw record (D1/D2).
+This is a deliberate, documented live-behavior change: the evidence timestamp
+(when the underlying observation was captured) replaces the derivation
+timestamp (when a later phase happened to re-scan it). `run_events` and
+`schema_migrations` stay wall-clock — they are operational logs, not
+projections, and are excluded from round-trip comparison.
+
+**D4 — spec §3 deviations, forced by the spec's own §7 round-trip contract**
+(surface these in the PR body; they are refinements, not direction changes):
+1. `get_messages` for an id with **no raw record** returns
+   `{"_": "ReplayUnknownMessage", "id": i}` — *not* the spec table's synthetic
+   `messageEmpty`. A synthetic empty would fabricate deletion evidence
+   (`mark_deleted(evidence='empty')`) for ids the original run never observed
+   as deleted — e.g. gap ids the original probe found *alive* (which
+   `_probe_gaps` deliberately does not record), or range ids only reachable
+   because replayed backfill also serves catch-up-delivered messages. The
+   collector skips any non-`messageEmpty` shape, so the placeholder projects
+   nothing — which is exactly DB1's state.
+2. `get_sponsored_messages` — the original collector never stores the
+   envelope, only each `SponsoredMessage` individually. Replay *reconstructs*
+   `{"_": "SponsoredMessages", "messages": [...]}` from those records, and
+   serves a synthetic `{"_": "sponsoredMessagesEmpty"}` when none exist
+   (empty-and-skipped originals are indistinguishable; both project nothing).
+3. `join_channel` returns a synthetic `{"_": "Updates", "updates": []}` and
+   reproject runs with `allow_join=True` — otherwise a source whose original
+   run used `--join` would skip its discussion sweep and lose projections. No
+   network is involved; nothing is joined.
+4. `get_channel_difference` past the last stored record serves a synthetic
+   final `{"_": "updates.channelDifferenceEmpty", "final": True, "pts": pts}`
+   rather than `SkipAndRecord` — a mid-`catch_up` `SkipAndRecord` would mark
+   the whole folded history phase skipped and discard backfill counts.
+5. Phase-set reproduction ("a run that never did graph reprojects without
+   graph") is by **raw-kind detection** (see Task 6), not per-method
+   `SkipAndRecord` alone — the graph phase's mention scan is RPC-free and
+   would otherwise project edges a graph-less DB1 never had.
+
+**D5 — round-trip equality contract** (what the §7 test asserts):
+all of `channels`, `channel_snapshots`, `peers`, `messages`,
+`message_revisions`, `message_metrics`, `message_tombstones`, `edges`,
+`media`, `custody_log`, `web_snapshots`, plus `raw_records` itself — compared
+as **sets of rows after dropping autoincrement pk columns and
+`source_raw_id`** ("modulo primary keys / autoincrement ids"; `source_raw_id`
+is such an id transitively — the referenced record's *content* round-trips via
+the `raw_records` comparison). Set (distinct-row) comparison, not multiset: a
+message delivered by both `getHistory` and `getChannelDifference` is
+legitimately served twice on replay, producing byte-identical duplicate
+raw/metrics rows. `run_events`, `sync_state`, `sync_ranges`, `flood_log`,
+`schema_migrations`, `messages_fts` are excluded (operational/bookkeeping).
+
+**File structure** (new files):
+
+| File | Responsibility |
+|---|---|
+| `src/paperboy/clock.py` | `Clock` Protocol, `LiveClock`, `ReplayClock` |
+| `src/paperboy/replay.py` | `ReplaySource` (read-only raw access + media root), `RawReplayGateway`, `RawReplayWebClient` |
+| `src/paperboy/reproject.py` | target enumeration, phase detection, orchestration, summary |
+| `tests/test_reproject_parity.py` | frozen-clock golden parity test (seam safety net) |
+| `tests/test_clock.py`, `tests/test_replay_gateway.py`, `tests/test_replay_web.py`, `tests/test_reproject.py` | unit + round-trip/guardrail suites |
+
+Modified: `store/db.py` (`add_raw` param), `collectors/base.py` (clock field),
+`recipes.py` (clock passthrough), all six collectors + `store/repliers.py`
+(timestamp sites), `web/client.py`/`collectors/web.py` (a `WebGetter`
+Protocol so the replay client type-checks), `app.py` (`build_reproject`),
+`cli.py` (`reproject` command).
+
+---
+
+### Task 1: Frozen-clock parity golden test
+
+The seam refactor (Tasks 2–3) touches every projection site. This test pins
+the *entire* DB a full collect produces — under a frozen clock — as a
+committed golden fixture **before** the refactor, so the refactor provably
+changes nothing about live collection.
+
+**Files:**
+- Create: `tests/test_reproject_parity.py`
+- Create: `tests/fixtures/reproject/parity_golden.json` (generated in step 3)
+
+**Interfaces:**
+- Produces: `full_collect_fixtures() -> dict` (FakeGateway fixtures covering
+  every phase), `run_full_collect(tmp_path, monkeypatch) -> Store`
+  (frozen-clock collect of channel,history,discussion,graph,web,media),
+  `dump_db(conn, data_dir: Path) -> dict[str, list]` (canonical, path- and
+  pk-normalized dump). Task 7 reuses `dump_db`'s exclusion sets via import.
+
+- [ ] **Step 1: Write the test module**
+
+```python
+"""Live-collect parity: a full frozen-clock collect must produce byte-identical
+projections before and after the observed-at seam (spec §5). Regenerate the
+golden with: UPDATE_GOLDEN=1 uv run pytest tests/test_reproject_parity.py -q
+"""
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+from paperboy.config import load_settings
+from paperboy.recipes import collect_channel
+from paperboy.collectors.web import WebCollector
+from paperboy.store.db import Store
+from paperboy.targets import parse_target
+from paperboy.web.client import WebClient
+from tests.fakes import FakeGateway
+
+FX = Path("tests/fixtures/tl")
+GOLDEN = Path("tests/fixtures/reproject/parity_golden.json")
+FROZEN_NOW = "2026-01-01T00:00:00+00:00"
+
+# Tables whose content the parity golden pins. Excludes operational /
+# bookkeeping tables (schema_migrations, flood_log) and the FTS shadow tables.
+PARITY_TABLES = (
+    "raw_records", "channels", "channel_snapshots", "peers", "messages",
+    "message_revisions", "message_metrics", "message_tombstones", "edges",
+    "media", "custody_log", "web_snapshots", "sync_state", "sync_ranges",
+    "run_events",
+)
+
+
+def freeze_clock(monkeypatch) -> None:
+    """Pin utc_now_iso in EVERY imported paperboy module. Modules import it
+    by name (`from paperboy.ids import utc_now_iso`), so patching the
+    definition alone would miss every importer's local reference."""
+    for name, mod in list(sys.modules.items()):
+        if name.startswith(("paperboy", "tests")) and hasattr(mod, "utc_now_iso"):
+            monkeypatch.setattr(mod, "utc_now_iso", lambda: FROZEN_NOW)
+
+
+def full_collect_fixtures() -> dict:
+    resolve = json.loads((FX / "resolve_durov.json").read_text())
+    full_channel = json.loads((FX / "full_channel.json").read_text())
+    return {
+        "resolve": resolve,
+        "full_channel": full_channel,
+        "self": {"_": "user", "id": 1, "self": True, "phone": "+15551234567"},
+        "history": [
+            {
+                "_": "message", "id": 3, "message": "see https://t.me/other_channel",
+                "date": 1767322500, "views": 10,
+                "entities": [{"_": "MessageEntityUrl", "offset": 4, "length": 24}],
+            },
+            {
+                "_": "message", "id": 2, "message": "", "date": 1767322445,
+                "media": {
+                    "_": "MessageMediaDocument",
+                    "document": {
+                        "_": "Document", "id": 9, "access_hash": 1,
+                        "mime_type": "text/plain",
+                        "attributes": [
+                            {"_": "DocumentAttributeFilename", "file_name": "a.txt"}
+                        ],
+                    },
+                },
+            },
+            {"_": "message", "id": 1, "message": "m1", "date": 1767322400},
+        ],
+        # One catch-up page carrying an edit of msg 1 — exercises the
+        # revisions path and (later) replay's nested-payload clock.
+        "channel_difference": {
+            "_": "updates.channelDifference", "final": True, "pts": 43,
+            "new_messages": [
+                {"_": "message", "id": 1, "message": "m1 edited",
+                 "date": 1767322400, "edit_date": 1767322600},
+            ],
+            "other_updates": [],
+        },
+        "get_messages": {},
+        "media": {2: b"file contents"},
+        "channel_recommendations": json.loads((FX / "recommendations.json").read_text()),
+        "sponsored_messages": json.loads((FX / "sponsored_messages.json").read_text()),
+        "chat_invite": {},
+    }
+
+
+_TME_HTML = """<html><body>
+<div class="tgme_widget_message" data-post="durov/1">
+  <div class="tgme_widget_message_text">m1</div>
+  <time datetime="2026-01-01T00:00:00+00:00"></time>
+</div>
+</body></html>"""
+
+
+def _web_transport() -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if url.startswith("https://t.me/s/durov?before="):
+            return httpx.Response(200, text="<html><body></body></html>")
+        if url.startswith("https://t.me/s/durov"):
+            return httpx.Response(200, text=_TME_HTML)
+        if url.startswith("https://web.archive.org/cdx/"):
+            return httpx.Response(200, text=json.dumps([
+                ["urlkey", "timestamp", "original", "mimetype", "statuscode",
+                 "digest", "length"],
+                ["me,t)/s/durov", "20260101000000", "https://t.me/s/durov",
+                 "text/html", "200", "DIGEST1", "1234"],
+            ]))
+        raise AssertionError(f"unexpected URL fetched: {url}")
+
+    return httpx.MockTransport(handler)
+
+
+async def run_full_collect(data_dir: Path) -> Path:
+    """Collect every phase into <data_dir>/default/paperboy.sqlite; returns the DB path."""
+    settings = load_settings("default", {"data_dir": data_dir})
+    db = data_dir / "default" / "paperboy.sqlite"
+    web = WebCollector(
+        client=WebClient(transport=_web_transport()),
+        min_interval=0.0, sleep=lambda s: None,
+    )
+    from paperboy.recipes import _default_collectors
+    from paperboy.collectors.media import MediaCollector
+    collectors = [
+        c for c in _default_collectors(include_media=False, include_web=False)
+    ] + [web, MediaCollector()]
+    with Store.open(db) as store:
+        await collect_channel(
+            FakeGateway(full_collect_fixtures()), store, settings,
+            parse_target("@durov"),
+            phases=["channel", "history", "discussion", "graph", "web", "media"],
+            log=logging.getLogger("parity"), collectors=collectors,
+        )
+    return db
+
+
+def dump_db(conn, data_dir: Path, tables=PARITY_TABLES) -> dict[str, list]:
+    """Canonical dump: per table, sorted rows as column->value dicts, with the
+    machine-specific data_dir prefix normalized out of path-bearing values."""
+    prefix = str(data_dir)
+    out: dict[str, list] = {}
+    for table in tables:
+        cols = [r[1] for r in conn.execute(f"PRAGMA table_info({table})")]
+        rows = []
+        for row in conn.execute(f"SELECT * FROM {table}"):
+            d = {
+                c: (v.replace(prefix, "<DATA_DIR>") if isinstance(v, str) else v)
+                for c, v in zip(cols, row)
+            }
+            rows.append(d)
+        out[table] = sorted(rows, key=lambda d: json.dumps(d, sort_keys=True, default=str))
+    return out
+
+
+@pytest.mark.asyncio
+async def test_full_collect_matches_golden(tmp_path, monkeypatch):
+    freeze_clock(monkeypatch)
+    db = await run_full_collect(tmp_path)
+    with Store.open(db) as store:
+        dumped = dump_db(store.conn, tmp_path)
+    if os.environ.get("UPDATE_GOLDEN"):
+        GOLDEN.parent.mkdir(parents=True, exist_ok=True)
+        GOLDEN.write_text(json.dumps(dumped, indent=1, sort_keys=True, default=str))
+        pytest.skip("golden regenerated")
+    golden = json.loads(GOLDEN.read_text())
+    assert dumped == golden
+```
+
+Note: `run_full_collect` opens the store with `Store.open` (not read-only) —
+this is the *live* collect being pinned. If `parse_tme_page` needs different
+HTML attributes than `_TME_HTML` sketches, read
+`src/paperboy/web/tme_parser.py` and adjust the fixture HTML until
+`tme_posts == 1`; the golden pins whatever the parser actually produces.
+
+- [ ] **Step 2: Verify the test fails for the right reason (no golden yet)**
+
+Run: `uv run pytest tests/test_reproject_parity.py -q`
+Expected: FAIL with `FileNotFoundError` on `parity_golden.json` (or the
+explicit golden-missing branch).
+
+- [ ] **Step 3: Generate the golden from CURRENT (pre-seam) code**
+
+Run: `UPDATE_GOLDEN=1 uv run pytest tests/test_reproject_parity.py -q` then
+`uv run pytest tests/test_reproject_parity.py -q`
+Expected: skip, then PASS. Manually inspect the fixture: every `observed_at`/
+`first_seen`/`fetched_at` must equal `2026-01-01T00:00:00+00:00`; if any
+differs, `freeze_clock` missed a module — fix before committing (a leaked
+real timestamp makes the golden machine-specific).
+
+- [ ] **Step 4: Lint/type, commit**
+
+```bash
+uv run ruff check && uv run pyright
+git add tests/test_reproject_parity.py tests/fixtures/reproject/parity_golden.json
+git commit -m "test(reproject): frozen-clock parity golden for the observed-at seam"
+```
+
+---
+
+### Task 2: The `Clock` seam and `add_raw(observed_at=...)`
+
+**Files:**
+- Create: `src/paperboy/clock.py`
+- Modify: `src/paperboy/store/db.py:86-100` (`add_raw`)
+- Test: `tests/test_clock.py`
+
+**Interfaces:**
+- Produces: `Clock` (Protocol: `for_payload(payload: dict) -> str`),
+  `LiveClock`, `ReplayClock` (`serve(observed_at: str, *payloads: dict)`,
+  `serve_json(observed_at: str, payload_json: str)`, `begin_batch()`,
+  `for_payload(payload)`), `ReplayClockError`.
+  `Store.add_raw(kind, payload, tier, context, observed_at: str | None = None)`.
+- Consumed by: Task 3 (collectors), Task 4/5 (replay pair feeds `ReplayClock`).
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""tests/test_clock.py"""
+import pytest
+
+from paperboy.clock import LiveClock, ReplayClock, ReplayClockError
+from paperboy.store.db import Store, dumps
+
+
+def test_live_clock_returns_fresh_iso_utc():
+    t = LiveClock().for_payload({"_": "Message", "id": 1})
+    assert t.endswith("+00:00")
+
+
+def test_replay_clock_returns_served_payloads_stamp():
+    clock = ReplayClock()
+    m1, m2 = {"_": "Message", "id": 1}, {"_": "Message", "id": 2}
+    clock.serve("2026-01-01T00:00:01+00:00", m1)
+    clock.serve("2026-01-01T00:00:02+00:00", m2)
+    # Payload-keyed: order of lookup does not matter (history consumes a
+    # whole page before projecting each message).
+    assert clock.for_payload(m2) == "2026-01-01T00:00:02+00:00"
+    assert clock.for_payload(m1) == "2026-01-01T00:00:01+00:00"
+    # Lookup is by value, not object identity — a re-parsed equal dict hits.
+    assert clock.for_payload({"_": "Message", "id": 1}) == "2026-01-01T00:00:01+00:00"
+
+
+def test_replay_clock_serve_json_matches_dict_lookup():
+    clock = ReplayClock()
+    payload = {"sha256": "ab", "kind": "photo"}
+    clock.serve_json("2026-01-01T00:00:03+00:00", dumps(payload))
+    assert clock.for_payload(payload) == "2026-01-01T00:00:03+00:00"
+
+
+def test_replay_clock_unknown_payload_falls_back_to_last_served():
+    clock = ReplayClock()
+    clock.serve("2026-01-01T00:00:04+00:00", {"_": "ChannelDifference"})
+    # A nested dict with no individually-stored record inherits its
+    # envelope's stamp.
+    assert clock.for_payload({"_": "novel"}) == "2026-01-01T00:00:04+00:00"
+
+
+def test_replay_clock_raises_before_anything_served():
+    with pytest.raises(ReplayClockError):
+        ReplayClock().for_payload({"_": "x"})
+
+
+def test_begin_batch_clears_registry_but_keeps_current():
+    clock = ReplayClock()
+    clock.serve("2026-01-01T00:00:05+00:00", {"_": "a"})
+    clock.begin_batch()
+    assert clock.for_payload({"_": "a"}) == "2026-01-01T00:00:05+00:00"  # fallback
+
+
+def test_add_raw_accepts_explicit_observed_at(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as store:
+        store.add_raw("Message", {"_": "Message", "id": 1}, "stranger",
+                      {"channel_id": 5}, observed_at="2026-01-01T00:00:06+00:00")
+        row = store.conn.execute("SELECT observed_at FROM raw_records").fetchone()
+        assert row["observed_at"] == "2026-01-01T00:00:06+00:00"
+
+
+def test_add_raw_defaults_to_now(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as store:
+        store.add_raw("Message", {"_": "Message", "id": 1}, "stranger", None)
+        row = store.conn.execute("SELECT observed_at FROM raw_records").fetchone()
+        assert row["observed_at"].endswith("+00:00")
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_clock.py -q` — Expected: FAIL,
+`ModuleNotFoundError: paperboy.clock`.
+
+- [ ] **Step 3: Implement `src/paperboy/clock.py`**
+
+```python
+"""The observation clock (spec §5): where a projection's `observed_at` comes from.
+
+Projections must be a pure function of the raw log, so their timestamps must
+come from the observation being projected, not from the wall clock at
+projection time. `LiveClock` IS the wall clock (a live collect observes now);
+`ReplayClock` returns the ORIGINAL `observed_at` of the raw record being
+replayed, fed by `RawReplayGateway`/`RawReplayWebClient` as they serve records.
+
+Lookup is payload-keyed (canonical JSON of the served dict), because
+collectors do not project in serve order: `history` consumes a whole
+`iter_history` page into a list first, and `catch_up` projects messages
+nested inside a `ChannelDifference` envelope.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from paperboy.ids import utc_now_iso
+from paperboy.store.db import dumps
+
+
+class ReplayClockError(Exception):
+    """A replay projection asked for a timestamp before anything was served —
+    a replay-wiring bug, never a data condition; fail loudly."""
+
+
+class Clock(Protocol):
+    def for_payload(self, payload: dict) -> str:
+        """The `observed_at` for a projection derived from `payload`."""
+        ...
+
+
+class LiveClock:
+    """Live collection: every observation happens now."""
+
+    def for_payload(self, payload: dict) -> str:
+        del payload
+        return utc_now_iso()
+
+
+class ReplayClock:
+    """Replay: observations happened when the raw log says they did.
+
+    `serve`/`serve_json` are called by the replay gateway per record served;
+    `begin_batch` bounds the registry to one gateway response (the collector
+    always projects a response fully before making the next call).
+    A payload with no registered stamp (e.g. a dict nested in an envelope
+    whose members were never individually recorded) inherits the most
+    recently served record's stamp.
+    """
+
+    def __init__(self) -> None:
+        self._current: str | None = None
+        self._by_payload: dict[str, str] = {}
+
+    def begin_batch(self) -> None:
+        self._by_payload.clear()
+
+    def serve(self, observed_at: str, *payloads: dict) -> None:
+        self._current = observed_at
+        for payload in payloads:
+            self._by_payload[dumps(payload)] = observed_at
+
+    def serve_json(self, observed_at: str, payload_json: str) -> None:
+        """Register a record by its stored canonical JSON without re-parsing."""
+        self._current = observed_at
+        self._by_payload[payload_json] = observed_at
+
+    def for_payload(self, payload: dict) -> str:
+        stamp = self._by_payload.get(dumps(payload), self._current)
+        if stamp is None:
+            raise ReplayClockError(
+                "ReplayClock.for_payload before any record was served"
+            )
+        return stamp
+```
+
+- [ ] **Step 4: Amend `Store.add_raw`** (`src/paperboy/store/db.py`)
+
+```python
+    def add_raw(
+        self,
+        kind: str,
+        payload: dict,
+        tier: str,
+        context: dict | None,
+        observed_at: str | None = None,
+    ) -> int:
+        """Append one TL object (as `to_dict()`) to the raw log; returns its rowid.
+
+        `observed_at` is the caller's per-record observation stamp — the same
+        value the caller passes to every projection of this record, so raw and
+        projection agree (spec §5, the reproject clock seam). `None` (legacy
+        callers, tests) stamps now.
+        """
+        cur = self.conn.execute(
+            "INSERT INTO raw_records(kind, observed_at, tier, context_json, payload_json) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                kind,
+                observed_at if observed_at is not None else utc_now_iso(),
+                tier,
+                dumps(context) if context is not None else None,
+                dumps(payload),
+            ),
+        )
+        assert cur.lastrowid is not None
+        return cur.lastrowid
+```
+
+- [ ] **Step 5: Run tests, full suite, lint/type**
+
+Run: `uv run pytest tests/test_clock.py -q && uv run pytest -q && uv run ruff check && uv run pyright`
+Expected: all PASS (nothing consumes the clock yet; parity golden untouched).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/paperboy/clock.py src/paperboy/store/db.py tests/test_clock.py
+git commit -m "feat(clock): observation-clock seam + explicit add_raw observed_at (spec §5)"
+```
+
+---
+
+### Task 3: Thread the clock through every projection site
+
+The "mechanical but broad" refactor (spec §5). The parity golden from Task 1
+is the gate: after every edit below, a frozen-clock live collect must still
+produce the identical DB.
+
+**Files:**
+- Modify: `src/paperboy/collectors/base.py` (`CollectContext`),
+  `src/paperboy/recipes.py` (`collect_channel` clock passthrough),
+  `src/paperboy/collectors/channel.py`, `history.py`, `graph.py`,
+  `discussion.py`, `media.py`, `web.py`, `src/paperboy/store/repliers.py`
+- Test: existing suite + `tests/test_reproject_parity.py` (unchanged, must stay green)
+
+**Interfaces:**
+- Consumes: `Clock`/`LiveClock` from Task 2.
+- Produces: `CollectContext.clock: Clock`;
+  `collect_channel(..., clock: Clock | None = None)`;
+  `MediaCollector._record_custody(ctx, path, sha, message_uri, recorded_at)`;
+  `_scan_message_entities` tuples gain a trailing `observed_at: str` element.
+
+- [ ] **Step 1: `CollectContext` gains the clock** (`collectors/base.py`)
+
+After the `profile: str = "default"` field add:
+
+```python
+    # Where a projection's `observed_at` comes from (spec §5 / clock.py):
+    # the wall clock on a live collect, the raw log's original stamps on a
+    # reproject replay. Appended with a default for the same reason `profile`
+    # is — every existing positional construction stays valid.
+    clock: Clock = field(default_factory=LiveClock)
+```
+
+with `from paperboy.clock import Clock, LiveClock` imported at module top
+(real import — `default_factory` needs it at runtime, so not TYPE_CHECKING).
+
+- [ ] **Step 2: `collect_channel` passthrough** (`recipes.py`)
+
+Add keyword param `clock: Clock | None = None` (import `Clock`, `LiveClock`
+from `paperboy.clock`; `Clock` under TYPE_CHECKING, `LiveClock` real) and build:
+
+```python
+    ctx = CollectContext(
+        gateway, store, settings, target, None, None, "stranger", log, profile,
+        clock or LiveClock(),
+    )
+```
+
+- [ ] **Step 3: `channel.py` — per-record stamps**
+
+Replace the single phase-start `observed_at = utc_now_iso()` (line 77) with
+per-record captures taken immediately after each gateway call, and pass each
+into its `add_raw` and projections. Full replacement of `collect`'s body
+mechanics (drop the `utc_now_iso` import, import nothing new — the clock
+rides on `ctx`):
+
+```python
+    async def collect(self, ctx: CollectContext) -> CollectResult:
+        peer_uris: set[str] = set()
+
+        # (existing comment about self-first, #12, retained)
+        self_user = _redact_self(await ctx.gateway.get_self())
+        t_self = ctx.clock.for_payload(self_user)
+        ctx.store.add_raw(
+            self_user.get("_", "User"), self_user, "self", None, observed_at=t_self
+        )
+        self_uri = user_uri(self_user["id"])
+        set_state(ctx.store, "account", "self", {"uri": self_uri, "id": self_user.get("id")})
+
+        resolved = await ctx.gateway.resolve(ctx.target.value)
+        t_resolved = ctx.clock.for_payload(resolved)
+        resolve_raw_id = ctx.store.add_raw(
+            resolved.get("_", "ResolvedPeer"), resolved, ctx.tier,
+            {"target": ctx.target.raw}, observed_at=t_resolved,
+        )
+        chan = _pick_channel(resolved.get("chats", []), _resolved_channel_id(resolved))
+        input_channel = {"channel_id": chan["id"], "access_hash": chan["access_hash"]}
+
+        full = await ctx.gateway.get_full_channel(input_channel)
+        t_full = ctx.clock.for_payload(full)
+        full_raw_id = ctx.store.add_raw(
+            full.get("_", "ChatFull"), full, ctx.tier, {"channel_id": chan["id"]},
+            observed_at=t_full,
+        )
+        ...  # identity check + chan_for_channel selection unchanged
+
+        channel_uri_ = upsert_channel(
+            ctx.store, full_chat, chan_for_channel, full_raw_id, t_full
+        )
+        set_state(ctx.store, "channel", str(channel_id), {"pts": full_chat["pts"]})
+
+        if linked_chat_id:
+            add_edge(..., t_full, ctx.tier, full_raw_id, {"field": "linked_chat_id"})
+
+        for source_raw_id, payload, t in (
+            (resolve_raw_id, resolved, t_resolved), (full_raw_id, full, t_full),
+        ):
+            for obj in (*payload.get("chats", []), *payload.get("users", [])):
+                uri = upsert_peer(
+                    ctx.store, obj, source_raw_id, t,
+                    seen_in_chat=None, seen_in_msg=None,
+                )
+                ...
+```
+
+(Every `...` is existing code retained verbatim; only the timestamp plumbing
+changes. The self-user timestamp `t_self` exists for the raw record even
+though no projection uses it.)
+
+- [ ] **Step 4: `history.py`**
+
+- `_observe_message`, both branches: replace `observed_at = utc_now_iso()`
+  with `observed_at = ctx.clock.for_payload(m)`, and pass
+  `observed_at=observed_at` into both `add_raw` calls.
+- `_probe_gaps`: `observed_at = ctx.clock.for_payload(r)`; pass into
+  `add_raw(..., observed_at=observed_at)`.
+- `catch_up`: after the `get_channel_difference` call add
+  `t_diff = ctx.clock.for_payload(diff)`; pass `observed_at=t_diff` to the
+  diff `add_raw`; replace the `updateDeleteChannelMessages` loop's
+  `utc_now_iso()` with `t_diff` (the deletion was observed when the
+  difference was). Nested `_observe_message` calls need no change — they
+  stamp per-payload themselves.
+- Drop `utc_now_iso` from the imports.
+
+- [ ] **Step 5: `graph.py`**
+
+- `_collect_recommendations`: `observed_at = ctx.clock.for_payload(result)`
+  (replacing `utc_now_iso()`); pass into `add_raw`.
+- `_collect_invite_previews`: `observed_at = ctx.clock.for_payload(preview)`;
+  pass into `add_raw`.
+- `_collect_sponsored`: move the timestamp inside the per-message loop:
+  `observed_at = ctx.clock.for_payload(sponsored)`; pass into that message's
+  `add_raw` and its edge.
+- Mention edges (D3): extend the `collect()` messages query with
+  `first_seen`:
+
+```python
+        rows = ctx.store.conn.execute(
+            "SELECT channel_id, msg_id, text, entities_json, source_raw_id, first_seen "
+            "FROM messages WHERE channel_id=? AND entities_json IS NOT NULL",
+            (ctx.channel_id,),
+        ).fetchall()
+```
+
+  In `_scan_message_entities`, capture `observed_at = row["first_seen"]` and
+  append it to every emitted tuple (type becomes
+  `tuple[str, str, dict, int | None, str]`; `_record_link` gains an
+  `observed_at: str` parameter it forwards). `_write_mention_edges` drops its
+  own `utc_now_iso()` and unpacks
+  `for subject, object_, evidence, source_raw_id, observed_at in mention_edges:`.
+  Update both functions' docstrings: the edge's `observed_at` is the message
+  observation the mention was found in — the scan itself adds no new
+  observation.
+- Drop `utc_now_iso` from the imports.
+
+- [ ] **Step 6: `discussion.py`**
+
+`_write_thread_edges`: add `first_seen` to the SELECT column list and replace
+the per-row `observed_at = utc_now_iso()` with
+`observed_at = row["first_seen"]` (same D3 rationale, note it in the
+docstring). Drop `utc_now_iso` import.
+
+- [ ] **Step 7: `store/repliers.py`**
+
+Add `observed_at` to the raw SELECT
+(`"SELECT id, observed_at, payload_json FROM raw_records ..."`) and replace
+the per-row `observed_at = utc_now_iso()` with
+`observed_at = row["observed_at"]`. Docstring note: the replier sample is
+projected at the stamp of the message observation that carried it. Drop the
+import.
+
+- [ ] **Step 8: `media.py`**
+
+- Build the `MediaDownload` payload dict *before* stamping, capture
+  `downloaded_at = ctx.clock.for_payload(raw_payload)`, and use it for the
+  `media` INSERT, the custody row, and `add_raw(..., observed_at=downloaded_at)`.
+  Concretely, replace lines 179–199 with:
+
+```python
+            raw_payload = {
+                "sha256": sha, "kind": kind, "size": len(data), "mime_type": mime_type,
+                "file_name": file_name, "path": path_str, "message_uri": row["uri"],
+            }
+            downloaded_at = ctx.clock.for_payload(raw_payload)
+            ctx.store.conn.execute(
+                "INSERT INTO media (sha256, message_uri, kind, mime_type, size, file_name, "
+                "attributes_json, path, downloaded_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    sha, row["uri"], kind, mime_type, len(data), file_name,
+                    dumps(attributes) if attributes is not None else None,
+                    path_str, downloaded_at,
+                ),
+            )
+            self._record_custody(ctx, path_str, sha, row["uri"], downloaded_at)
+            ctx.store.add_raw(
+                "MediaDownload", raw_payload, ctx.tier,
+                {"channel_id": channel_id, "msg_id": row["msg_id"]},
+                observed_at=downloaded_at,
+            )
+```
+
+- `_record_custody` gains a `recorded_at: str` parameter (replacing its
+  internal `utc_now_iso()`); the two dedup call sites pass the message row's
+  `first_seen` (add `first_seen` to the messages SELECT at line 121).
+- Guard the file write for replay idempotency (spec §4 — content-addressed,
+  so an existing path is already the right bytes; also spares live re-runs):
+
+```python
+            path = media_root / sha[:2] / f"{sha}{ext}"
+            if not path.exists():
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(data)
+```
+
+- Drop `utc_now_iso` from the imports.
+
+- [ ] **Step 9: `web.py`**
+
+In `_collect_tme` and `_collect_wayback`, build the raw payload dict first,
+stamp from it, and pass the stamp into `add_raw`:
+
+```python
+            response = self._paced_get(client, url)
+            raw_payload = {
+                "url": url, "status_code": response.status_code, "text": response.text,
+            }
+            fetched_at = ctx.clock.for_payload(raw_payload)
+            ctx.store.add_raw(
+                "tme_page", raw_payload, ctx.tier,
+                {"channel_username": username}, observed_at=fetched_at,
+            )
+```
+
+(and identically for `wayback_cdx`). Drop `utc_now_iso` from the imports.
+
+- [ ] **Step 10: The gate — parity + full suite + lint/type**
+
+Run: `uv run pytest -q && uv run ruff check && uv run pyright`
+Expected: ALL PASS, **including `tests/test_reproject_parity.py` against the
+Task-1 golden with zero fixture changes**. If parity fails, the refactor
+changed live behavior — fix the refactor, never regenerate the golden. (The
+D3 sites are safe under a frozen clock: every candidate value is the same
+frozen instant.)
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add -A src/paperboy tests
+git commit -m "refactor(collectors): thread the observation clock through every projection site (spec §5)"
+```
+
+---
+
+### Task 4: `ReplaySource` + `RawReplayGateway`
+
+**Files:**
+- Create: `src/paperboy/replay.py`
+- Test: `tests/test_replay_gateway.py`
+
+**Interfaces:**
+- Consumes: `ReplayClock` (Task 2), `SkipAndRecord` from `paperboy.budget`,
+  `parse_target` from `paperboy.targets`.
+- Produces:
+
+```python
+class ReplaySource:
+    conn: sqlite3.Connection          # opened file:...?mode=ro
+    media_root: Path
+    @classmethod
+    def open(cls, db_path: Path, media_root: Path) -> ReplaySource: ...
+    def close(self) -> None: ...      # + __enter__/__exit__
+    def resolve_targets(self) -> list[str]         # distinct context.target, capture order
+    def linked_group_ids(self) -> set[int]         # from ChatFull payloads
+    def has_kind(self, *kinds: str) -> bool        # lower(kind) IN kinds
+    def has_context_channel(self, channel_ids: set[int]) -> bool
+
+class RawReplayGateway:                # implements the Gateway Protocol
+    def __init__(self, source: ReplaySource, clock: ReplayClock) -> None: ...
+```
+
+- [ ] **Step 1: Write failing tests** (`tests/test_replay_gateway.py`)
+
+Build a source DB by hand with `Store.open` + `add_raw(observed_at=...)` —
+no collector involved, so each method's serving contract is tested in
+isolation:
+
+```python
+import pytest
+
+from paperboy.budget import SkipAndRecord
+from paperboy.clock import ReplayClock
+from paperboy.replay import RawReplayGateway, ReplaySource
+from paperboy.store.db import Store
+
+CID = 100
+IC = {"channel_id": CID, "access_hash": 7}
+
+
+def _seed(tmp_path):
+    """A minimal raw log: self, resolve, full, three messages (one edited),
+    a probe MessageEmpty, one diff, one recommendation set, one MediaDownload."""
+    db = tmp_path / "src.sqlite"
+    media_root = tmp_path / "media"
+    with Store.open(db) as st:
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None,
+                   observed_at="2026-01-01T00:00:00+00:00")
+        st.add_raw("ResolvedPeer",
+                   {"_": "contacts.ResolvedPeer",
+                    "peer": {"_": "PeerChannel", "channel_id": CID},
+                    "chats": [{"_": "Channel", "id": CID, "access_hash": 7}]},
+                   "stranger", {"target": "@durov"},
+                   observed_at="2026-01-01T00:00:01+00:00")
+        st.add_raw("ChatFull",
+                   {"_": "messages.ChatFull",
+                    "full_chat": {"_": "ChannelFull", "id": CID, "pts": 40,
+                                  "linked_chat_id": 555},
+                    "chats": [{"_": "Channel", "id": CID, "access_hash": 7}]},
+                   "stranger", {"channel_id": CID},
+                   observed_at="2026-01-01T00:00:02+00:00")
+        for i, (mid, text, t) in enumerate([
+            (3, "m3", "2026-01-01T00:01:03+00:00"),
+            (2, "m2", "2026-01-01T00:01:02+00:00"),
+            (1, "m1", "2026-01-01T00:01:01+00:00"),
+            (1, "m1 edited", "2026-01-01T00:02:00+00:00"),  # later revision
+        ]):
+            st.add_raw("Message", {"_": "message", "id": mid, "message": text},
+                       "stranger", {"channel_id": CID}, observed_at=t)
+        st.add_raw("MessageEmpty", {"_": "MessageEmpty", "id": 4}, "stranger",
+                   {"channel_id": CID}, observed_at="2026-01-01T00:03:00+00:00")
+        st.add_raw("ChannelDifference",
+                   {"_": "updates.channelDifferenceEmpty", "final": True, "pts": 41},
+                   "stranger", {"channel_id": CID},
+                   observed_at="2026-01-01T00:04:00+00:00")
+        st.add_raw("Chats", {"_": "messages.chats",
+                             "chats": [{"_": "Channel", "id": 200, "access_hash": 9}]},
+                   "stranger", {"channel_id": CID},
+                   observed_at="2026-01-01T00:05:00+00:00")
+        sha = "ab" + "0" * 62
+        path = media_root / sha[:2] / f"{sha}.txt"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"file contents")
+        st.add_raw("MediaDownload",
+                   {"sha256": sha, "kind": "document", "size": 13,
+                    "mime_type": "text/plain", "file_name": "a.txt",
+                    "path": str(path), "message_uri": f"tg:msg:{CID}/2"},
+                   "stranger", {"channel_id": CID, "msg_id": 2},
+                   observed_at="2026-01-01T00:06:00+00:00")
+    return db, media_root
+
+
+def _gateway(tmp_path):
+    db, media_root = _seed(tmp_path)
+    clock = ReplayClock()
+    return RawReplayGateway(ReplaySource.open(db, media_root), clock), clock
+
+
+@pytest.mark.asyncio
+async def test_resolve_matches_target_and_stamps_clock(tmp_path):
+    gw, clock = _gateway(tmp_path)
+    resolved = await gw.resolve("durov")
+    assert resolved["peer"]["channel_id"] == CID
+    assert clock.for_payload(resolved) == "2026-01-01T00:00:01+00:00"
+
+
+@pytest.mark.asyncio
+async def test_resolve_unknown_target_skips(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    with pytest.raises(SkipAndRecord):
+        await gw.resolve("someone_else")
+
+
+@pytest.mark.asyncio
+async def test_get_self_serves_self_tier_record(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    assert (await gw.get_self())["id"] == 1
+
+
+@pytest.mark.asyncio
+async def test_iter_history_pages_newest_first_excluding_empties(tmp_path):
+    gw, clock = _gateway(tmp_path)
+    page = [m async for m in gw.iter_history(IC, offset_id=0, limit=100)]
+    # id DESC; both revisions of msg 1 in capture order; MessageEmpty excluded.
+    assert [(m["id"], m["message"]) for m in page] == [
+        (3, "m3"), (2, "m2"), (1, "m1"), (1, "m1 edited"),
+    ]
+    assert clock.for_payload(page[3]) == "2026-01-01T00:02:00+00:00"
+    assert clock.for_payload(page[1]) == "2026-01-01T00:01:02+00:00"
+
+
+@pytest.mark.asyncio
+async def test_iter_history_never_splits_an_id_group_across_pages(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    # limit=3 would cut between msg 1's two revisions; the page extends.
+    page = [m async for m in gw.iter_history(IC, offset_id=0, limit=3)]
+    assert [m["id"] for m in page] == [3, 2, 1, 1]
+    next_page = [m async for m in gw.iter_history(IC, offset_id=1, limit=3)]
+    assert next_page == []
+
+
+@pytest.mark.asyncio
+async def test_get_messages_serves_stored_and_placeholder(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    out = await gw.get_messages(IC, [4, 99])
+    assert out[0]["_"] == "MessageEmpty"          # stored probe result
+    assert out[1] == {"_": "ReplayUnknownMessage", "id": 99}  # D4.1: no fabricated evidence
+
+
+@pytest.mark.asyncio
+async def test_channel_difference_serves_stored_then_synthetic_final(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    first = await gw.get_channel_difference(IC, 40, 100)
+    assert first["pts"] == 41 and first["final"]
+    again = await gw.get_channel_difference(IC, 41, 100)
+    assert again == {"_": "updates.channelDifferenceEmpty", "final": True, "pts": 41}
+
+
+@pytest.mark.asyncio
+async def test_recommendations_served_and_missing_raw_skips(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    recs = await gw.get_channel_recommendations(IC)
+    assert recs["chats"][0]["id"] == 200
+    with pytest.raises(SkipAndRecord):
+        await gw.get_channel_recommendations({"channel_id": 999, "access_hash": 0})
+
+
+@pytest.mark.asyncio
+async def test_sponsored_reconstructs_envelope_or_empty(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    assert (await gw.get_sponsored_messages(IC))["_"] == "sponsoredMessagesEmpty"
+
+
+@pytest.mark.asyncio
+async def test_download_media_reads_content_addressed_file(tmp_path):
+    gw, clock = _gateway(tmp_path)
+    data = await gw.download_media(IC, {"id": 2})
+    assert data == b"file contents"
+    assert await gw.download_media(IC, {"id": 3}) is None  # no record -> unavailable
+
+
+@pytest.mark.asyncio
+async def test_join_channel_is_synthetic_and_offline(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    assert (await gw.join_channel(IC))["_"] == "Updates"
+
+
+@pytest.mark.asyncio
+async def test_doctor_methods_are_not_replayable(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    for coro in (gw.get_authorizations(), gw.get_password_state(), gw.get_privacy("phone")):
+        with pytest.raises(SkipAndRecord):
+            await coro
+
+
+def test_source_helpers(tmp_path):
+    db, media_root = _seed(tmp_path)
+    src = ReplaySource.open(db, media_root)
+    assert src.resolve_targets() == ["@durov"]
+    assert src.linked_group_ids() == {555}
+    assert src.has_kind("mediadownload") and not src.has_kind("tme_page")
+
+
+def test_source_is_read_only(tmp_path):
+    db, media_root = _seed(tmp_path)
+    src = ReplaySource.open(db, media_root)
+    import sqlite3
+    with pytest.raises(sqlite3.OperationalError):
+        src.conn.execute("DELETE FROM raw_records")
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_replay_gateway.py -q` — Expected: FAIL,
+`ModuleNotFoundError: paperboy.replay`.
+
+- [ ] **Step 3: Implement `src/paperboy/replay.py`**
+
+Core mechanics (implement fully; every method mirrors this pattern):
+
+```python
+"""Replay `Gateway`/web-client pair (spec §2–§4): serve `raw_records` back to
+the real collectors, so a reproject is the same code path as a live collect.
+
+`ReplaySource` is strictly read-only (`mode=ro` URI); every serve registers
+the record's original `observed_at` on the shared `ReplayClock` so
+projections carry capture-time stamps (spec §5). A method with no matching
+raw raises `SkipAndRecord`, reproducing the phase set the original run
+executed (spec §3) — with the documented deviations D4.1–D4.4 in
+docs/superpowers/plans/2026-08-26-reproject.md.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import httpx
+
+from paperboy.budget import SkipAndRecord
+from paperboy.clock import ReplayClock
+from paperboy.store.db import dumps
+from paperboy.targets import parse_target
+
+_MESSAGE_KINDS = ("message", "messageservice")
+
+
+class ReplaySource:
+    """Read-only access to a source DB's raw log + its content-addressed media."""
+
+    def __init__(self, conn: sqlite3.Connection, media_root: Path) -> None:
+        self.conn = conn
+        self.media_root = media_root
+
+    @classmethod
+    def open(cls, db_path: Path, media_root: Path) -> "ReplaySource":
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        return cls(conn, media_root)
+
+    def close(self) -> None: ...
+    # __enter__/__exit__ like Store
+
+    def resolve_targets(self) -> list[str]:
+        rows = self.conn.execute(
+            "SELECT json_extract(context_json, '$.target') AS target FROM raw_records "
+            "WHERE lower(kind) = 'resolvedpeer' AND target IS NOT NULL ORDER BY id"
+        ).fetchall()
+        seen: dict[str, None] = {}
+        for r in rows:
+            seen.setdefault(r["target"])
+        return list(seen)
+
+    def linked_group_ids(self) -> set[int]:
+        rows = self.conn.execute(
+            "SELECT json_extract(payload_json, '$.full_chat.linked_chat_id') AS g "
+            "FROM raw_records WHERE lower(kind) = 'chatfull'"
+        ).fetchall()
+        return {r["g"] for r in rows if r["g"]}
+
+    def has_kind(self, *kinds: str) -> bool:
+        qmarks = ",".join("?" * len(kinds))
+        return self.conn.execute(
+            f"SELECT 1 FROM raw_records WHERE lower(kind) IN ({qmarks}) LIMIT 1",
+            kinds,
+        ).fetchone() is not None
+
+    def has_context_channel(self, channel_ids: set[int]) -> bool:
+        return any(
+            self.conn.execute(
+                "SELECT 1 FROM raw_records "
+                "WHERE json_extract(context_json, '$.channel_id') = ? LIMIT 1",
+                (cid,),
+            ).fetchone() is not None
+            for cid in channel_ids
+        )
+
+
+class RawReplayGateway:
+    """`Gateway` served from a raw log. Never touches the network — there is
+    no client, no session, no Budget anywhere in this class."""
+
+    def __init__(self, source: ReplaySource, clock: ReplayClock) -> None:
+        self._src = source
+        self._clock = clock
+        # get_channel_difference is inherently sequential (a pts catch-up
+        # loop); a per-channel cursor over the stored pages models that.
+        self._diff_cursor: dict[int, int] = {}
+
+    def _latest(self, kinds: tuple[str, ...], where: str, params: tuple) -> sqlite3.Row | None:
+        qmarks = ",".join("?" * len(kinds))
+        return self._src.conn.execute(
+            f"SELECT observed_at, payload_json FROM raw_records "
+            f"WHERE lower(kind) IN ({qmarks}) AND {where} ORDER BY id DESC LIMIT 1",
+            (*kinds, *params),
+        ).fetchone()
+
+    def _serve(self, row: sqlite3.Row) -> dict:
+        payload = json.loads(row["payload_json"])
+        self._clock.begin_batch()
+        self._clock.serve_json(row["observed_at"], row["payload_json"])
+        return payload
+
+    async def resolve(self, target_value: str) -> dict:
+        rows = self._src.conn.execute(
+            "SELECT observed_at, payload_json, "
+            "json_extract(context_json, '$.target') AS target "
+            "FROM raw_records WHERE lower(kind) = 'resolvedpeer' ORDER BY id DESC"
+        ).fetchall()
+        for row in rows:
+            raw_target = row["target"]
+            if raw_target and parse_target(raw_target).value == target_value:
+                return self._serve(row)
+        raise SkipAndRecord(f"replay: no ResolvedPeer recorded for {target_value!r}")
+
+    async def get_full_channel(self, input_channel: dict) -> dict:
+        row = self._latest(
+            ("chatfull",),
+            "json_extract(context_json, '$.channel_id') = ?",
+            (input_channel["channel_id"],),
+        )
+        if row is None:
+            raise SkipAndRecord(
+                f"replay: no ChatFull recorded for channel {input_channel['channel_id']}"
+            )
+        return self._serve(row)
+
+    async def get_self(self) -> dict:
+        row = self._latest(("user",), "tier = 'self'", ())
+        if row is None:
+            raise SkipAndRecord("replay: no self User recorded")
+        return self._serve(row)
+
+    async def iter_history(
+        self, input_channel: dict, *, offset_id: int, limit: int
+    ) -> AsyncIterator[dict]:
+        # Reconstructs the original paging (spec §3): id DESC below the
+        # cursor. Secondary order id ASC (capture order) so an edited
+        # message's revisions replay oldest-first. MessageEmpty is excluded —
+        # getHistory never yielded one; they came from the probe.
+        rows = self._src.conn.execute(
+            "SELECT id, observed_at, payload_json, "
+            "CAST(json_extract(payload_json, '$.id') AS INTEGER) AS msg_id "
+            "FROM raw_records "
+            "WHERE lower(kind) IN ('message', 'messageservice') "
+            "AND json_extract(context_json, '$.channel_id') = ? "
+            "AND (? = 0 OR CAST(json_extract(payload_json, '$.id') AS INTEGER) < ?) "
+            "ORDER BY msg_id DESC, id ASC",
+            (input_channel["channel_id"], offset_id, offset_id),
+        ).fetchall()
+        # Never split one msg_id's records across pages: the collector's next
+        # cursor is `min(page ids)` and the next page takes strictly-below,
+        # so a split id's tail records would be unreachable forever.
+        page = list(rows[:limit])
+        while len(rows) > len(page) and rows[len(page)]["msg_id"] == page[-1]["msg_id"]:
+            page.append(rows[len(page)])
+        self._clock.begin_batch()
+        for row in page:
+            self._clock.serve_json(row["observed_at"], row["payload_json"])
+            yield json.loads(row["payload_json"])
+```
+
+`get_messages(ic, ids)`: per id, `_latest(("message","messageservice","messageempty"), "context channel AND json_extract(payload_json,'$.id')=?", ...)`;
+serve found rows (register each on the clock, one shared `begin_batch` at
+the top, `serve_json` per row); `{"_": "ReplayUnknownMessage", "id": i}` for
+misses (D4.1 — with the comment explaining why not `messageEmpty`).
+
+`get_channel_difference(ic, pts, limit)`: fetch all
+`lower(kind) LIKE 'channeldifference%'` rows for the channel `ORDER BY id
+ASC` once, cursor per channel; serve next; when serving, also register every
+nested message so `_observe_message` gets per-message stamps:
+
+```python
+        payload = json.loads(row["payload_json"])
+        self._clock.begin_batch()
+        self._clock.serve_json(row["observed_at"], row["payload_json"])
+        nested = [
+            *payload.get("new_messages", []),
+            *payload.get("messages", []),
+            *(u["message"] for u in payload.get("other_updates", [])
+              if isinstance(u.get("message"), dict)),
+        ]
+        for m in nested:
+            m_row = self._latest(
+                ("message", "messageservice", "messageempty"),
+                "json_extract(context_json, '$.channel_id') = ? "
+                "AND payload_json = ?",
+                (input_channel["channel_id"], dumps(m)),
+            )
+            if m_row is not None:
+                self._clock.serve_json(m_row["observed_at"], m_row["payload_json"])
+        return payload
+```
+
+Exhausted cursor → `{"_": "updates.channelDifferenceEmpty", "final": True,
+"pts": pts}` served with the channel's latest raw `observed_at` (query
+`MAX(observed_at)` for the channel's records) — D4.4.
+
+`check_chat_invite(hash_)`: kinds `('chatinvite','chatinvitealready','chatinvitepeek')`,
+`json_extract(context_json,'$.hash') = ?`; miss → `SkipAndRecord`.
+
+`get_channel_recommendations(ic)`: kinds `('chats','chatsslice')` by context
+channel; miss → `SkipAndRecord`.
+
+`get_sponsored_messages(ic)`: all `lower(kind)='sponsoredmessage'` rows for
+the channel `ORDER BY id ASC`; none → `{"_": "sponsoredMessagesEmpty"}`;
+else register each row on the clock and return
+`{"_": "SponsoredMessages", "messages": [payloads]}` (D4.2).
+
+`download_media(ic, message)`: latest `mediadownload` row matching
+`context.channel_id` and `context.msg_id = message["id"]`; none → `None`.
+Else resolve the file: `Path(payload["path"])` if it exists, otherwise
+`self._src.media_root / sha[:2] / (sha + Path(payload["path"]).suffix)`;
+still missing → `SkipAndRecord(f"replay: media file missing for sha {sha}")`.
+Read bytes, `begin_batch()` + `serve_json(row["observed_at"], row["payload_json"])`,
+return bytes.
+
+`join_channel(ic)`: `return {"_": "Updates", "updates": []}` (D4.3, with the
+zero-network comment).
+
+`get_authorizations` / `get_password_state` / `get_privacy`: raise
+`SkipAndRecord("replay: doctor state is not recorded; reproject never runs doctor")`.
+
+- [ ] **Step 4: Run tests to green, then full suite + lint/type**
+
+Run: `uv run pytest tests/test_replay_gateway.py -q && uv run pytest -q && uv run ruff check && uv run pyright`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/paperboy/replay.py tests/test_replay_gateway.py
+git commit -m "feat(replay): RawReplayGateway + ReplaySource — serve raw_records through the Gateway seam"
+```
+
+---
+
+### Task 5: `RawReplayWebClient` + the `WebGetter` seam
+
+**Files:**
+- Modify: `src/paperboy/web/client.py` (add `WebGetter` Protocol),
+  `src/paperboy/collectors/web.py` (annotations only),
+  `src/paperboy/replay.py` (append `RawReplayWebClient`)
+- Test: `tests/test_replay_web.py`
+
+**Interfaces:**
+- Produces: `WebGetter` Protocol (`def get(self, url: str) -> httpx.Response`);
+  `RawReplayWebClient(source: ReplaySource, clock: ReplayClock)` satisfying it.
+- `WebCollector.__init__`'s `client` param + `_client` attr + `_get_client`
+  return type become `WebGetter | None` / `WebGetter`.
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""tests/test_replay_web.py"""
+from paperboy.clock import ReplayClock
+from paperboy.replay import RawReplayWebClient, ReplaySource
+from paperboy.store.db import Store
+
+
+def _seed(tmp_path):
+    db = tmp_path / "src.sqlite"
+    with Store.open(db) as st:
+        for i, t in enumerate(["2026-01-01T00:00:01+00:00", "2026-01-01T00:00:02+00:00"]):
+            st.add_raw("tme_page",
+                       {"url": "https://t.me/s/durov", "status_code": 200,
+                        "text": f"<html>page capture {i}</html>"},
+                       "stranger", {"channel_username": "durov"}, observed_at=t)
+        st.add_raw("wayback_cdx",
+                   {"url": "https://web.archive.org/cdx/search/cdx?url=t.me/s/durov*"
+                           "&output=json&filter=statuscode:200&collapse=digest&limit=10000",
+                    "status_code": 200, "text": "[]"},
+                   "stranger", {"channel_username": "durov"},
+                   observed_at="2026-01-01T00:00:03+00:00")
+    return db
+
+
+def _client(tmp_path):
+    clock = ReplayClock()
+    return RawReplayWebClient(ReplaySource.open(_seed(tmp_path), tmp_path / "media"), clock), clock
+
+
+def test_serves_stored_response_and_stamps_clock(tmp_path):
+    client, clock = _client(tmp_path)
+    resp = client.get("https://t.me/s/durov")
+    assert resp.status_code == 200
+    assert resp.text == "<html>page capture 0</html>"
+    assert clock.for_payload(
+        {"url": "https://t.me/s/durov", "status_code": 200, "text": resp.text}
+    ) == "2026-01-01T00:00:01+00:00"
+
+
+def test_same_url_serves_captures_in_order(tmp_path):
+    client, _ = _client(tmp_path)
+    assert client.get("https://t.me/s/durov").text == "<html>page capture 0</html>"
+    assert client.get("https://t.me/s/durov").text == "<html>page capture 1</html>"
+
+
+def test_unrecorded_url_is_a_definitive_404(tmp_path):
+    client, _ = _client(tmp_path)
+    resp = client.get("https://t.me/s/durov?before=5")
+    # 404, not 5xx: an unambiguous "nothing there", so the collector's page
+    # loop stops cleanly instead of reporting a failure (web.py's
+    # _is_ambiguous_failure treats 404 as an answer).
+    assert resp.status_code == 404 and resp.text == ""
+
+
+def test_web_client_satisfies_web_getter():
+    from paperboy.web.client import WebClient, WebGetter
+    client: WebGetter = WebClient()   # structural check exercised by pyright too
+    client.close()
+```
+
+- [ ] **Step 2: Run to verify failure** — `uv run pytest tests/test_replay_web.py -q`
+Expected: FAIL, `ImportError: RawReplayWebClient`.
+
+- [ ] **Step 3: Implement**
+
+In `web/client.py` (below the imports):
+
+```python
+class WebGetter(Protocol):
+    """The shape `WebCollector` needs from an HTTP client — satisfied by the
+    real `WebClient` and by `replay.RawReplayWebClient` (spec §4)."""
+
+    def get(self, url: str) -> httpx.Response: ...
+```
+
+(`from typing import Protocol`; `WebClient.get`'s extra keyword-only
+`max_redirects=...` default keeps it call-compatible.) In `collectors/web.py`
+change the three annotations to `WebGetter`.
+
+Append to `replay.py`:
+
+```python
+class RawReplayWebClient:
+    """Serve stored `tme_page`/`wayback_cdx` captures as `httpx.Response`s.
+
+    Keyed by exact URL — the web collector re-derives the same URL sequence
+    from the same parsed posts, so replay requests exactly the recorded set.
+    Repeat captures of one URL (multi-run sources) serve in capture order.
+    An unrecorded URL is a definitive empty 404: the page loop must stop
+    cleanly there, exactly where the original run stopped.
+    """
+
+    def __init__(self, source: ReplaySource, clock: ReplayClock) -> None:
+        self._src = source
+        self._clock = clock
+        self._served: dict[str, int] = {}   # url -> raw ids already served
+
+    def get(self, url: str) -> httpx.Response:
+        row = self._src.conn.execute(
+            "SELECT id, observed_at, payload_json FROM raw_records "
+            "WHERE lower(kind) IN ('tme_page', 'wayback_cdx') "
+            "AND json_extract(payload_json, '$.url') = ? AND id > ? "
+            "ORDER BY id ASC LIMIT 1",
+            (url, self._served.get(url, 0)),
+        ).fetchone()
+        if row is None:
+            return httpx.Response(404, text="")
+        self._served[url] = row["id"]
+        payload = json.loads(row["payload_json"])
+        self._clock.begin_batch()
+        self._clock.serve_json(row["observed_at"], row["payload_json"])
+        return httpx.Response(payload["status_code"], text=payload["text"])
+```
+
+- [ ] **Step 4: Green + full suite + lint/type; commit**
+
+```bash
+uv run pytest tests/test_replay_web.py -q && uv run pytest -q && uv run ruff check && uv run pyright
+git add src/paperboy/replay.py src/paperboy/web/client.py src/paperboy/collectors/web.py tests/test_replay_web.py
+git commit -m "feat(replay): RawReplayWebClient + WebGetter protocol seam"
+```
+
+---
+
+### Task 6: `reproject` recipe, composition, and CLI
+
+**Files:**
+- Create: `src/paperboy/reproject.py`
+- Modify: `src/paperboy/app.py` (add `build_reproject`),
+  `src/paperboy/cli.py` (add the `reproject` command)
+- Test: `tests/test_reproject.py` (CLI/orchestration cases; the round-trip
+  battery lands in Task 7 in the same file)
+
+**Interfaces:**
+- Produces:
+
+```python
+# reproject.py
+class ReprojectError(Exception): ...   # operator-facing (empty source, etc.)
+
+REPROJECT_TABLES: tuple[str, ...]  # the diff-summary table list (raw + projections)
+
+def detect_phases(source: ReplaySource) -> list[str]: ...
+
+async def reproject(
+    source: ReplaySource, out_store: Store, settings: Settings,
+    profile: str, phases: list[str] | None, log: logging.Logger,
+) -> ReprojectSummary: ...
+
+@dataclass
+class ReprojectSummary:
+    phases: list[str]
+    results: dict[str, list[CollectResult]]        # target raw string -> phase results
+    table_counts: dict[str, tuple[int, int]]       # table -> (source_rows, target_rows)
+
+# app.py
+def build_reproject(settings: Settings, profile: str, out_path: Path) -> tuple[ReplaySource, Store]
+```
+
+- [ ] **Step 1: Write failing orchestration tests** (append to a new `tests/test_reproject.py`)
+
+```python
+import json
+import logging
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from paperboy.cli import app
+from paperboy.replay import ReplaySource
+from paperboy.reproject import detect_phases
+from paperboy.store.db import Store
+
+from tests.test_reproject_parity import run_full_collect
+
+runner = CliRunner()
+
+
+@pytest.mark.asyncio
+async def test_detect_phases_reflects_recorded_raw_kinds(tmp_path):
+    db = await run_full_collect(tmp_path)
+    src = ReplaySource.open(db, tmp_path / "default" / "media")
+    phases = detect_phases(src)
+    assert phases[:2] == ["channel", "history"]
+    assert "graph" in phases and "web" in phases and "media" in phases
+
+
+@pytest.mark.asyncio
+async def test_detect_phases_minimal_source(tmp_path):
+    # channel+history-only raw log -> no graph/web/media/discussion phases.
+    ...  # build with collect_channel(phases=["channel", "history"]) via the
+         # parity fixtures, then assert detect_phases == ["channel", "history"]
+
+
+@pytest.mark.asyncio
+async def test_cli_reproject_writes_fresh_db_and_prints_diff(tmp_path, monkeypatch):
+    await run_full_collect(tmp_path)
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    out_db = tmp_path / "default" / "paperboy.reprojected.sqlite"
+    assert out_db.exists()
+    assert "channels" in result.output and "messages" in result.output
+
+
+@pytest.mark.asyncio
+async def test_cli_reproject_refuses_existing_out(tmp_path, monkeypatch):
+    await run_full_collect(tmp_path)
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    out = tmp_path / "default" / "paperboy.reprojected.sqlite"
+    out.write_bytes(b"")
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 1
+    assert "refusing" in result.output.lower()
+
+
+def test_cli_reproject_empty_source_exits_1(tmp_path, monkeypatch):
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    (tmp_path / "default").mkdir(parents=True)
+    with Store.open(tmp_path / "default" / "paperboy.sqlite"):
+        pass  # schema only, no raws
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 1
+    assert "no resolve records" in result.output
+```
+
+(Fill the `...` in `test_detect_phases_minimal_source` with a real
+channel+history-only collect using `full_collect_fixtures()` — no
+placeholder survives into the actual test file.)
+
+- [ ] **Step 2: Run to verify failure** — `uv run pytest tests/test_reproject.py -q`
+
+- [ ] **Step 3: Implement `src/paperboy/reproject.py`**
+
+```python
+"""The reproject recipe (spec §6): enumerate targets and phases from the raw
+log, then run the NORMAL collectors against the replay pair into a fresh
+store. Everything collector-shaped is reused; this module only wires."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from paperboy.clock import ReplayClock
+from paperboy.collectors.base import CollectResult
+from paperboy.collectors.channel import ChannelCollector
+from paperboy.collectors.discussion import DiscussionCollector
+from paperboy.collectors.graph import GraphCollector
+from paperboy.collectors.history import HistoryCollector
+from paperboy.collectors.media import MediaCollector
+from paperboy.collectors.web import WebCollector
+from paperboy.config import Settings
+from paperboy.recipes import collect_channel
+from paperboy.replay import RawReplayGateway, RawReplayWebClient, ReplaySource
+from paperboy.store.db import Store
+from paperboy.targets import parse_target
+
+
+class ReprojectError(Exception):
+    """Operator-facing reproject failure (empty source, bad --out)."""
+
+
+REPROJECT_TABLES = (
+    "raw_records", "channels", "channel_snapshots", "peers", "messages",
+    "message_revisions", "message_metrics", "message_tombstones", "edges",
+    "media", "custody_log", "web_snapshots",
+)
+
+
+@dataclass
+class ReprojectSummary:
+    phases: list[str]
+    results: dict[str, list[CollectResult]]
+    table_counts: dict[str, tuple[int, int]]
+
+
+def detect_phases(source: ReplaySource) -> list[str]:
+    """The phase set the original run(s) executed, inferred from raw kinds
+    (spec §3: a source that never ran graph reprojects without graph). The
+    inference is necessarily raw-only (spec §8) and conservative: a phase
+    whose every RPC was skipped leaves no raw and is treated as never-run;
+    --phases overrides.
+    """
+    phases = ["channel", "history"]
+    linked = source.linked_group_ids()
+    if linked and source.has_context_channel(linked):
+        phases.append("discussion")
+    if source.has_kind("chats", "chatsslice", "chatinvite", "chatinvitealready",
+                       "chatinvitepeek", "sponsoredmessage"):
+        phases.append("graph")
+    if source.has_kind("tme_page", "wayback_cdx"):
+        phases.append("web")
+    if source.has_kind("mediadownload"):
+        phases.append("media")
+    return phases
+
+
+async def reproject(
+    source: ReplaySource,
+    out_store: Store,
+    settings: Settings,
+    profile: str,
+    phases: list[str] | None,
+    log: logging.Logger,
+) -> ReprojectSummary:
+    targets = source.resolve_targets()
+    if not targets:
+        raise ReprojectError(
+            "source has no resolve records in raw_records — nothing to reproject"
+        )
+    active_phases = phases if phases is not None else detect_phases(source)
+    # allow_join=True so a source whose original run used --join replays its
+    # discussion sweep; RawReplayGateway.join_channel is a synthetic no-op
+    # (plan D4.3) — nothing is joined, nothing leaves this machine.
+    replay_settings = settings.model_copy(update={"allow_join": True})
+
+    results: dict[str, list[CollectResult]] = {}
+    for raw_target in targets:
+        clock = ReplayClock()
+        gateway = RawReplayGateway(source, clock)
+        web_client = RawReplayWebClient(source, clock)
+        collectors = [
+            ChannelCollector(), HistoryCollector(), DiscussionCollector(),
+            GraphCollector(),
+            WebCollector(client=web_client, min_interval=0.0, sleep=lambda s: None),
+            MediaCollector(),
+        ]
+        results[raw_target] = await collect_channel(
+            gateway, out_store, replay_settings, parse_target(raw_target),
+            list(active_phases), log,
+            collectors=collectors, profile=profile, clock=clock,
+        )
+
+    counts = {
+        t: (
+            source.conn.execute(f"SELECT count(*) FROM {t}").fetchone()[0],
+            out_store.conn.execute(f"SELECT count(*) FROM {t}").fetchone()[0],
+        )
+        for t in REPROJECT_TABLES
+    }
+    return ReprojectSummary(list(active_phases), results, counts)
+```
+
+- [ ] **Step 4: `app.py` — `build_reproject`**
+
+```python
+def build_reproject(
+    settings: Settings, profile: str, out_path: Path
+) -> tuple[ReplaySource, Store]:
+    """Wire the replay pair's source + a fresh target Store. Deliberately the
+    ONLY composition path for `reproject`: no client, no gateway, no Budget,
+    no secrets — a reproject is incapable of touching Telegram, the web, or
+    the keychain (spec §2, §8).
+    """
+    source_db = profile_dir(settings, profile) / "paperboy.sqlite"
+    if not source_db.exists():
+        raise ConfigError(f"no source DB for profile {profile!r} at {source_db}")
+    if out_path.exists():
+        raise ConfigError(
+            f"refusing to overwrite existing {out_path} — move it aside or pass a fresh --out"
+        )
+    media_root = profile_dir(settings, profile) / "media"
+    return ReplaySource.open(source_db, media_root), Store.open(out_path)
+```
+
+(imports: `from pathlib import Path`, `from paperboy.replay import ReplaySource`.)
+
+- [ ] **Step 5: `cli.py` — the command**
+
+```python
+@app.command()
+def reproject(
+    profile: str = typer.Option("default", "--profile"),
+    out: str = typer.Option(
+        None, "--out",
+        help="Target DB path (default <data_dir>/<profile>/paperboy.reprojected.sqlite). "
+             "The source DB is never touched.",
+    ),
+    phases: str = typer.Option(
+        None, "--phases",
+        help="Comma-separated phase subset; default: auto-detected from the raw log.",
+    ),
+) -> None:
+    """Rebuild all projections from raw_records into a fresh DB — offline,
+    no network, no credentials. See the reproject design doc."""
+    settings = _settings_with_overrides(profile)
+    configure_logging(profile_dir(settings, profile) / "paperboy.log", console=True)
+    log = logging.getLogger("paperboy.cli")
+    out_path = Path(out) if out else profile_dir(settings, profile) / "paperboy.reprojected.sqlite"
+    phase_list = phases.split(",") if phases else None
+
+    try:
+        source, out_store = composition.build_reproject(settings, profile, out_path)
+    except composition.ConfigError as exc:
+        console.print(f"[red]{exc}[/]")
+        raise typer.Exit(code=1) from None
+    try:
+        with source, out_store:
+            summary = asyncio.run(
+                reproject_run(source, out_store, settings, profile, phase_list, log)
+            )
+    except ReprojectError as exc:
+        console.print(f"[red]{exc}[/]")
+        out_path.unlink(missing_ok=True)  # don't leave a half-made target behind
+        raise typer.Exit(code=1) from None
+
+    for raw_target, results in summary.results.items():
+        table = Table(title=f"reproject {raw_target} -> {out_path}")
+        table.add_column("phase"); table.add_column("counts"); table.add_column("stopped")
+        for r in results:
+            table.add_row(r.name, str(r.counts), r.stopped or "-")
+        console.print(table)
+
+    diff = Table(title="row counts — source vs reprojected")
+    diff.add_column("table"); diff.add_column("source"); diff.add_column("reprojected")
+    for name, (src_n, out_n) in summary.table_counts.items():
+        diff.add_row(name, str(src_n), str(out_n))
+    console.print(diff)
+```
+
+with `from paperboy.reproject import ReprojectError, reproject as reproject_run`
+at the top. Note the command name `reproject` vs the imported function —
+alias the import as shown to avoid the collision.
+
+- [ ] **Step 6: Green + full suite + lint/type; commit**
+
+```bash
+uv run pytest tests/test_reproject.py -q && uv run pytest -q && uv run ruff check && uv run pyright
+git add src/paperboy/reproject.py src/paperboy/app.py src/paperboy/cli.py tests/test_reproject.py
+git commit -m "feat(reproject): recipe, composition root, and CLI command (spec §6)"
+```
+
+---### Task 7: The correctness battery — round-trip identity + guardrails
+
+All in `tests/test_reproject.py`. These are spec §7 verbatim; the round-trip
+is the feature's correctness contract.
+
+**Files:**
+- Modify: `tests/test_reproject.py` (append), reusing
+  `run_full_collect`/`full_collect_fixtures`/`dump_db` from
+  `tests/test_reproject_parity.py`.
+
+**Interfaces:**
+- Consumes: everything shipped in Tasks 1–6. No new production code except
+  fixes this battery forces.
+
+- [ ] **Step 1: The round-trip comparison helper + identity test**
+
+```python
+# D5 (plan): equality modulo autoincrement pks and source_raw_id, compared as
+# DISTINCT row sets — replay legitimately serves one observation through two
+# paths (getHistory + getChannelDifference), duplicating byte-identical rows.
+ROUND_TRIP_EXCLUDE = {
+    "raw_records": {"id"},
+    "channels": {"source_raw_id"},
+    "channel_snapshots": {"id", "source_raw_id"},
+    "peers": {"source_raw_id"},
+    "messages": {"source_raw_id"},
+    "message_revisions": {"id", "source_raw_id"},
+    "message_metrics": {"id"},
+    "message_tombstones": {"id"},
+    "edges": {"id", "source_raw_id"},
+    "media": set(),
+    "custody_log": {"id"},
+    "web_snapshots": {"id"},
+}
+
+
+def _table_set(conn, table: str, exclude: set[str]) -> set[tuple]:
+    cols = [r[1] for r in conn.execute(f"PRAGMA table_info({table})") if r[1] not in exclude]
+    sql = f"SELECT {', '.join(cols)} FROM {table}"
+    return {tuple(row) for row in conn.execute(sql)}
+
+
+def assert_round_trip(db1: Path, db2: Path) -> None:
+    import sqlite3
+    c1, c2 = sqlite3.connect(db1), sqlite3.connect(db2)
+    try:
+        for table, exclude in ROUND_TRIP_EXCLUDE.items():
+            s1, s2 = _table_set(c1, table, exclude), _table_set(c2, table, exclude)
+            assert s1 == s2, (
+                f"{table} diverged:\n only in source: {sorted(s1 - s2)[:5]}\n"
+                f" only in reprojected: {sorted(s2 - s1)[:5]}"
+            )
+    finally:
+        c1.close(); c2.close()
+
+
+@pytest.mark.asyncio
+async def test_round_trip_identity(tmp_path, monkeypatch):
+    """Spec §7: collect -> reproject -> projections identical, timestamps
+    included. Runs with the REAL clock (no freezing) — timestamp equality is
+    exactly what the observed-at seam exists to guarantee."""
+    db1 = await run_full_collect(tmp_path)
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    assert_round_trip(db1, tmp_path / "default" / "paperboy.reprojected.sqlite")
+```
+
+- [ ] **Step 2: Zero network / zero credentials**
+
+```python
+@pytest.mark.asyncio
+async def test_reproject_is_incapable_of_network_or_keychain(tmp_path, monkeypatch):
+    db1 = await run_full_collect(tmp_path)
+    del db1
+
+    def _forbidden(*a, **k):
+        raise AssertionError("reproject touched a forbidden constructor")
+
+    import keyring
+    import paperboy.gateway as gw
+    import paperboy.web.client as wc
+    monkeypatch.setattr(gw.TelethonGateway, "__init__", _forbidden)
+    monkeypatch.setattr(wc.WebClient, "__init__", _forbidden)
+    monkeypatch.setattr(keyring, "get_password", _forbidden)
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+```
+
+- [ ] **Step 3: Corrected-projection test** (the feature's raison d'être)
+
+```python
+@pytest.mark.asyncio
+async def test_reproject_corrects_old_code_projections(tmp_path, monkeypatch):
+    """A DB whose projections were written by OLD code (10-flag channels, a
+    stored self peer, a lost edge) reprojects to the current correct shape —
+    raw is the system of record."""
+    import sqlite3
+    db1 = await run_full_collect(tmp_path)
+    conn = sqlite3.connect(db1)
+    good_flags = conn.execute("SELECT flags_json FROM channels").fetchone()[0]
+    assert len(json.loads(good_flags)) > 3
+    conn.execute("UPDATE channels SET flags_json = ?",
+                 (json.dumps({"broadcast": True}),))           # old 1-flag shape
+    conn.execute(
+        "INSERT INTO peers (uri, kind, id, is_min, first_seen, last_seen) "
+        "VALUES ('tg:user:1', 'user', 1, 0, 'x', 'x')")        # self row (pre-#12)
+    conn.execute("DELETE FROM edges")                          # lost projections
+    conn.commit(); conn.close()
+
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    assert runner.invoke(app, ["reproject", "--profile", "default"]).exit_code == 0
+    out = sqlite3.connect(tmp_path / "default" / "paperboy.reprojected.sqlite")
+    assert json.loads(out.execute("SELECT flags_json FROM channels").fetchone()[0]) \
+        == json.loads(good_flags)
+    assert out.execute("SELECT count(*) FROM peers WHERE uri='tg:user:1'").fetchone()[0] == 0
+    assert out.execute("SELECT count(*) FROM edges").fetchone()[0] > 0
+    out.close()
+```
+
+- [ ] **Step 4: Missing-raw (phase-set reproduction), partial source, media file-read**
+
+```python
+@pytest.mark.asyncio
+async def test_source_without_graph_reprojects_without_graph(tmp_path, monkeypatch):
+    # channel+history-only DB1 (no graph/web/media raws) -> DB2 must not grow
+    # mention edges the original never projected (plan D4.5).
+    ...  # collect with phases=["channel","history"], reproject, then
+         # assert_round_trip(db1, db2) — the round-trip helper IS the assertion.
+
+
+@pytest.mark.asyncio
+async def test_partial_interrupted_source_reprojects_to_same_partial_state(tmp_path, monkeypatch):
+    # DB1 whose catch_up PhaseStopped mid-backlog: channel_difference fixture
+    # is [non_final_page(pts 41), PhaseStop("flood")]. Reproject must land on
+    # the same partial projections (raw_records excluded here: replay closes
+    # the log with one synthetic final empty diff, plan D4.4).
+    ...  # build via collect_channel with the exception-fixture FakeGateway,
+         # reproject via CLI, compare all ROUND_TRIP_EXCLUDE tables except
+         # raw_records.
+
+
+@pytest.mark.asyncio
+async def test_reproject_never_rewrites_media_files(tmp_path, monkeypatch):
+    await run_full_collect(tmp_path)
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    from pathlib import Path as _P
+    def _no_write(self, data):
+        raise AssertionError(f"reproject wrote a media file: {self}")
+    monkeypatch.setattr(_P, "write_bytes", _no_write)
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+```
+
+Fill both `...` bodies fully (no placeholders in the committed file): the
+first mirrors `test_round_trip_identity` with a reduced phase list; the
+second builds DB1 inline with
+`fx["channel_difference"] = [<non-final page dict>, PhaseStop("flood")]`
+exactly as `tests/test_recipe.py::_diff_page` does.
+
+- [ ] **Step 5: Run the battery, then everything**
+
+Run: `uv run pytest tests/test_reproject.py -q && uv run pytest -q && uv run ruff check && uv run pyright`
+Expected: PASS. Any round-trip divergence is a real seam/replay bug — debug
+with `superpowers:systematic-debugging`, never by widening the exclusions
+(the exclusion sets in D5 are the contract; changing them requires updating
+the plan/PR rationale, not making a red test green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_reproject.py
+git commit -m "test(reproject): round-trip identity + zero-network/credential + corrected-projection battery (spec §7)"
+```
+
+---
+
+### Task 8: Documentation + real-archive smoke (DoD input)
+
+**Files:**
+- Create: `docs/features/reproject.md`
+- Modify: `CLAUDE.md` (Status + Commands), `README.md` (command list, if it enumerates commands)
+- Modify: `docs/superpowers/specs/2026-08-25-reproject-design.md` (append an
+  "Implementation notes" section recording deviations D4.1–D4.5 and the D5
+  equality contract, each with one-line rationale)
+
+- [ ] **Step 1: Write `docs/features/reproject.md`**
+
+Cover: what it does, the replay architecture (one paragraph + the clock
+seam), CLI usage with the default `--out`, phase auto-detection and its
+conservative-inference caveat, the D4 deviations, and a **Smoke transcript**
+section to be filled in step 2.
+
+- [ ] **Step 2: Real-archive smoke (safe: offline, source untouched)**
+
+```bash
+uv run paperboy reproject --profile default
+sqlite3 data/default/paperboy.reprojected.sqlite \
+  "SELECT json_array_length(json_extract(flags_json,'$')) IS NOT NULL, length(flags_json) FROM channels;
+   SELECT count(*) FROM peers WHERE uri IN (SELECT json_extract(value_json,'$.uri') FROM sync_state WHERE scope='account');
+   SELECT count(*) FROM messages; SELECT count(*) FROM edges;"
+```
+
+Verify against spec §9's payoff: the reprojected `channels.flags_json` has
+the full flag set (~48, not 10), `peers` contains no self row, message/edge
+counts are ≥ the source's live-code counts. Paste the actual command output
+into the feature doc's smoke section and into the DoD report. If anything
+errors on the real archive (older raw shapes), that is a bug to fix in
+`replay.py` (no-shed), then re-run.
+
+- [ ] **Step 3: Update CLAUDE.md status line + commands list; spec appendix; commit**
+
+```bash
+uv run pytest -q && uv run ruff check && uv run pyright
+git add docs CLAUDE.md README.md
+git commit -m "docs(reproject): feature doc with real-archive smoke, spec implementation notes"
+```
+
+---
+
+## Self-Review (performed while writing)
+
+- **Spec coverage:** §2 replay pair → Tasks 4–5; §3 method table → Task 4
+  (with D4 deviations recorded and tested); §4 media/web → Tasks 4–5 + media
+  write-guard in Task 3; §5 clock seam + parity test → Tasks 1–3; §6 CLI +
+  composition + diff summary → Task 6; §7 full test battery → Task 7 (+ Task
+  4 unit tests); §8 guardrails → Task 6 composition + Task 7 step 2; §9
+  payoff → Task 8 smoke. Deferred items (§9: `--force`, `--verify`,
+  incremental) deliberately absent.
+- **Type consistency:** `Clock.for_payload(dict) -> str` is the single
+  collector-facing clock method everywhere; `ReplayClock.serve/serve_json/
+  begin_batch` are gateway-facing only. `add_raw`'s new param is
+  keyword-with-default everywhere it's passed. `WebGetter` is the only
+  annotation change the web collector needs. `collect_channel(..., clock=)`
+  matches Task 6's call.
+- **Known judgment calls** (flag in the PR body): D3's live-behavior change
+  for derived-edge timestamps; D4.1–D4.5; D5's `source_raw_id` exclusion and
+  distinct-row comparison. Each is argued inline where implemented.

--- a/docs/superpowers/plans/2026-08-26-reproject.md
+++ b/docs/superpowers/plans/2026-08-26-reproject.md
@@ -2520,3 +2520,161 @@ git commit -m "docs(reproject): ADR-0005 run-structure revision — multi-run re
   path), sticky media detection (would fabricate custody observations for
   runs that never ran media — #36 stays open, narrowed), and any mutation of
   the source DB for legacy segmentation (replay-time inference only).
+
+---
+
+# Revision R2 (2026-08-26): review round-2 findings — invariant composition + doc structure
+
+> Authorized after round 2's review exhaustion (#33, second escalation
+> comment). Base: `2269372` on `feat/reproject`. The reviewers confirmed the
+> run-id redesign itself is sound (two-run gate live, real archive
+> reproduces digit-for-digit, no shortcuts in the diff); what failed is
+> (A) ADR-0005 §6's original upsert rule, which was recency-only and
+> dropped `peers.py`'s richness invariant — §6 is now amended with the
+> composed lattice, read it first — and (B) `docs/features/reproject.md`'s
+> shape, which makes doc rot the default. Round 3 is NARROW: four tasks,
+> no new features.
+>
+> **Environment rule for every command in this revision:** the macOS system
+> volume ran out of space mid-review (spurious `sqlite3 disk I/O error`s).
+> Run ALL pytest invocations as
+> `TMPDIR=/Volumes/Storage/tmp uv run pytest -q --basetemp=/Volumes/Storage/tmp/pytest`
+> (`/Volumes/Storage/tmp` exists). Never write test tmp under `/`.
+
+## Task R7: The composed upsert invariant (ADR-0005 §6 as amended)
+
+**Files:**
+- Modify: `src/paperboy/store/peers.py` (the `ON CONFLICT` clause + module
+  docstring), `tests/test_store_peers.py`
+
+- [ ] **Step 1: Write the eight-case table test, confirm the failing cells
+  RED first.** One parametrized test covering every (stored, incoming) ×
+  (older, newer) case from the amended ADR §6 lattice — stored full/min ×
+  incoming full/min × incoming stamp older/newer. For each case assert all
+  of: identity columns (`username`, `access_hash`, `is_min`), provenance
+  columns (`seen_in_chat`, `seen_in_msg`), `source_raw_id`, and the
+  `first_seen`/`last_seen` window. The two cells the review proved broken
+  (min-stored ← full-incoming-with-OLDER-stamp discarding the profile;
+  full-stored ← min-incoming interplay under the recency guard) must fail
+  against `2269372` before any fix — run and record the failure. Keep the
+  existing `test_min_does_not_clobber_full` and round-2's
+  `test_min_observation_older_than_first_seen_still_widens_the_window`;
+  the new table test supersedes neither (they pin the historical shapes).
+
+- [ ] **Step 2: Implement.** In the main `ON CONFLICT(uri) DO UPDATE`, the
+  identity/profile CASE guards become
+  `WHEN excluded.last_seen >= peers.last_seen OR (peers.is_min AND NOT excluded.is_min) THEN …`
+  (richness overrides recency for min→full); provenance columns keep the
+  plain recency guard; `first_seen`/`last_seen` stay MIN/MAX. The
+  incoming-min-on-richer-row early branch keeps its round-2 recency guard
+  and its provenance-only scope (that IS cell full←min). Rewrite the module
+  docstring to state the four-cell lattice and cite ADR-0005 §6 (amended) —
+  the docstring being the only home of the richness invariant is exactly
+  how round 2's regression happened.
+
+- [ ] **Step 3: The ordering property gate** (append to
+  `tests/test_store_peers.py`): apply one fixed set of three observations
+  of the same peer — full@t1, min@t2, full@t3 (distinct usernames/hashes) —
+  in ALL `itertools.permutations` orders; assert the final peers row is
+  byte-identical across all six orders and matches the lattice's expected
+  outcome. This is the gate class the escalation demanded: it can fail for
+  ordering defects without a reviewer inventing a probe. Confirm it fails
+  on `2269372` (pre-fix) for at least one permutation before the fix lands;
+  green after.
+
+- [ ] **Step 4: Integration fixture through the real collector path**
+  (append to `tests/test_reproject.py`): a two-run round-trip variant where
+  run 1 observes a peer FULL (in the resolve/full_channel users vector) and
+  run 2 observes the same peer only as a `min` author stub (message
+  `from_id`), then reproject — `assert_round_trip` must hold, and the
+  reprojected peers row must keep the full profile with the widened window.
+  No `SkipAndRecord` short-circuit anywhere on the path (the round-2 gate's
+  blind spot: its only two-target run bailed at `@atom8388` before reaching
+  peer projection).
+
+- [ ] **Step 5: Full suite (with the TMPDIR rule) + lint/type; commit**
+
+```bash
+TMPDIR=/Volumes/Storage/tmp uv run pytest -q --basetemp=/Volumes/Storage/tmp/pytest && uv run ruff check && uv run pyright
+git add src/paperboy/store/peers.py tests/test_store_peers.py tests/test_reproject.py
+git commit -m "fix(store): compose richness with recency in upsert_peer — ADR-0005 §6 amendment (#33 round-2 finding A)"
+```
+
+## Task R8: Restructure `docs/features/reproject.md`
+
+**Files:**
+- Modify: `docs/features/reproject.md`
+
+- [ ] **Step 1: Single source of truth.** Behavior statements live in
+  exactly one place — the module/function docstrings (the
+  `_reset_incremental_backfill_state` docstring is already the best account
+  in the repo). Rewrite "How it works" to a short orientation that POINTS
+  at the docstrings (`reproject.py`, `replay.py`, `clock.py`,
+  `store/peers.py`) instead of paraphrasing them. Fix the two passages
+  round 2's fix falsified (the pre-narrowing description of the
+  `history`/`history_sweep` reset — currently at ~:71-78 and ~:499-504;
+  locate by content, not line number).
+
+- [ ] **Step 2: Freeze the narratives.** Every smoke transcript and "bug
+  found and fixed" narrative gets a dated header:
+  `> Historical record (2026-08-26, commit <sha>). Kept as evidence; for
+  current behavior see the module docstrings.` — and its prose changed to
+  unambiguous past tense where it currently asserts present behavior. Do
+  not delete the transcripts (they are DoD evidence); do stop them from
+  claiming currency.
+
+- [ ] **Step 3: Cross-refs.** ADR-0005's status line and CLAUDE.md's
+  pointer stay valid; verify both still point at sections that exist after
+  the restructure. Full suite + lint (docs don't need pytest, run anyway to
+  be sure nothing imports the doc paths); commit
+
+```bash
+TMPDIR=/Volumes/Storage/tmp uv run pytest -q --basetemp=/Volumes/Storage/tmp/pytest && uv run ruff check && uv run pyright
+git add docs/features/reproject.md docs/adr/0005-run-structure.md CLAUDE.md
+git commit -m "docs(reproject): single-source-of-truth restructure — docstrings canonical, narratives frozen (#33 round-2 finding B)"
+```
+
+## Task R9: CLI wart + worktree hygiene (no-shed)
+
+- [ ] **Step 1:** `paperboy reproject --profile <nonexistent>` currently
+  mkdirs `data/<nonexistent>/` (via `configure_logging`) before
+  `build_reproject` rejects the profile — smoke case 8 left a
+  `data/ghost-profile/` behind. Reorder the `reproject` CLI command so the
+  source-DB existence check runs before `configure_logging` creates the
+  profile dir (or log to stderr-only until validated — pick the smaller
+  change), with a test: invoking reproject on a nonexistent profile exits 1
+  AND creates no directory. Red first.
+- [ ] **Step 2:** ensure no stray `data/ghost-profile/` or other
+  test-created dirs exist in the working tree; never commit anything under
+  `data/`.
+- [ ] **Step 3:** full suite + lint/type; commit
+  `fix(cli): reproject must not create a profile dir for a profile it then rejects`
+
+## Task R10: Complete the deferred verification + final validation
+
+- [ ] **Step 1: The 5-mutation battery round 2's reviewer could not
+  finish** (disk-space casualty): for each of the five round-2 regression
+  tests the reviewer listed as unproven-live (see the #33 round-2
+  escalation — the segmentation, run_id-guard, and backfill-state tests
+  from `2269372`), apply the obvious reverting mutation to the code under
+  test, confirm the test FAILS, revert the mutation. Record
+  mutation→failing-test pairs in the DoD report. Any test that survives its
+  mutation is dead signal — fix the test, not the mutation.
+- [ ] **Step 2: Real-archive smoke re-run** (delete only the stale
+  `data/default/paperboy.reprojected.sqlite` first): all round-2 numbers
+  must reproduce digit-for-digit, plus the R7 fix must not change any
+  archive count (the archive's replay is stamp-ordered, so richness cells
+  fire only if a min stub follows a full observation across runs — report
+  whichever way it lands, with the count diff if any).
+- [ ] **Step 3:** full suite + lint/type; update the DoD report; commit.
+
+## Revision R2 self-review
+
+- R7 turns both of round 2's finding-A orderings into permanent gates (the
+  8-case table + the 6-permutation property test) — the class, not the
+  instance. R8 removes the structural cause of finding B rather than
+  patching two stale lines. R9/R10 clear every loose end the escalation
+  named (ghost dir, unproven mutations, TMPDIR).
+- Deliberately NOT done: re-litigating the run-id design (verified sound),
+  touching `upsert_channel`'s rule (no min concept — ADR §6 records why),
+  deleting smoke narratives (frozen, not erased).

--- a/docs/superpowers/plans/2026-08-26-reproject.md
+++ b/docs/superpowers/plans/2026-08-26-reproject.md
@@ -1970,3 +1970,553 @@ git commit -m "docs(reproject): feature doc with real-archive smoke, spec implem
 - **Known judgment calls** (flag in the PR body): D3's live-behavior change
   for derived-edge timestamps; D4.1–D4.5; D5's `source_raw_id` exclusion and
   distinct-row comparison. Each is argued inline where implemented.
+
+---
+
+# Revision R (2026-08-26): run-structure redesign (ADR-0005)
+
+> Authorized after the first review loop exhausted (#33, escalation comment).
+> Base: `40088db` on `feat/reproject` — the green single-run implementation of
+> Tasks 1–8 **without** the rejected `_backfill_older_*` shadow path (that
+> path exists only on parked branch `worktree-wf_d33e1b80-e14-7`; do not merge
+> it — R5 re-derives multi-run support from the run-id design instead).
+> Read `docs/adr/0005-run-structure.md` and spec §11 before starting.
+> The D1–D5 design decisions above still stand; R-tasks build on them.
+
+**Goal of the revision:** faithful replay of multi-run archives by recording
+run structure (`raw_records.run_id`) and replaying once per historical run —
+deleting the need for any projection logic outside the collectors.
+
+## Task R1: The two-run round-trip gate (red first, committed as strict xfail)
+
+The missing convergence signal from #33. Written and confirmed failing
+BEFORE any implementation, committed with `@pytest.mark.xfail(strict=True)`
+so every intermediate commit stays green while the gate stays real — R5
+removes the marker and the test must then pass (strict xfail turns an
+unexpected pass into a failure, so the marker cannot silently linger).
+
+**Files:**
+- Modify: `tests/test_reproject_parity.py` (a fixtures hook on
+  `run_full_collect`), `tests/test_reproject.py` (the gate test)
+
+**Interfaces:**
+- `run_full_collect(data_dir: Path, mutate_fixtures: Callable[[dict], dict] | None = None) -> Path`
+  — the hook applies to the FakeGateway fixtures dict only; web transport
+  unchanged. Existing callers unaffected (default None).
+
+- [ ] **Step 1: Add the hook** — in `run_full_collect`, replace
+  `FakeGateway(full_collect_fixtures())` with:
+
+```python
+    fixtures = full_collect_fixtures()
+    if mutate_fixtures is not None:
+        fixtures = mutate_fixtures(fixtures)
+    ...
+        await collect_channel(FakeGateway(fixtures), store, settings, ...)
+```
+
+- [ ] **Step 2: Write the gate test** (append to `tests/test_reproject.py`)
+
+```python
+def _second_run_fixtures(fx: dict) -> dict:
+    """Run 2 observes one NEW message carrying NEW media, on top of
+    everything run 1 saw — so run 2 exercises incremental backfill, repeat
+    snapshots/metrics/web captures, AND a fresh MediaDownload (which is what
+    makes run 2's media phase raw-detectable, spec D4.5/ADR-0005 residual)."""
+    fx = {**fx, "history": [
+        {
+            "_": "message", "id": 4, "message": "new in run 2",
+            "date": 1769322400, "views": 3,
+            "media": {
+                "_": "MessageMediaDocument",
+                "document": {
+                    "_": "Document", "id": 77, "access_hash": 1,
+                    "mime_type": "text/plain",
+                    "attributes": [
+                        {"_": "DocumentAttributeFilename", "file_name": "b.txt"}
+                    ],
+                },
+            },
+        },
+        *fx["history"],
+    ]}
+    fx["media"] = {**fx["media"], 4: b"second run bytes"}
+    return fx
+
+
+@pytest.mark.xfail(
+    reason="#33 / ADR-0005: multi-run replay lands in tasks R2-R5",
+    strict=True,
+)
+def test_two_run_round_trip_identity(tmp_path, monkeypatch):
+    """ADR-0005 gate: a source built from TWO collect passes — the ordinary
+    real-archive shape — must round-trip identically, time series included."""
+    asyncio.run(run_full_collect(tmp_path))
+    db1 = asyncio.run(run_full_collect(tmp_path, mutate_fixtures=_second_run_fixtures))
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    assert_round_trip(db1, tmp_path / "default" / "paperboy.reprojected.sqlite")
+```
+
+- [ ] **Step 3: Verify it fails for the RIGHT reason** — run once with the
+  xfail marker commented out:
+  `uv run pytest tests/test_reproject.py::test_two_run_round_trip_identity -q`
+  Expected: FAIL with table divergence (at minimum `channel_snapshots`,
+  `web_snapshots`, `raw_records` counts collapsed to one run's worth —
+  the #33 reproduction). Restore the marker; the run must then report
+  xfailed, and the FULL suite stays green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+uv run pytest -q && uv run ruff check && uv run pyright
+git add tests/test_reproject_parity.py tests/test_reproject.py
+git commit -m "test(reproject): two-run round-trip gate, strict-xfail until ADR-0005 lands (#33)"
+```
+
+## Task R2: `run_id` in the raw log
+
+**Files:**
+- Create: `src/paperboy/store/migrations/0003_run_id.sql`
+- Modify: `src/paperboy/store/db.py` (`begin_run`, `add_raw`),
+  `src/paperboy/recipes.py` (`collect_channel(run_id=...)`),
+  `tests/test_reproject_parity.py` (`dump_db` run_id normalization),
+  `tests/fixtures/reproject/parity_golden.json` (regenerated, see step 5)
+- Test: `tests/test_clock.py` or `tests/test_store_migrations.py` additions
+
+**Interfaces:**
+- `Store.begin_run(run_id: str | None = None) -> str` — sets the id stamped
+  on every subsequent `add_raw`; generates `uuid4().hex` when None.
+- `collect_channel(..., run_id: str | None = None)` — calls
+  `store.begin_run(run_id)` before building the context. Live callers pass
+  nothing (fresh id); replay passes the source run's id.
+
+- [ ] **Step 1: Failing tests**
+
+```python
+def test_add_raw_stamps_the_begun_run(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as store:
+        rid = store.begin_run()
+        store.add_raw("Message", {"_": "Message", "id": 1}, "stranger", None)
+        row = store.conn.execute("SELECT run_id FROM raw_records").fetchone()
+        assert row["run_id"] == rid and len(rid) == 32
+
+
+def test_add_raw_without_begin_run_leaves_null(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as store:
+        store.add_raw("Message", {"_": "Message", "id": 1}, "stranger", None)
+        assert store.conn.execute(
+            "SELECT run_id FROM raw_records"
+        ).fetchone()["run_id"] is None
+
+
+def test_begin_run_accepts_injected_id(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as store:
+        assert store.begin_run("legacy-0001") == "legacy-0001"
+```
+
+- [ ] **Step 2: Migration** — `0003_run_id.sql`:
+
+```sql
+-- 0003_run_id: which collect pass produced each raw record (ADR-0005).
+-- Nullable: legacy rows predate the column and are segmented at replay
+-- time by the tier='self' marker rule — never rewritten here.
+ALTER TABLE raw_records ADD COLUMN run_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_raw_records_run ON raw_records(run_id);
+```
+
+  NOTE: `executescript` re-runs the whole file if interrupted, and
+  `ALTER TABLE ADD COLUMN` is not idempotent — but `schema_migrations`
+  gates by stem exactly as for 0001/0002, and the index line is. Match the
+  existing migration style; no special handling needed.
+
+- [ ] **Step 3: `Store.begin_run` + `add_raw` stamping**
+
+```python
+    def begin_run(self, run_id: str | None = None) -> str:
+        """Mark the start of one collect pass (ADR-0005): every subsequent
+        `add_raw` carries this id, so replay can reconstruct pass boundaries.
+        Replay injects the SOURCE run's id, making a reprojected DB itself
+        re-reprojectable; live runs take a fresh opaque id."""
+        self._run_id = run_id if run_id is not None else uuid4().hex
+        return self._run_id
+```
+
+  with `self._run_id: str | None = None` initialised in `__init__`, and the
+  INSERT extended with `run_id` = `self._run_id`.
+
+- [ ] **Step 4: `collect_channel` begins the run** — add keyword
+  `run_id: str | None = None`; first statement of the function body:
+  `store.begin_run(run_id)`.
+
+- [ ] **Step 5: Parity golden — normalize and regenerate ONCE, reviewed**
+
+  `run_id` values are random per process, so `dump_db` must normalize them:
+  map each distinct non-NULL `run_id` to `run-0001`, `run-0002`, … in order
+  of first appearance (by raw rowid). Then regenerate the golden
+  (`UPDATE_GOLDEN=1 …`) and **diff-review it**: the ONLY change must be the
+  new `"run_id": "run-0001"` field on `raw_records` rows. Any other diff
+  means live behavior changed — stop and fix instead of committing. This is
+  the one sanctioned regeneration (schema addition), per the golden's
+  protocol.
+
+- [ ] **Step 6: Full suite + lint/type; commit**
+
+```bash
+uv run pytest -q && uv run ruff check && uv run pyright
+git add -A src/paperboy tests
+git commit -m "feat(store): run_id on raw_records + begin_run seam (ADR-0005)"
+```
+
+## Task R3: Order-independent `upsert_peer` / `upsert_channel`
+
+A live-collect correctness fix in its own right (two observations applied
+out of order must not invert `first_seen`/`last_seen` or let stale data
+clobber newer state), and defense-in-depth for replay.
+
+**Files:**
+- Modify: `src/paperboy/store/peers.py`, `src/paperboy/store/channels.py`
+- Test: `tests/test_store_peers.py`, `tests/test_store_channels.py`
+
+- [ ] **Step 1: Failing tests** (one shown per module; mirror for channels)
+
+```python
+def test_out_of_order_observation_keeps_seen_window_and_newest_state(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as store:
+        raw_new = store.add_raw("User", {"_": "user", "id": 9}, "stranger", None)
+        raw_old = store.add_raw("User", {"_": "user", "id": 9}, "stranger", None)
+        upsert_peer(store, {"_": "user", "id": 9, "username": "new_name"},
+                    raw_new, "2026-02-01T00:00:00+00:00",
+                    seen_in_chat=None, seen_in_msg=None)
+        # The OLDER observation arrives second (out of order):
+        upsert_peer(store, {"_": "user", "id": 9, "username": "old_name"},
+                    raw_old, "2026-01-01T00:00:00+00:00",
+                    seen_in_chat=None, seen_in_msg=None)
+        row = store.conn.execute(
+            "SELECT username, first_seen, last_seen FROM peers"
+        ).fetchone()
+        assert row["first_seen"] == "2026-01-01T00:00:00+00:00"
+        assert row["last_seen"] == "2026-02-01T00:00:00+00:00"
+        assert row["username"] == "new_name"   # stale data must not clobber
+```
+
+- [ ] **Step 2: Implement** — in `upsert_peer`'s main upsert, guard every
+  current-state column and widen the seen window (ISO-8601 UTC strings
+  compare lexicographically — the repo's canonical timestamp form):
+
+```sql
+ON CONFLICT(uri) DO UPDATE SET
+    kind        = CASE WHEN excluded.last_seen >= peers.last_seen THEN excluded.kind        ELSE peers.kind        END,
+    id          = CASE WHEN excluded.last_seen >= peers.last_seen THEN excluded.id          ELSE peers.id          END,
+    access_hash = CASE WHEN excluded.last_seen >= peers.last_seen THEN excluded.access_hash ELSE peers.access_hash END,
+    is_min      = CASE WHEN excluded.last_seen >= peers.last_seen THEN excluded.is_min      ELSE peers.is_min      END,
+    seen_in_chat= CASE WHEN excluded.last_seen >= peers.last_seen THEN excluded.seen_in_chat ELSE peers.seen_in_chat END,
+    seen_in_msg = CASE WHEN excluded.last_seen >= peers.last_seen THEN excluded.seen_in_msg ELSE peers.seen_in_msg END,
+    username    = CASE WHEN excluded.last_seen >= peers.last_seen THEN excluded.username    ELSE peers.username    END,
+    first_name  = CASE WHEN excluded.last_seen >= peers.last_seen THEN excluded.first_name  ELSE peers.first_name  END,
+    last_name   = CASE WHEN excluded.last_seen >= peers.last_seen THEN excluded.last_name   ELSE peers.last_name   END,
+    title       = CASE WHEN excluded.last_seen >= peers.last_seen THEN excluded.title       ELSE peers.title       END,
+    flags_json  = CASE WHEN excluded.last_seen >= peers.last_seen THEN excluded.flags_json  ELSE peers.flags_json  END,
+    source_raw_id = CASE WHEN excluded.last_seen >= peers.last_seen THEN excluded.source_raw_id ELSE peers.source_raw_id END,
+    first_seen  = MIN(peers.first_seen, excluded.first_seen),
+    last_seen   = MAX(peers.last_seen,  excluded.last_seen)
+```
+
+  The min-observation-on-richer-row branch (`UPDATE peers SET seen_in_chat=…
+  WHERE uri=?`) gets the same treatment: apply its field updates only when
+  `? >= last_seen` (bind `observed_at`), and always
+  `last_seen = MAX(last_seen, ?)`. `upsert_channel`: same CASE pattern for
+  its update set; `channel_snapshots` append stays unconditional (it is the
+  time series). Update both docstrings: last-write-wins becomes
+  newest-observation-wins, and say why (ADR-0005 §6).
+
+- [ ] **Step 3: Full suite + parity golden still green** (frozen clock ⇒
+  all comparisons `>=` true ⇒ behavior identical) **; commit**
+
+```bash
+uv run pytest -q && uv run ruff check && uv run pyright
+git add src/paperboy/store tests
+git commit -m "fix(store): order-independent peer/channel upserts — newest observation wins (ADR-0005)"
+```
+
+## Task R4: #34 — non-channel resolution is a skip, not a crash
+
+**Files:**
+- Modify: `src/paperboy/collectors/channel.py` (`_resolved_channel_id`)
+- Test: `tests/test_collector_channel.py`
+
+- [ ] **Step 1: Failing test** — a `resolve` fixture whose `peer` is
+  `{"_": "PeerUser", "user_id": 7}` run through `collect_channel` must yield
+  the channel phase `stopped="skip"` (and the run continue), not a raised
+  `ValueError`. Check the existing non-channel test asserting `ValueError`
+  and repoint it at `SkipAndRecord`.
+
+- [ ] **Step 2: Implement** — in `_resolved_channel_id`, replace
+  `raise ValueError(...)` with `raise SkipAndRecord(...)` (import from
+  `paperboy.budget`), keeping the message; update its docstring ("refuse" →
+  "skip cleanly: a username can legitimately be a user or basic group —
+  issue #34"). `_pick_channel`'s `ValueError` stays: that one is an internal
+  invariant breach (resolve *said* channel but chats disagree), not a
+  data condition.
+
+- [ ] **Step 3: Full suite; commit**
+
+```bash
+uv run pytest -q && uv run ruff check && uv run pyright
+git add src/paperboy/collectors/channel.py tests/test_collector_channel.py
+git commit -m "fix(channel): non-channel resolution skips cleanly instead of crashing (#34)"
+```
+
+## Task R5: Per-run replay (the core)
+
+**Files:**
+- Modify: `src/paperboy/replay.py`, `src/paperboy/reproject.py`,
+  `tests/test_replay_gateway.py`, `tests/test_replay_web.py`,
+  `tests/test_reproject.py` (remove the R1 xfail marker)
+
+**Interfaces:**
+
+```python
+@dataclass(frozen=True)
+class ReplayRun:
+    run_id: str      # real id, or "legacy-000N" for an inferred segment
+    lo: int          # first raw rowid of the pass (inclusive)
+    hi: int          # last raw rowid of the pass (inclusive)
+
+class ReplaySource:
+    def runs(self) -> list[ReplayRun]: ...                      # capture order
+    def resolve_targets(self, run: ReplayRun) -> list[str]: ... # now run-scoped
+    def linked_group_ids(self, run: ReplayRun) -> set[int]: ...
+    def has_kind(self, run: ReplayRun, *kinds: str) -> bool: ...
+    def has_context_channel(self, run: ReplayRun, channel_ids: set[int]) -> bool: ...
+
+class RawReplayGateway:
+    def __init__(self, source: ReplaySource, clock: ReplayClock, run: ReplayRun) -> None: ...
+
+class RawReplayWebClient:
+    def __init__(self, source: ReplaySource, clock: ReplayClock, run: ReplayRun) -> None: ...
+
+def detect_phases(source: ReplaySource, run: ReplayRun) -> list[str]: ...
+```
+
+- [ ] **Step 1: Failing tests for `runs()`** (in `test_replay_gateway.py`)
+
+```python
+def test_runs_groups_by_run_id_in_capture_order(tmp_path):
+    db = tmp_path / "src.sqlite"
+    with Store.open(db) as st:
+        st.begin_run("aaa")
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw("Message", {"_": "message", "id": 1}, "stranger", {"channel_id": 5})
+        st.begin_run("bbb")
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+    src = ReplaySource.open(db, tmp_path / "media")
+    runs = src.runs()
+    assert [(r.run_id, r.lo, r.hi) for r in runs] == [("aaa", 1, 2), ("bbb", 3, 3)]
+
+
+def test_runs_segments_legacy_rows_at_self_markers(tmp_path):
+    db = tmp_path / "src.sqlite"
+    with Store.open(db) as st:  # no begin_run: run_id stays NULL (legacy)
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw("Message", {"_": "message", "id": 1}, "stranger", {"channel_id": 5})
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw("Message", {"_": "message", "id": 2}, "stranger", {"channel_id": 5})
+    src = ReplaySource.open(db, tmp_path / "media")
+    assert [(r.run_id, r.lo, r.hi) for r in src.runs()] == [
+        ("legacy-0001", 1, 2), ("legacy-0002", 3, 4),
+    ]
+
+
+def test_runs_mixed_legacy_then_stamped(tmp_path):
+    # Legacy segment(s) precede stamped runs — the migration boundary shape.
+    ...  # two legacy rows (one self marker), then begin_run("ccc") + rows;
+         # expect [("legacy-0001", 1, 2), ("ccc", 3, ...)]
+```
+
+  (Write the `...` body out fully in the actual test file.)
+
+- [ ] **Step 2: Implement `ReplaySource.runs()`**
+
+```python
+    def runs(self) -> list[ReplayRun]:
+        """Capture-ordered collect passes (ADR-0005). Stamped rows group by
+        run_id; legacy NULL rows are segmented at each tier='self' User
+        record — every collect pass's first raw write (channel.py writes
+        self before anything, and the CLI refuses dependent phases without
+        `channel`) — rows before the first marker join the first segment.
+        Runs must be contiguous rowid ranges (one sequential process per
+        pass); interleaving means a corrupt source and fails loudly."""
+        rows = self.conn.execute(
+            "SELECT id, run_id, tier, lower(kind) AS k FROM raw_records ORDER BY id"
+        ).fetchall()
+        runs: list[ReplayRun] = []
+        current_id: str | None = None
+        legacy_n = 0
+        lo = hi = None
+        seen_run_ids: set[str] = set()
+
+        def _flush() -> None:
+            nonlocal lo, hi
+            if lo is not None:
+                assert current_id is not None
+                runs.append(ReplayRun(current_id, lo, hi))
+                lo = hi = None
+
+        for row in rows:
+            if row["run_id"] is not None:
+                boundary = row["run_id"] != current_id
+                next_id = row["run_id"]
+            else:
+                is_marker = row["tier"] == "self" and (
+                    row["k"] == "user" or row["k"].endswith(".user")
+                )
+                boundary = is_marker or current_id is None
+                next_id = f"legacy-{legacy_n + 1:04d}" if boundary else current_id
+            if boundary:
+                _flush()
+                if next_id in seen_run_ids:
+                    raise ReprojectSourceError(
+                        f"raw log run {next_id!r} is not contiguous — refusing to replay"
+                    )
+                seen_run_ids.add(next_id)
+                if row["run_id"] is None:
+                    legacy_n += 1
+                current_id = next_id
+                lo = row["id"]
+            hi = row["id"]
+        _flush()
+        return runs
+```
+
+  with `class ReprojectSourceError(Exception)` in `replay.py` (re-exported or
+  caught by `reproject.py` as operator-facing). NOTE the subtlety the first
+  legacy segment needs: `boundary` is also true for the very first NULL row
+  even when it is not a marker — rows before the first marker form
+  `legacy-0001`, and a later marker then STARTS `legacy-0002`. Hand-check
+  against `test_runs_segments_legacy_rows_at_self_markers` (marker-first
+  source: the marker itself opens segment 1 — the `current_id is None`
+  clause must not double-count it; get this right against the tests, they
+  are the contract).
+
+- [ ] **Step 3: Scope every replay query to the run** — `RawReplayGateway`
+  and `RawReplayWebClient` take `run: ReplayRun`; every SQL in both classes
+  gains `AND id BETWEEN ? AND ?` (bind `run.lo`, `run.hi`) — including
+  `_latest`, `resolve`, `iter_history`, `get_messages`, the diff query and
+  its synthetic-stamp `MAX(observed_at)` query, `download_media`,
+  recommendations/invites/sponsored, and the web client's URL lookup (whose
+  `id > ?` cursor then starts at `run.lo - 1`). `ReplaySource`'s helper
+  queries (`resolve_targets`, `linked_group_ids`, `has_kind`,
+  `has_context_channel`) same. Within one run each call site now has at
+  most one record, which is what makes `_latest`'s "a live RPC has one
+  now" comment true again — update the comments accordingly. Update every
+  existing test in `test_replay_gateway.py`/`test_replay_web.py` to build
+  the gateway with `src.runs()[0]` (the seeded fixtures are single-run, so
+  behavior is unchanged — no assertion should need to move; if one does,
+  that is a real regression to investigate, not adjust).
+
+- [ ] **Step 4: Per-run orchestration in `reproject()`**
+
+  Replace the per-target loop with runs-outer / targets-inner; per-run
+  detection; thread the run id into the target store:
+
+```python
+    runs = source.runs()
+    if not runs:
+        raise ReprojectError("source raw log is empty — nothing to reproject")
+    replayed_any = False
+    for run in runs:
+        run_phases = phases if phases is not None else detect_phases(source, run)
+        for raw_target in source.resolve_targets(run):
+            replayed_any = True
+            clock = ReplayClock()
+            gateway = RawReplayGateway(source, clock, run)
+            web_client = RawReplayWebClient(source, clock, run)
+            collectors = [...]  # unchanged list
+            try:
+                run_results = await collect_channel(
+                    gateway, out_store, replay_settings, parse_target(raw_target),
+                    list(run_phases), log,
+                    collectors=collectors, profile=profile, clock=clock,
+                    run_id=run.run_id,
+                )
+            except Exception as exc:
+                ...  # existing per-target isolation (D4.7), keyed per run
+            results.setdefault(raw_target, []).extend(run_results)
+    if not replayed_any:
+        raise ReprojectError(
+            "source has no resolve records in raw_records — nothing to reproject"
+        )
+```
+
+  `ReprojectSummary.phases` becomes the union in first-seen order (or a
+  per-run mapping — pick one, render it sensibly in the CLI tables; the CLI
+  currently prints one table per target, which still works with
+  results-extended-per-run). `detect_phases(source, run)` passes `run`
+  through to the source helpers; docstring keeps the D4.5 conservatism note
+  and adds the per-run scope (ADR-0005). Catch `ReprojectSourceError` in
+  the CLI alongside `ReprojectError`.
+
+- [ ] **Step 5: Remove the R1 xfail marker.** Run the gate:
+  `uv run pytest tests/test_reproject.py::test_two_run_round_trip_identity -q`
+  Expected: PASS — the redesign's definition of done. Then the whole
+  battery: every single-run test (round-trip, corrected-projection,
+  zero-network, partial-source, media-no-rewrite) must still pass — a
+  single-run source is now just the one-run case of the same model.
+
+- [ ] **Step 6: Full suite + lint/type; commit**
+
+```bash
+uv run pytest -q && uv run ruff check && uv run pyright
+git add -A src/paperboy tests
+git commit -m "feat(reproject): replay once per historical run — run-scoped gateway, per-run phases (ADR-0005, #33)"
+```
+
+## Task R6: Docs + real-archive smoke (multi-run this time)
+
+**Files:**
+- Modify: `docs/features/reproject.md` (run-structure section + NEW smoke
+  transcript), `CLAUDE.md` (status), ADR-0005 (status stays accepted; add a
+  "verified" note with the smoke date)
+
+- [ ] **Step 1: Real-archive smoke.** Delete any stale
+  `data/default/paperboy.reprojected.sqlite` from the previous round first
+  (it is a generated artifact of this feature's own earlier smoke — confirm
+  the filename matches before deleting; touch nothing else under `data/`).
+
+```bash
+uv run paperboy reproject --profile default
+```
+
+  Verify, and paste actual output into the feature doc:
+  - segmentation: number of replayed runs ≈ `run_events`' distinct run count
+    (cross-check only — `SELECT count(*) FROM run_events WHERE kind='complete'
+    AND phase='channel'` approximates pass count);
+  - time series now survive: `web_snapshots`, `channel_snapshots`,
+    `message_metrics` reprojected counts match the source's (they collapsed
+    to one run's worth in round 1 — the #33 evidence table);
+  - the round-1 payoffs still hold: 48-flag `flags_json`, zero self peers;
+  - `@atom8388` (the non-channel target) now shows as a clean per-run skip
+    in the output, not an error row.
+
+- [ ] **Step 2: Update docs; full suite; commit**
+
+```bash
+uv run pytest -q && uv run ruff check && uv run pyright
+git add docs CLAUDE.md
+git commit -m "docs(reproject): ADR-0005 run-structure revision — multi-run real-archive smoke"
+```
+
+## Revision self-review
+
+- R1 is the gate #33 said was missing, strict-xfail keeps commits green
+  while it is red, and its fixture varies run 2 (new message + new media) so
+  incremental backfill and per-run media detection are both exercised.
+- R2/R3/R4 are independent, individually-tested, and each is also a
+  live-collect improvement; R5 consumes R2's ids and R1's gate; R6 proves
+  the ADR's claims against the archive that broke round 1.
+- Deliberately NOT done: merging `worktree-wf_d33e1b80-e14-7` (the shadow
+  path), sticky media detection (would fabricate custody observations for
+  runs that never ran media — #36 stays open, narrowed), and any mutation of
+  the source DB for legacy segmentation (replay-time inference only).

--- a/docs/superpowers/specs/2026-08-25-reproject-design.md
+++ b/docs/superpowers/specs/2026-08-25-reproject-design.md
@@ -1,8 +1,8 @@
 # `reproject` — rebuild projections from the raw log, no network
 
-**Status:** design, 2026-08-25. Realizes the raw-first thesis
-(`raw_records` is the system of record; normalized tables are a projection that
-can be rebuilt from raw) as an actual command.
+**Status:** shipped, 2026-08-26 (see §10, Implementation notes). Realizes the
+raw-first thesis (`raw_records` is the system of record; normalized tables
+are a projection that can be rebuilt from raw) as an actual command.
 **Execution:** one `single-feature-run` on `feat/reproject`.
 
 ## 1. Goal
@@ -147,3 +147,86 @@ real collectors run.
   everything already captured, including the since-deleted content that lives
   only in raw — with no Telegram call. A live re-run is then needed only for
   genuinely-new data and the people layer.
+
+## 10. Implementation notes (2026-08-26)
+
+Shipped per `docs/superpowers/plans/2026-08-26-reproject.md`. Deviations from
+§3/§7 above, each forced by the round-trip identity test (D5 below) being the
+correctness contract rather than a direction change:
+
+- **D4.1 — `get_messages` placeholder.** An id with no raw record returns
+  `{"_": "ReplayUnknownMessage", "id": i}`, not a synthetic `messageEmpty` —
+  the latter would fabricate deletion evidence (`mark_deleted(evidence=
+  'empty')`) for ids the original run never actually observed as deleted
+  (a gap the probe found alive, or a range only reachable via replayed
+  catch-up). The collector skips any non-`messageEmpty` shape, so the
+  placeholder projects nothing — exactly the source's state.
+- **D4.2 — `get_sponsored_messages` envelope reconstruction.** The original
+  collector never stores the `SponsoredMessages` envelope, only each
+  `SponsoredMessage` individually; replay reconstructs
+  `{"_": "SponsoredMessages", "messages": [...]}` from those records, and
+  serves `{"_": "sponsoredMessagesEmpty"}` when none exist (empty-and-skipped
+  originals are indistinguishable; both project nothing).
+- **D4.3 — `join_channel` is a synthetic no-op**, and reproject always runs
+  with `allow_join=True` — otherwise a source whose original run used
+  `--join` would skip its discussion sweep and lose projections on replay.
+  No network is involved; nothing is joined, because no session exists.
+- **D4.4 — `get_channel_difference` past the last stored page** serves a
+  synthetic final `{"_": "updates.channelDifferenceEmpty", "final": True,
+  "pts": pts}`, not `SkipAndRecord` — a mid-`catch_up` `SkipAndRecord` would
+  mark the whole folded history phase skipped and discard the backfill
+  counts already applied that run. This is why the round-trip test excludes
+  `raw_records` specifically for an interrupted/partial source
+  (`test_partial_interrupted_source_reprojects_to_same_partial_state`): the
+  synthetic closing page has no raw counterpart in the (crashed) original.
+- **D4.5 — phase-set reproduction is by raw-*kind* detection**
+  (`detect_phases`), not per-method `SkipAndRecord` alone — the `graph`
+  phase's mention scan is RPC-free and would otherwise project edges into a
+  graph-less source's reproject that the original run never had.
+- **D4.6 — kind matching is namespace-tolerant, found live, not in
+  design.** Telethon's `to_dict()` prefixes some RPC-result *envelope*
+  types with their TL namespace (`contacts.resolvedPeer` for `ResolvedPeer`,
+  `messages.chatFull` for `ChatFull`, `updates.channelDifference*` for
+  `ChannelDifference*`) but not others (`Message`, `ChatInvite*`,
+  `SponsoredMessage`, `MediaDownload`, `User`, ...). §3's method table
+  implicitly assumed one consistent shape; every kind lookup in `replay.py`
+  now matches a bare kind or any `<namespace>.<kind>` suffix
+  (`_kind_clause`). Undetected against the hand-authored fixtures (which
+  happened to use the real casing already) — only surfaced running
+  `reproject` against the actual `default` archive, which is exactly why
+  §9's real-archive smoke step exists as part of DoD, not just the fixture
+  suite.
+- **D4.7 — one bad historical target must not abort the whole run.** Not
+  anticipated by §3/§7 at all: a source can carry raws from more than one
+  historically-resolved target (successive live `collect` invocations), and
+  `collect_channel` was designed for exactly one target per call — it has no
+  notion of "this target, among several, turned out bad" (e.g. one later
+  resolving to a non-channel peer, which crashes `channel.collect` with a
+  bare `ValueError` even on a live run). Found on the real archive: a stray
+  historical target crashed the *entire* multi-target reproject after the
+  primary channel's full phase set had already completed and committed.
+  Fixed with a per-target `try/except` in `reproject()` that logs the
+  failure and records it as that target's own failed result, leaving every
+  other target's already-committed projections intact. The underlying
+  `channel.py` crash-instead-of-skip behavior is orthogonal to reproject (a
+  live-collect defect this smoke test happened to surface) and is tracked
+  separately as issue #34; the source-wide-not-per-target phase-detection
+  scope this multi-target case also exposed (one source, two spellings of
+  the same channel, redundantly reprojected twice) is tracked as issue #35.
+
+**D5 — round-trip equality contract.** All of `raw_records`, `channels`,
+`channel_snapshots`, `peers`, `messages`, `message_revisions`,
+`message_metrics`, `message_tombstones`, `edges`, `media`, `custody_log`,
+`web_snapshots` compared as **sets of distinct rows** after dropping
+autoincrement pk columns and `source_raw_id` (`source_raw_id` is such an id
+transitively — the referenced record's *content* round-trips via the
+`raw_records` comparison itself). Set, not multiset: a message delivered by
+both `getHistory` and `getChannelDifference` is legitimately served twice on
+replay, producing byte-identical duplicate raw/metrics rows — real signal
+(two independent observations), not a bug to dedupe away. `run_events`,
+`sync_state`, `sync_ranges`, `flood_log`, `schema_migrations`,
+`messages_fts` are excluded as operational/bookkeeping, not projections of
+raw content. Verified live against the real `default` archive
+(`docs/features/reproject.md`): source `channels.flags_json` (10 flags,
+pre-#20-fix) reprojects to the current 48-flag set; the source's one
+leftover self peer row (pre-#12-fix) reprojects to zero.

--- a/docs/superpowers/specs/2026-08-25-reproject-design.md
+++ b/docs/superpowers/specs/2026-08-25-reproject-design.md
@@ -1,0 +1,149 @@
+# `reproject` — rebuild projections from the raw log, no network
+
+**Status:** design, 2026-08-25. Realizes the raw-first thesis
+(`raw_records` is the system of record; normalized tables are a projection that
+can be rebuilt from raw) as an actual command.
+**Execution:** one `single-feature-run` on `feat/reproject`.
+
+## 1. Goal
+
+Apply every projection-layer change (channel flags, self-exclusion, edge
+idempotency, peer provenance, the `MessageEmpty` guard, and any future
+projector) to an *already-captured* archive **without re-scraping Telegram**.
+Today the only way to get corrected projections is a live re-run; `reproject`
+makes it a local, offline, zero-network operation over the raw log.
+
+## 2. Approach — replay through the Gateway seam
+
+The raw log *is* the log of gateway responses: every collector called a Gateway
+method, `to_dict()`'d the response, and appended it to `raw_records`. So the
+projection can be rebuilt by running the **normal collectors** against a gateway
+that serves `raw_records` back instead of Telegram.
+
+- **`RawReplayGateway`** implements the existing `Gateway` Protocol, backed by a
+  source `paperboy.sqlite`'s `raw_records`. **`RawReplayWebClient`** does the
+  same for the `web` collector's HTTP vector.
+- `recipes.collect_channel` runs unchanged against them, writing into a **fresh
+  target DB**. Because it is the same collector code path, the reprojection is
+  *provably identical* to a live collect — it reproduces edges, tombstones,
+  revisions, snapshots, everything, not just messages — and needs **no collector
+  refactor**.
+
+This is exactly the seam `FakeGateway` already validates; `RawReplayGateway` is
+`FakeGateway`'s production sibling, sourced from a real raw log rather than
+hand-authored fixtures.
+
+### Hard invariant: zero network
+
+`reproject` constructs **only** the replay gateway/web-client — never a
+`TelethonGateway` or real `WebClient`, never a session, never `Budget`. A
+reproject must be incapable of touching Telegram or the web. Enforced by
+construction (the composition root builds the replay pair) and asserted in test.
+
+## 3. Method-by-method reconstruction
+
+Each `Gateway` Protocol method maps to raw kinds, keyed by the `context_json`
+already stored on every record:
+
+| Protocol method | Served from `raw_records` |
+|---|---|
+| `resolve(target)` | `ResolvedPeer` whose `context.target` matches |
+| `get_full_channel(ic)` | `ChatFull` for `context.channel_id` |
+| `get_self()` | the `User` record written at `tier='self'` |
+| `iter_history(ic, offset_id, limit)` | `Message`/`MessageService` for the channel, `id DESC`, `< offset_id`, `LIMIT` — reconstructs the original paging so the collector's cursor + gap-probe logic runs identically. **Excludes `MessageEmpty`** (getHistory never yielded them — they came from the probe) |
+| `get_messages(ic, ids)` | the stored `Message`/`MessageEmpty` for each id; a synthetic `messageEmpty` for an id with no record (a true gap) |
+| `get_channel_difference(ic, pts, limit)` | the stored `ChannelDifference*` for the channel, in capture order |
+| `check_chat_invite(hash)` | `ChatInvite`/`ChatInvitePeek` for `context.hash` |
+| `get_channel_recommendations(ic)` | the recommendations `Chats`/`ChatsSlice` for the channel |
+| `get_sponsored_messages(ic)` | the stored sponsored response, or `SkipAndRecord` if none |
+| `download_media(ic, message)` | **special — see §4** |
+| (future) `get_participants`/`get_users`/`get_full_user` | their raw kinds, once the people layer exists — reproject picks them up automatically |
+
+A method with no matching raw raises `SkipAndRecord`, so the collector skips
+that phase cleanly — reproject reproduces exactly the phase set the original run
+executed (a run that never did `graph` reprojects without `graph`).
+
+## 4. Special cases
+
+- **Media.** `download_media` returned bytes the collector content-addressed to
+  disk; the bytes are not in `raw_records` (only a `MediaDownload` metadata
+  record). On replay the files already exist under
+  `<data_dir>/<profile>/media/<sha>`, so `RawReplayGateway.download_media` reads
+  and returns the bytes from that content-addressed path (keyed by the hash in
+  the `MediaDownload` record), letting the media collector re-hash and re-project
+  the `media`/`custody_log` rows identically. If the target DB is a different
+  profile, media is read from the *source* profile's directory. No file is
+  re-downloaded or re-written.
+- **Web.** `RawReplayWebClient` serves `tme_page` / `wayback_cdx` records by
+  `context.channel_username`, reproducing the `web_snapshots` projection.
+
+## 5. Timestamp fidelity (the one clock decision)
+
+Projections stamp `observed_at`/`first_seen`/`last_seen`/snapshots with
+`utc_now_iso()`. To make a reproject a faithful copy — and to make the
+round-trip identity test (§7) hold — reproject **preserves the original
+observation time**: it threads each raw record's stored `observed_at` as the
+clock for that object's projection, rather than stamping "now". This needs a seam:
+a `ctx.now()` the collectors read at projection sites, defaulting to
+`utc_now_iso()` in live mode and returning the raw record's stored `observed_at`
+in replay mode. Threading it through every `observed_at = utc_now_iso()`
+projection site is the **main implementation effort and the only
+collector-touching change** in this feature — mechanical but broad (each
+collector + the store snapshot writers), so it carries its own test that a live
+collect is byte-identical before and after the seam is introduced. (Without the
+seam, reproject still produces correct *content* but resets all timestamps to
+reproject-time, and the §7 round-trip test must exclude timestamp columns;
+timestamp fidelity is worth the seam.)
+
+## 6. CLI and composition
+
+```
+paperboy reproject [--profile P] --out PATH [--phases ...]
+```
+Reads `<data_dir>/<P>/paperboy.sqlite`'s `raw_records`, rebuilds into a new DB at
+`--out` (default `<data_dir>/<P>/paperboy.reprojected.sqlite`), original
+untouched. The composition root (`app.py`) gets a `build_reproject` that wires
+the replay pair + a fresh Store; `cli.py` gains the `reproject` command.
+`--phases` optionally limits which projections to rebuild. On success it prints
+a per-phase counts table and a short diff summary vs the source (row counts per
+table), so the operator can verify before swapping.
+
+## 7. Testing — round-trip identity
+
+The correctness contract is a **round-trip**: collect against a `FakeGateway`
+into DB1 (populating `raw_records` + projections), `reproject` DB1's raw into
+DB2, and assert **DB2's projection tables equal DB1's** (channels, peers,
+messages, revisions, tombstones, edges, media, web_snapshots — modulo primary
+keys / autoincrement ids). With timestamp preservation (§5) this is exact
+equality; it is the single most powerful test in the suite — it proves the
+projection is a pure function of the raw log.
+
+Plus: a zero-network assertion (no `TelethonGateway`/`WebClient`/session ever
+constructed); a corrected-projection test (a DB1 whose projections were written
+by *old* code — e.g. a self peer row, a fixed 10-flag channel — reprojects to
+the *new* correct shape: no self, 48 flags); a missing-raw test (a source
+missing `graph` raw reprojects without graph, no crash); the media file-read
+path; and a partial/interrupted source (budget/phase-stop) reprojects to the
+same partial state.
+
+## 8. Guardrails
+
+Zero network (§2). Read-only w.r.t. the source DB (only `raw_records` is read;
+its projections are never mutated). No credentials/session required (a reproject
+must run with no keychain access at all — it is the one command that needs no
+Telegram identity). Self-exclusion, tri-state, idempotency all apply because the
+real collectors run.
+
+## 9. Scope and follow-ups
+
+- **In scope:** the replay gateway + web client, the reproject command +
+  composition, the observed-at seam, the round-trip test.
+- **Deferred:** an in-place `--force` mode (this design writes a fresh DB only);
+  a `--verify` mode that only diffs without writing; incremental reproject of a
+  single phase into an existing DB. All are additive later.
+- **Payoff for the current archive:** once shipped, one `reproject` of the
+  existing `default` DB yields corrected flags (48 not 10), a self-free `peers`,
+  #11 provenance, idempotent edges, and the `MessageEmpty` guard applied — over
+  everything already captured, including the since-deleted content that lives
+  only in raw — with no Telegram call. A live re-run is then needed only for
+  genuinely-new data and the people layer.

--- a/docs/superpowers/specs/2026-08-25-reproject-design.md
+++ b/docs/superpowers/specs/2026-08-25-reproject-design.md
@@ -230,3 +230,50 @@ raw content. Verified live against the real `default` archive
 (`docs/features/reproject.md`): source `channels.flags_json` (10 flags,
 pre-#20-fix) reprojects to the current 48-flag set; the source's one
 leftover self peer row (pre-#12-fix) reprojects to zero.
+
+## 11. Revision 2 (2026-08-26): run structure — replay per collect pass (ADR-0005)
+
+The first implementation round failed its review gate (#33): a source built
+from **several historical collect runs** — the ordinary shape, the real
+`default` archive has seven — cannot be faithfully replayed by a one-run
+model, because the projection is a function of the raw log *plus the run
+structure*, which §2–§3 above never recorded. The review loop showed
+negative convergence against hand-written compensation ("backfill older
+observations" outside the collectors); the design fix is to record the
+missing datum and delete the compensation. Full rationale and options:
+`docs/adr/0005-run-structure.md`.
+
+This section **supersedes** the affected wording above:
+
+- **§2/§3 (one replay pass):** `reproject` now replays **once per historical
+  run**, in capture order. Per run: that run's targets (its `ResolvedPeer`
+  records), that run's detected phase set, and a gateway whose every query is
+  scoped to that run's rowid range. `_latest()`-style "serve the newest
+  record" semantics apply *within one run* (where each call site has at most
+  one record — a live RPC's one "now"), never across runs. The target store
+  carries `sync_state`/projections across replayed runs exactly as the live
+  store did across real runs, so incremental backfills, repeat snapshots,
+  `first_seen`/`last_seen` evolution, and per-run web captures reproduce by
+  construction.
+- **Schema:** `raw_records.run_id TEXT` (migration `0003_run_id.sql`),
+  stamped by `Store.begin_run()` per `collect_channel` invocation. Replay
+  passes the source run's id through, so a reprojected DB is itself
+  re-reprojectable. Legacy rows (NULL) are segmented at replay time by the
+  `tier='self'` User marker — every collect pass's first raw write — labeled
+  `legacy-0001…`; the source is never mutated.
+- **§5 unchanged** (the clock seam is orthogonal and stands), but
+  `upsert_peer`/`upsert_channel` additionally become order-independent
+  (`first_seen = MIN`, `last_seen = MAX`, current-state fields only from an
+  observation ≥ the stored `last_seen`) — a live-collect correctness fix in
+  its own right, not a replay workaround.
+- **§7 (round-trip):** the identity contract now explicitly covers a
+  **two-run source** (two full collect passes at distinct times into one DB,
+  then reproject) — this fixture is the convergence gate the first round
+  lacked, and is written red-first.
+- **D4.7's per-target error isolation** stays; #34's underlying
+  crash-instead-of-skip (`_resolved_channel_id` raising a bare `ValueError`
+  for a non-channel resolution) is fixed in this revision as `SkipAndRecord`
+  (it is on this feature's replay path for the real archive: `@atom8388`).
+- **Known residual (narrowed #36):** a historical run whose media phase
+  downloaded nothing new leaves no raw trace, so per-run phase detection
+  (D4.5, conservative by design) cannot replay its duplicate-custody rows.

--- a/src/paperboy/app.py
+++ b/src/paperboy/app.py
@@ -6,6 +6,7 @@ every real object gets built here so tests can monkeypatch one seam
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import keyring
@@ -14,6 +15,7 @@ from paperboy.budget import Budget
 from paperboy.config import profile_dir
 from paperboy.gateway import TelethonGateway
 from paperboy.logging_setup import register_secret
+from paperboy.replay import ReplaySource
 from paperboy.secrets import SERVICE, KeyringSecrets
 from paperboy.store.db import Store
 
@@ -125,3 +127,22 @@ async def build_gateway(
 def build_store(settings: Settings, profile: str) -> Store:
     path = profile_dir(settings, profile) / "paperboy.sqlite"
     return Store.open(path)
+
+
+def build_reproject(
+    settings: Settings, profile: str, out_path: Path
+) -> tuple[ReplaySource, Store]:
+    """Wire the replay pair's source + a fresh target `Store`. Deliberately
+    the ONLY composition path for `reproject`: no client, no gateway, no
+    `Budget`, no secrets — a reproject is incapable of touching Telegram,
+    the web, or the keychain (spec §2, §8).
+    """
+    source_db = profile_dir(settings, profile) / "paperboy.sqlite"
+    if not source_db.exists():
+        raise ConfigError(f"no source DB for profile {profile!r} at {source_db}")
+    if out_path.exists():
+        raise ConfigError(
+            f"refusing to overwrite existing {out_path} — move it aside or pass a fresh --out"
+        )
+    media_root = profile_dir(settings, profile) / "media"
+    return ReplaySource.open(source_db, media_root), Store.open(out_path)

--- a/src/paperboy/cli.py
+++ b/src/paperboy/cli.py
@@ -22,6 +22,7 @@ from paperboy.export.jsonl import export_jsonl
 from paperboy.ids import channel_uri
 from paperboy.logging_setup import configure_logging
 from paperboy.recipes import collect_channel
+from paperboy.replay import ReprojectSourceError
 from paperboy.reproject import ReprojectError
 from paperboy.reproject import reproject as reproject_run
 from paperboy.targets import parse_target
@@ -339,7 +340,7 @@ def reproject(
             summary = asyncio.run(
                 reproject_run(source, out_store, settings, profile, phase_list, log)
             )
-    except ReprojectError as exc:
+    except (ReprojectError, ReprojectSourceError) as exc:
         console.print(f"[red]{exc}[/]")
         out_path.unlink(missing_ok=True)  # don't leave a half-made target behind
         raise typer.Exit(code=1) from None

--- a/src/paperboy/cli.py
+++ b/src/paperboy/cli.py
@@ -343,6 +343,19 @@ def reproject(
         console.print(f"[red]{exc}[/]")
         out_path.unlink(missing_ok=True)  # don't leave a half-made target behind
         raise typer.Exit(code=1) from None
+    except Exception:
+        # `build_reproject` already created + migrated `out_path` before this
+        # block runs, so ANY failure here — not just a `ReprojectError` (a
+        # corrupt/unreadable source DB raises a bare `sqlite3.DatabaseError`
+        # from `resolve_targets`, found running this smoke test) — leaves a
+        # half-migrated file at `out_path` behind unless we clean it up too.
+        # Left in place, it would make a retry against the default --out path
+        # hit "refusing to overwrite" for a file that was never actually
+        # usable. Unlike the ReprojectError branch, an unexpected failure is
+        # not translated into a clean message — the real traceback is more
+        # useful for a genuinely unanticipated error than a shim message.
+        out_path.unlink(missing_ok=True)
+        raise
 
     for raw_target, results in summary.results.items():
         table = Table(title=f"reproject {raw_target} -> {out_path}")

--- a/src/paperboy/cli.py
+++ b/src/paperboy/cli.py
@@ -325,8 +325,6 @@ def reproject(
     """Rebuild all projections from raw_records into a fresh DB — offline,
     no network, no credentials. See docs/features/reproject.md."""
     settings = _settings_with_overrides(profile)
-    configure_logging(profile_dir(settings, profile) / "paperboy.log", console=True)
-    log = logging.getLogger("paperboy.cli")
     out_path = Path(out) if out else profile_dir(settings, profile) / "paperboy.reprojected.sqlite"
     phase_list = phases.split(",") if phases else None
 
@@ -335,6 +333,11 @@ def reproject(
     except composition.ConfigError as exc:
         console.print(f"[red]{exc}[/]")
         raise typer.Exit(code=1) from None
+    # Only now that the profile is validated: configure_logging mkdirs the
+    # profile dir, so doing it earlier manufactured `data/<typo>/` for a
+    # profile build_reproject was about to reject (#33 round-2 smoke case 8).
+    configure_logging(profile_dir(settings, profile) / "paperboy.log", console=True)
+    log = logging.getLogger("paperboy.cli")
     try:
         with source, out_store:
             summary = asyncio.run(

--- a/src/paperboy/cli.py
+++ b/src/paperboy/cli.py
@@ -22,6 +22,8 @@ from paperboy.export.jsonl import export_jsonl
 from paperboy.ids import channel_uri
 from paperboy.logging_setup import configure_logging
 from paperboy.recipes import collect_channel
+from paperboy.reproject import ReprojectError
+from paperboy.reproject import reproject as reproject_run
 from paperboy.targets import parse_target
 
 app = typer.Typer(
@@ -304,6 +306,60 @@ def export_cmd(
     for name, n in counts.items():
         table.add_row(f"{name}.jsonl", str(n))
     console.print(table)
+
+
+@app.command()
+def reproject(
+    profile: str = typer.Option("default", "--profile"),
+    out: str = typer.Option(
+        None, "--out",
+        help="Target DB path (default <data_dir>/<profile>/paperboy.reprojected.sqlite). "
+             "The source DB is never touched.",
+    ),
+    phases: str = typer.Option(
+        None, "--phases",
+        help="Comma-separated phase subset; default: auto-detected from the raw log.",
+    ),
+) -> None:
+    """Rebuild all projections from raw_records into a fresh DB — offline,
+    no network, no credentials. See docs/features/reproject.md."""
+    settings = _settings_with_overrides(profile)
+    configure_logging(profile_dir(settings, profile) / "paperboy.log", console=True)
+    log = logging.getLogger("paperboy.cli")
+    out_path = Path(out) if out else profile_dir(settings, profile) / "paperboy.reprojected.sqlite"
+    phase_list = phases.split(",") if phases else None
+
+    try:
+        source, out_store = composition.build_reproject(settings, profile, out_path)
+    except composition.ConfigError as exc:
+        console.print(f"[red]{exc}[/]")
+        raise typer.Exit(code=1) from None
+    try:
+        with source, out_store:
+            summary = asyncio.run(
+                reproject_run(source, out_store, settings, profile, phase_list, log)
+            )
+    except ReprojectError as exc:
+        console.print(f"[red]{exc}[/]")
+        out_path.unlink(missing_ok=True)  # don't leave a half-made target behind
+        raise typer.Exit(code=1) from None
+
+    for raw_target, results in summary.results.items():
+        table = Table(title=f"reproject {raw_target} -> {out_path}")
+        table.add_column("phase")
+        table.add_column("counts")
+        table.add_column("stopped")
+        for r in results:
+            table.add_row(r.name, str(r.counts), r.stopped or "-")
+        console.print(table)
+
+    diff = Table(title="row counts — source vs reprojected")
+    diff.add_column("table")
+    diff.add_column("source")
+    diff.add_column("reprojected")
+    for name, (src_n, out_n) in summary.table_counts.items():
+        diff.add_row(name, str(src_n), str(out_n))
+    console.print(diff)
 
 
 @app.command()

--- a/src/paperboy/clock.py
+++ b/src/paperboy/clock.py
@@ -1,0 +1,76 @@
+"""The observation clock (spec §5): where a projection's `observed_at` comes from.
+
+Projections must be a pure function of the raw log, so their timestamps must
+come from the observation being projected, not from the wall clock at
+projection time. `LiveClock` IS the wall clock (a live collect observes now);
+`ReplayClock` returns the ORIGINAL `observed_at` of the raw record being
+replayed, fed by `RawReplayGateway`/`RawReplayWebClient` as they serve records.
+
+Lookup is payload-keyed (canonical JSON of the served dict), because
+collectors do not project in serve order: `history` consumes a whole
+`iter_history` page into a list first, and `catch_up` projects messages
+nested inside a `ChannelDifference` envelope.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from paperboy.ids import utc_now_iso
+from paperboy.store.db import dumps
+
+
+class ReplayClockError(Exception):
+    """A replay projection asked for a timestamp before anything was served —
+    a replay-wiring bug, never a data condition; fail loudly."""
+
+
+class Clock(Protocol):
+    def for_payload(self, payload: dict) -> str:
+        """The `observed_at` for a projection derived from `payload`."""
+        ...
+
+
+class LiveClock:
+    """Live collection: every observation happens now."""
+
+    def for_payload(self, payload: dict) -> str:
+        del payload
+        return utc_now_iso()
+
+
+class ReplayClock:
+    """Replay: observations happened when the raw log says they did.
+
+    `serve`/`serve_json` are called by the replay gateway per record served;
+    `begin_batch` bounds the registry to one gateway response (the collector
+    always projects a response fully before making the next call).
+    A payload with no registered stamp (e.g. a dict nested in an envelope
+    whose members were never individually recorded) inherits the most
+    recently served record's stamp.
+    """
+
+    def __init__(self) -> None:
+        self._current: str | None = None
+        self._by_payload: dict[str, str] = {}
+
+    def begin_batch(self) -> None:
+        self._by_payload.clear()
+
+    def serve(self, observed_at: str, *payloads: dict) -> None:
+        self._current = observed_at
+        for payload in payloads:
+            self._by_payload[dumps(payload)] = observed_at
+
+    def serve_json(self, observed_at: str, payload_json: str) -> None:
+        """Register a record by its stored canonical JSON without re-parsing."""
+        self._current = observed_at
+        self._by_payload[payload_json] = observed_at
+
+    def for_payload(self, payload: dict) -> str:
+        stamp = self._by_payload.get(dumps(payload), self._current)
+        if stamp is None:
+            raise ReplayClockError(
+                "ReplayClock.for_payload before any record was served"
+            )
+        return stamp

--- a/src/paperboy/collectors/base.py
+++ b/src/paperboy/collectors/base.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass, field
 from logging import Logger
 from typing import TYPE_CHECKING, Protocol
 
+from paperboy.clock import Clock, LiveClock
+
 if TYPE_CHECKING:
     from paperboy.config import Settings
     from paperboy.gateway import Gateway
@@ -34,6 +36,12 @@ class CollectContext:
     # at the end with a default rather than threaded through every existing
     # positional `CollectContext(...)` call site (recipes.py, every test).
     profile: str = "default"
+    # Where a projection's `observed_at` comes from (spec §5 / clock.py):
+    # the wall clock on a live collect, the raw log's original stamps on a
+    # reproject replay. Appended with a default for the same reason `profile`
+    # is — every existing positional `CollectContext(...)` construction stays
+    # valid.
+    clock: Clock = field(default_factory=LiveClock)
 
 
 @dataclass

--- a/src/paperboy/collectors/channel.py
+++ b/src/paperboy/collectors/channel.py
@@ -5,7 +5,7 @@ project it, and prime `ctx` for `history` (and later Phase 2 collectors).
 from __future__ import annotations
 
 from paperboy.collectors.base import CollectContext, CollectResult
-from paperboy.ids import channel_uri, user_uri, utc_now_iso
+from paperboy.ids import channel_uri, user_uri
 from paperboy.store.channels import upsert_channel
 from paperboy.store.edges import add_edge
 from paperboy.store.peers import upsert_peer
@@ -74,7 +74,6 @@ class ChannelCollector:
         return target.is_channel_like
 
     async def collect(self, ctx: CollectContext) -> CollectResult:
-        observed_at = utc_now_iso()
         peer_uris: set[str] = set()
 
         # Learn (and record) the collecting account FIRST, so `is_self` is
@@ -84,20 +83,27 @@ class ChannelCollector:
         # kept (redacted) so provenance can still say which account observed;
         # the id lives in sync_state only, never as a peer row.
         self_user = _redact_self(await ctx.gateway.get_self())
-        ctx.store.add_raw(self_user.get("_", "User"), self_user, "self", None)
+        t_self = ctx.clock.for_payload(self_user)
+        ctx.store.add_raw(
+            self_user.get("_", "User"), self_user, "self", None, observed_at=t_self
+        )
         self_uri = user_uri(self_user["id"])
         set_state(ctx.store, "account", "self", {"uri": self_uri, "id": self_user.get("id")})
 
         resolved = await ctx.gateway.resolve(ctx.target.value)
+        t_resolved = ctx.clock.for_payload(resolved)
         resolve_raw_id = ctx.store.add_raw(
-            resolved.get("_", "ResolvedPeer"), resolved, ctx.tier, {"target": ctx.target.raw}
+            resolved.get("_", "ResolvedPeer"), resolved, ctx.tier, {"target": ctx.target.raw},
+            observed_at=t_resolved,
         )
         chan = _pick_channel(resolved.get("chats", []), _resolved_channel_id(resolved))
         input_channel = {"channel_id": chan["id"], "access_hash": chan["access_hash"]}
 
         full = await ctx.gateway.get_full_channel(input_channel)
+        t_full = ctx.clock.for_payload(full)
         full_raw_id = ctx.store.add_raw(
-            full.get("_", "ChatFull"), full, ctx.tier, {"channel_id": chan["id"]}
+            full.get("_", "ChatFull"), full, ctx.tier, {"channel_id": chan["id"]},
+            observed_at=t_full,
         )
         full_chat = full["full_chat"]
         # getFullChannel(input_channel) must answer for the channel we asked
@@ -117,7 +123,7 @@ class ChannelCollector:
 
         channel_id = chan_for_channel["id"]
         channel_uri_ = upsert_channel(
-            ctx.store, full_chat, chan_for_channel, full_raw_id, observed_at
+            ctx.store, full_chat, chan_for_channel, full_raw_id, t_full
         )
 
         set_state(ctx.store, "channel", str(channel_id), {"pts": full_chat["pts"]})
@@ -126,14 +132,16 @@ class ChannelCollector:
         if linked_chat_id:
             add_edge(
                 ctx.store, channel_uri_, "linked_group", channel_uri(linked_chat_id),
-                observed_at, ctx.tier, full_raw_id,
+                t_full, ctx.tier, full_raw_id,
                 {"field": "linked_chat_id"},
             )
 
-        for source_raw_id, payload in ((resolve_raw_id, resolved), (full_raw_id, full)):
+        for source_raw_id, payload, t in (
+            (resolve_raw_id, resolved, t_resolved), (full_raw_id, full, t_full),
+        ):
             for obj in (*payload.get("chats", []), *payload.get("users", [])):
                 uri = upsert_peer(
-                    ctx.store, obj, source_raw_id, observed_at,
+                    ctx.store, obj, source_raw_id, t,
                     seen_in_chat=None, seen_in_msg=None,
                 )
                 if uri is not None:  # None => self, kept out of the store (#12)

--- a/src/paperboy/collectors/channel.py
+++ b/src/paperboy/collectors/channel.py
@@ -4,6 +4,7 @@ project it, and prime `ctx` for `history` (and later Phase 2 collectors).
 
 from __future__ import annotations
 
+from paperboy.budget import SkipAndRecord
 from paperboy.collectors.base import CollectContext, CollectResult
 from paperboy.ids import channel_uri, user_uri
 from paperboy.store.channels import upsert_channel
@@ -53,14 +54,15 @@ def _resolved_channel_id(resolved: dict) -> int:
     """The channel id `resolve()` actually resolved to, from its `peer` field.
 
     `contacts.ResolvedPeer` always carries `peer` in the wild; a channel-like
-    target resolving to anything else (a user, a basic group, a malformed
-    payload) means we have no authoritative identity — refuse rather than
-    guess from the `chats` vector.
+    target resolving to anything else (a user or a basic group — a username
+    can legitimately be either, issue #34) means we have no authoritative
+    channel identity here — skip cleanly rather than guess from the `chats`
+    vector or crash the whole run.
     """
     peer = resolved.get("peer") or {}
     channel_id = peer.get("channel_id")
     if not isinstance(channel_id, int):
-        raise ValueError(
+        raise SkipAndRecord(
             "target resolved to a non-channel peer "
             f"({peer.get('_') or 'no peer in response'})"
         )

--- a/src/paperboy/collectors/discussion.py
+++ b/src/paperboy/collectors/discussion.py
@@ -26,7 +26,7 @@ import json
 from paperboy.budget import PhaseStop, SkipAndRecord
 from paperboy.collectors.base import CollectContext, CollectResult
 from paperboy.collectors.history import HistoryCollector
-from paperboy.ids import channel_uri, msg_uri, peer_ref_uri, utc_now_iso
+from paperboy.ids import channel_uri, msg_uri, peer_ref_uri
 from paperboy.store.edges import add_edge_once
 from paperboy.store.events import record_run_event
 from paperboy.store.repliers import backfill_recent_repliers
@@ -183,14 +183,17 @@ class DiscussionCollector:
         channel_id = ctx.channel_id
         mirrors = self._mirror_map(ctx, group_id)
         rows = ctx.store.conn.execute(
-            "SELECT uri, msg_id, from_uri, reply_to_msg_id, reply_to_top_id, source_raw_id "
-            "FROM messages WHERE channel_id=? "
+            "SELECT uri, msg_id, from_uri, reply_to_msg_id, reply_to_top_id, source_raw_id, "
+            "first_seen FROM messages WHERE channel_id=? "
             "AND (reply_to_msg_id IS NOT NULL OR reply_to_top_id IS NOT NULL)",
             (group_id,),
         ).fetchall()
 
         for row in rows:
-            observed_at = utc_now_iso()
+            # The comment's own observation stamp (D3), not "now" — this
+            # re-scans every stored row on every run, so "now" would make the
+            # edge unreproducible from raw alone on reproject.
+            observed_at = row["first_seen"]
             if row["reply_to_msg_id"]:
                 # Every reply gets this, including a direct reply to a thread
                 # root: `replied_to` is comment → parent, with no restriction to

--- a/src/paperboy/collectors/graph.py
+++ b/src/paperboy/collectors/graph.py
@@ -30,7 +30,6 @@ from paperboy.ids import (
     parse_tme_link,
     user_uri,
     username_uri,
-    utc_now_iso,
     utf16_slice,
 )
 from paperboy.store.edges import add_edge_once
@@ -63,8 +62,8 @@ class GraphCollector:
         await self._collect_recommendations(ctx, counts)
 
         rows = ctx.store.conn.execute(
-            "SELECT channel_id, msg_id, text, entities_json, source_raw_id FROM messages "
-            "WHERE channel_id=? AND entities_json IS NOT NULL",
+            "SELECT channel_id, msg_id, text, entities_json, source_raw_id, first_seen "
+            "FROM messages WHERE channel_id=? AND entities_json IS NOT NULL",
             (ctx.channel_id,),
         ).fetchall()
         mention_edges, invite_hashes = _scan_message_entities(rows)
@@ -84,9 +83,10 @@ class GraphCollector:
             counts["skipped"] += 1
             return
 
-        observed_at = utc_now_iso()
+        observed_at = ctx.clock.for_payload(result)
         raw_id = ctx.store.add_raw(
-            result.get("_", "ChatsSlice"), result, ctx.tier, {"channel_id": ctx.channel_id}
+            result.get("_", "ChatsSlice"), result, ctx.tier, {"channel_id": ctx.channel_id},
+            observed_at=observed_at,
         )
         counts["raw"] += 1
         chats = result.get("chats", [])
@@ -114,11 +114,14 @@ class GraphCollector:
     def _write_mention_edges(
         self,
         ctx: CollectContext,
-        mention_edges: list[tuple[str, str, dict, int | None]],
+        mention_edges: list[tuple[str, str, dict, int | None, str]],
         counts: dict,
     ) -> None:
-        observed_at = utc_now_iso()
-        for subject, object_, evidence, source_raw_id in mention_edges:
+        # `observed_at` here is the message OBSERVATION the mention was found
+        # in (its `first_seen`, D3) — the entity scan itself is RPC-free and
+        # adds no new observation, so it must not stamp "now" (that would make
+        # the edge unreproducible from raw alone on reproject).
+        for subject, object_, evidence, source_raw_id, observed_at in mention_edges:
             if add_edge_once(
                 ctx.store, subject, _MENTIONS, object_, observed_at, ctx.tier, source_raw_id,
                 evidence,
@@ -136,9 +139,10 @@ class GraphCollector:
                 counts["skipped"] += 1
                 continue
 
-            observed_at = utc_now_iso()
+            observed_at = ctx.clock.for_payload(preview)
             raw_id = ctx.store.add_raw(
-                preview.get("_", "ChatInvite"), preview, ctx.tier, {"hash": hash_}
+                preview.get("_", "ChatInvite"), preview, ctx.tier, {"hash": hash_},
+                observed_at=observed_at,
             )
             counts["raw"] += 1
 
@@ -213,16 +217,20 @@ class GraphCollector:
         if kind == "sponsoredmessagesempty":
             return
 
-        observed_at = utc_now_iso()
         subject = channel_uri(ctx.channel_id)
         for sponsored in result.get("messages", []):
+            # Stamped per-message, not once for the envelope: on replay the
+            # envelope itself is synthetic (D4.2 — reconstructed from the
+            # individually-stored SponsoredMessage records), so only the
+            # per-message lookup has a registered clock stamp.
+            observed_at = ctx.clock.for_payload(sponsored)
             # No dedicated table (spec instruction) — raw + edges only. Every
             # sponsored message is raw-logged individually (not just the
             # envelope) so `sponsor_info`/`url`/`title` are each queryable
             # from `raw_records` without re-parsing the batch.
             raw_id = ctx.store.add_raw(
                 sponsored.get("_", "SponsoredMessage"), sponsored, ctx.tier,
-                {"channel_id": ctx.channel_id},
+                {"channel_id": ctx.channel_id}, observed_at=observed_at,
             )
             counts["raw"] += 1
 
@@ -246,16 +254,19 @@ class GraphCollector:
 
 def _scan_message_entities(
     rows: list[sqlite3.Row],
-) -> tuple[list[tuple[str, str, dict, int | None]], dict[str, list[str]]]:
+) -> tuple[list[tuple[str, str, dict, int | None, str]], dict[str, list[str]]]:
     """Walk stored messages' `entities_json` for `MentionName`/`TextUrl`/`Url`
     entities, without any RPC. Returns `(mention_edges, invite_hashes)`:
-    `mention_edges` is `(subject_uri, object_uri, evidence, source_raw_id)`
-    ready for `add_edge` (provenance borrowed from the message's own raw
-    record); `invite_hashes` maps each distinct invite hash found to the
-    list of message URIs that referenced it, for `_collect_invite_previews`
-    to dedupe the `checkChatInvite` RPC by hash rather than by mention.
+    `mention_edges` is `(subject_uri, object_uri, evidence, source_raw_id,
+    observed_at)` ready for `add_edge` (provenance borrowed from the
+    message's own raw record — `observed_at` is the message's own
+    `first_seen`, D3: the scan itself is RPC-free and adds no new
+    observation); `invite_hashes` maps each distinct invite hash found to
+    the list of message URIs that referenced it, for
+    `_collect_invite_previews` to dedupe the `checkChatInvite` RPC by hash
+    rather than by mention.
     """
-    mention_edges: list[tuple[str, str, dict, int | None]] = []
+    mention_edges: list[tuple[str, str, dict, int | None, str]] = []
     invite_hashes: dict[str, list[str]] = {}
 
     for row in rows:
@@ -263,6 +274,7 @@ def _scan_message_entities(
         text = row["text"] or ""
         uri = msg_uri(row["channel_id"], row["msg_id"])
         source_raw_id = row["source_raw_id"]
+        observed_at = row["first_seen"]
 
         for entity in entities:
             kind = (entity.get("_") or "").lower()
@@ -271,12 +283,12 @@ def _scan_message_entities(
                 if user_id is not None:
                     mention_edges.append((
                         uri, user_uri(user_id),
-                        {"entity": "MessageEntityMentionName"}, source_raw_id,
+                        {"entity": "MessageEntityMentionName"}, source_raw_id, observed_at,
                     ))
             elif kind == "messageentitytexturl":
                 _record_link(
                     uri, entity.get("url", ""), "MessageEntityTextUrl", source_raw_id,
-                    mention_edges, invite_hashes,
+                    observed_at, mention_edges, invite_hashes,
                 )
             elif kind == "messageentityurl":
                 offset, length = entity.get("offset"), entity.get("length")
@@ -284,7 +296,8 @@ def _scan_message_entities(
                     continue
                 url = utf16_slice(text, offset, length)
                 _record_link(
-                    uri, url, "MessageEntityUrl", source_raw_id, mention_edges, invite_hashes
+                    uri, url, "MessageEntityUrl", source_raw_id, observed_at,
+                    mention_edges, invite_hashes,
                 )
             # else: MessageEntityMention (bare @name) and every other entity
             # kind (bold, code, custom emoji, ...) carry nothing graph-shaped.
@@ -297,7 +310,8 @@ def _record_link(
     url: str,
     entity_name: str,
     source_raw_id: int | None,
-    mention_edges: list[tuple[str, str, dict, int | None]],
+    observed_at: str,
+    mention_edges: list[tuple[str, str, dict, int | None, str]],
     invite_hashes: dict[str, list[str]],
 ) -> None:
     parsed = parse_tme_link(url)
@@ -306,7 +320,7 @@ def _record_link(
     kind, value = parsed
     object_uri = invite_uri(value) if kind == "invite" else username_uri(value)
     mention_edges.append((
-        subject_uri, object_uri, {"entity": entity_name, "url": url}, source_raw_id,
+        subject_uri, object_uri, {"entity": entity_name, "url": url}, source_raw_id, observed_at,
     ))
     if kind == "invite":
         invite_hashes.setdefault(value, []).append(subject_uri)

--- a/src/paperboy/collectors/history.py
+++ b/src/paperboy/collectors/history.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from paperboy.budget import PhaseStop
 from paperboy.collectors.base import CollectContext, CollectResult
-from paperboy.ids import msg_uri, peer_ref_uri, utc_now_iso
+from paperboy.ids import msg_uri, peer_ref_uri
 from paperboy.store.edges import add_edge
 from paperboy.store.messages import mark_deleted, upsert_message
 from paperboy.store.peers import upsert_peer
@@ -181,15 +181,19 @@ class HistoryCollector:
         # `_probe_gaps` uses instead, and stop before the peer/edge
         # projection below, which has nothing to project for a placeholder.
         if m.get("_", "").lower() == "messageempty":
-            observed_at = utc_now_iso()
-            ctx.store.add_raw("MessageEmpty", m, ctx.tier, {"channel_id": channel_id})
+            observed_at = ctx.clock.for_payload(m)
+            ctx.store.add_raw(
+                "MessageEmpty", m, ctx.tier, {"channel_id": channel_id},
+                observed_at=observed_at,
+            )
             mark_deleted(ctx.store, channel_id, m["id"], "empty", observed_at)
             counts["tombstones"] += 1
             return
 
-        observed_at = utc_now_iso()
+        observed_at = ctx.clock.for_payload(m)
         raw_id = ctx.store.add_raw(
-            m.get("_", "Message"), m, ctx.tier, {"channel_id": channel_id}
+            m.get("_", "Message"), m, ctx.tier, {"channel_id": channel_id},
+            observed_at=observed_at,
         )
         uri = msg_uri(channel_id, m["id"])
         before = _latest_revision_hash(ctx, uri)
@@ -244,8 +248,11 @@ class HistoryCollector:
             for r in results:
                 if r.get("_", "").lower() != "messageempty":
                     continue
-                observed_at = utc_now_iso()
-                ctx.store.add_raw("MessageEmpty", r, ctx.tier, {"channel_id": channel_id})
+                observed_at = ctx.clock.for_payload(r)
+                ctx.store.add_raw(
+                    "MessageEmpty", r, ctx.tier, {"channel_id": channel_id},
+                    observed_at=observed_at,
+                )
                 mark_deleted(ctx.store, channel_id, r["id"], "empty", observed_at)
                 counts["tombstones"] += 1
 
@@ -303,8 +310,10 @@ class HistoryCollector:
                 if not exc.counts:
                     raise PhaseStop(str(exc), counts=counts) from exc
                 raise
+            t_diff = ctx.clock.for_payload(diff)
             ctx.store.add_raw(
-                diff.get("_", "ChannelDifference"), diff, ctx.tier, {"channel_id": channel_id}
+                diff.get("_", "ChannelDifference"), diff, ctx.tier, {"channel_id": channel_id},
+                observed_at=t_diff,
             )
 
             if diff.get("_", "").lower() == "channeldifferencetoolong":
@@ -337,7 +346,7 @@ class HistoryCollector:
                     self._observe_message(ctx, channel_id, update["message"], counts)
                 elif kind == "updatedeletechannelmessages":
                     for mid in update.get("messages", []):
-                        mark_deleted(ctx.store, channel_id, mid, "update", utc_now_iso())
+                        mark_deleted(ctx.store, channel_id, mid, "update", t_diff)
                         counts["tombstones"] += 1
 
             new_pts = diff.get("pts", pts)

--- a/src/paperboy/collectors/media.py
+++ b/src/paperboy/collectors/media.py
@@ -32,7 +32,6 @@ from typing import TYPE_CHECKING
 from paperboy.budget import PhaseStop, SkipAndRecord
 from paperboy.collectors.base import CollectContext, CollectResult
 from paperboy.config import profile_dir
-from paperboy.ids import utc_now_iso
 from paperboy.store.db import dumps
 
 if TYPE_CHECKING:
@@ -118,7 +117,7 @@ class MediaCollector:
         content_index = self._load_content_index(ctx, channel_id)
 
         rows = ctx.store.conn.execute(
-            "SELECT uri, msg_id, media_kind, media_json FROM messages "
+            "SELECT uri, msg_id, media_kind, media_json, first_seen FROM messages "
             "WHERE channel_id=? AND media_kind IS NOT NULL AND deleted_at IS NULL "
             "ORDER BY msg_id",
             (channel_id,),
@@ -134,7 +133,10 @@ class MediaCollector:
             key = _content_key(media)
             if key is not None and key in content_index:
                 sha, path = content_index[key]
-                self._record_custody(ctx, path, sha, row["uri"])
+                # A dedup hit derives from the STORED message row, not a
+                # fresh download (D3) — its own `first_seen` is the
+                # observation, not "now".
+                self._record_custody(ctx, path, sha, row["uri"], row["first_seen"])
                 counts["duplicates"] += 1
                 continue
 
@@ -157,7 +159,8 @@ class MediaCollector:
             if existing is not None:
                 # Safety-net dedup: two distinct document/photo ids hashed to
                 # the same bytes (or `key` was None, e.g. a malformed dict).
-                self._record_custody(ctx, existing, sha, row["uri"])
+                # Same D3 rationale as the content_index hit above.
+                self._record_custody(ctx, existing, sha, row["uri"], row["first_seen"])
                 counts["duplicates"] += 1
                 if key is not None:
                     content_index[key] = (sha, existing)
@@ -172,11 +175,19 @@ class MediaCollector:
                 mime_type, file_name, attributes = _document_attrs(media)
             ext = _guess_ext(kind, mime_type, file_name)
             path = media_root / sha[:2] / f"{sha}{ext}"
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_bytes(data)
+            # Content-addressed: an existing path is already the right bytes.
+            # Guards replay idempotency (spec §4 — reproject never re-writes a
+            # media file) and spares a live re-run a redundant write too.
+            if not path.exists():
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(data)
             path_str = str(path)
 
-            downloaded_at = utc_now_iso()
+            raw_payload = {
+                "sha256": sha, "kind": kind, "size": len(data), "mime_type": mime_type,
+                "file_name": file_name, "path": path_str, "message_uri": row["uri"],
+            }
+            downloaded_at = ctx.clock.for_payload(raw_payload)
             ctx.store.conn.execute(
                 "INSERT INTO media (sha256, message_uri, kind, mime_type, size, file_name, "
                 "attributes_json, path, downloaded_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -186,15 +197,11 @@ class MediaCollector:
                     path_str, downloaded_at,
                 ),
             )
-            self._record_custody(ctx, path_str, sha, row["uri"])
+            self._record_custody(ctx, path_str, sha, row["uri"], downloaded_at)
             ctx.store.add_raw(
-                "MediaDownload",
-                {
-                    "sha256": sha, "kind": kind, "size": len(data), "mime_type": mime_type,
-                    "file_name": file_name, "path": path_str, "message_uri": row["uri"],
-                },
-                ctx.tier,
+                "MediaDownload", raw_payload, ctx.tier,
                 {"channel_id": channel_id, "msg_id": row["msg_id"]},
+                observed_at=downloaded_at,
             )
             counts["downloaded"] += 1
             if key is not None:
@@ -228,9 +235,11 @@ class MediaCollector:
         row = ctx.store.conn.execute("SELECT path FROM media WHERE sha256=?", (sha,)).fetchone()
         return row["path"] if row else None
 
-    def _record_custody(self, ctx: CollectContext, path: str, sha: str, message_uri: str) -> None:
+    def _record_custody(
+        self, ctx: CollectContext, path: str, sha: str, message_uri: str, recorded_at: str
+    ) -> None:
         ctx.store.conn.execute(
             "INSERT INTO custody_log (path, sha256, recorded_at, source_message_uri) "
             "VALUES (?, ?, ?, ?)",
-            (path, sha, utc_now_iso(), message_uri),
+            (path, sha, recorded_at, message_uri),
         )

--- a/src/paperboy/collectors/web.py
+++ b/src/paperboy/collectors/web.py
@@ -23,7 +23,7 @@ from paperboy.ids import msg_uri
 from paperboy.store.sync import set_state
 from paperboy.store.web import insert_tme_snapshot, insert_wayback_snapshot
 from paperboy.targets import Target, TargetKind
-from paperboy.web.client import WebClient
+from paperboy.web.client import WebClient, WebGetter
 from paperboy.web.tme_parser import TmePost, parse_tme_page
 from paperboy.web.wayback import cdx_timestamp_to_iso, parse_cdx_rows
 
@@ -106,7 +106,7 @@ class WebCollector:
     def __init__(
         self,
         *,
-        client: WebClient | None = None,
+        client: WebGetter | None = None,
         min_interval: float = _DEFAULT_MIN_INTERVAL_SECONDS,
         sleep: Callable[[float], None] | None = None,
     ) -> None:
@@ -117,12 +117,12 @@ class WebCollector:
     def applies_to(self, target: Target) -> bool:
         return target.is_channel_like
 
-    def _get_client(self, ctx: CollectContext) -> WebClient:
+    def _get_client(self, ctx: CollectContext) -> WebGetter:
         if self._client is None:
             self._client = WebClient(proxy=ctx.settings.proxy)
         return self._client
 
-    def _paced_get(self, client: WebClient, url: str) -> httpx.Response:
+    def _paced_get(self, client: WebGetter, url: str) -> httpx.Response:
         self._sleep(self._min_interval)
         return client.get(url)
 
@@ -139,7 +139,7 @@ class WebCollector:
         return CollectResult(name=self.name, counts=counts)
 
     def _collect_tme(
-        self, ctx: CollectContext, client: WebClient, username: str, channel_id: int | None
+        self, ctx: CollectContext, client: WebGetter, username: str, channel_id: int | None
     ) -> dict[str, int]:
         counts = {"tme_posts": 0, "deleted_recovered": 0}
         # Always start from the NEWEST posts each run (t.me/s with no
@@ -238,7 +238,7 @@ class WebCollector:
             counts["deleted_recovered"] += 1
 
     def _collect_wayback(
-        self, ctx: CollectContext, client: WebClient, username: str
+        self, ctx: CollectContext, client: WebGetter, username: str
     ) -> dict[str, int]:
         # Bound the query: an unbounded `url=t.me/s/<name>*` CDX search on a
         # heavily-archived channel returns hundreds of thousands of rows (a

--- a/src/paperboy/collectors/web.py
+++ b/src/paperboy/collectors/web.py
@@ -19,7 +19,7 @@ import httpx
 
 from paperboy.budget import SkipAndRecord
 from paperboy.collectors.base import CollectContext, CollectResult
-from paperboy.ids import msg_uri, utc_now_iso
+from paperboy.ids import msg_uri
 from paperboy.store.sync import set_state
 from paperboy.store.web import insert_tme_snapshot, insert_wayback_snapshot
 from paperboy.targets import Target, TargetKind
@@ -157,12 +157,13 @@ class WebCollector:
                 url += f"?before={before_cursor}"
 
             response = self._paced_get(client, url)
-            fetched_at = utc_now_iso()
+            raw_payload = {
+                "url": url, "status_code": response.status_code, "text": response.text,
+            }
+            fetched_at = ctx.clock.for_payload(raw_payload)
             ctx.store.add_raw(
-                "tme_page",
-                {"url": url, "status_code": response.status_code, "text": response.text},
-                ctx.tier,
-                {"channel_username": username},
+                "tme_page", raw_payload, ctx.tier,
+                {"channel_username": username}, observed_at=fetched_at,
             )
 
             if _is_ambiguous_failure(response.status_code):
@@ -249,12 +250,13 @@ class WebCollector:
             f"&output=json&filter=statuscode:200&collapse=digest&limit={_WAYBACK_CDX_LIMIT}"
         )
         response = self._paced_get(client, url)
-        fetched_at = utc_now_iso()
+        raw_payload = {
+            "url": url, "status_code": response.status_code, "text": response.text,
+        }
+        fetched_at = ctx.clock.for_payload(raw_payload)
         ctx.store.add_raw(
-            "wayback_cdx",
-            {"url": url, "status_code": response.status_code, "text": response.text},
-            ctx.tier,
-            {"channel_username": username},
+            "wayback_cdx", raw_payload, ctx.tier,
+            {"channel_username": username}, observed_at=fetched_at,
         )
 
         if _is_ambiguous_failure(response.status_code):

--- a/src/paperboy/recipes.py
+++ b/src/paperboy/recipes.py
@@ -24,6 +24,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from paperboy.budget import HardStop, PhaseStop, SkipAndRecord
+from paperboy.clock import LiveClock
 from paperboy.collectors.base import CollectContext, CollectResult
 from paperboy.collectors.channel import ChannelCollector
 from paperboy.collectors.discussion import DiscussionCollector
@@ -35,6 +36,7 @@ from paperboy.progress import Progress
 from paperboy.store.events import record_run_event
 
 if TYPE_CHECKING:
+    from paperboy.clock import Clock
     from paperboy.collectors.base import Collector
     from paperboy.config import Settings
     from paperboy.gateway import Gateway
@@ -107,6 +109,7 @@ async def collect_channel(
     media: bool = False,
     web: bool = False,
     profile: str = "default",
+    clock: Clock | None = None,
 ) -> list[CollectResult]:
     """Run `channel`, then `history` (+ its `catch_up`), then `graph`, against `target`.
 
@@ -117,9 +120,14 @@ async def collect_channel(
     for `media`'s content-addressed download path. `collectors` overrides the
     default active list entirely — used by tests to inject a stub that raises
     `HardStop`/`PhaseStop`/`SkipAndRecord` without needing a real gateway
-    failure to trigger one.
+    failure to trigger one. `clock` (default `LiveClock()`) is where every
+    projection's `observed_at` comes from — `reproject` passes a `ReplayClock`
+    fed by the replay gateway so timestamps are reproduced from raw (spec §5).
     """
-    ctx = CollectContext(gateway, store, settings, target, None, None, "stranger", log, profile)
+    ctx = CollectContext(
+        gateway, store, settings, target, None, None, "stranger", log, profile,
+        clock or LiveClock(),
+    )
     include_media = media or (phases is not None and "media" in phases)
     include_web = web or (phases is not None and "web" in phases)
     active = collectors if collectors is not None else _default_collectors(

--- a/src/paperboy/recipes.py
+++ b/src/paperboy/recipes.py
@@ -110,6 +110,7 @@ async def collect_channel(
     web: bool = False,
     profile: str = "default",
     clock: Clock | None = None,
+    run_id: str | None = None,
 ) -> list[CollectResult]:
     """Run `channel`, then `history` (+ its `catch_up`), then `graph`, against `target`.
 
@@ -123,7 +124,12 @@ async def collect_channel(
     failure to trigger one. `clock` (default `LiveClock()`) is where every
     projection's `observed_at` comes from — `reproject` passes a `ReplayClock`
     fed by the replay gateway so timestamps are reproduced from raw (spec §5).
+    `run_id` (ADR-0005) marks every raw record this call writes as belonging
+    to one collect pass — `None` (live callers) mints a fresh opaque id;
+    `reproject` passes the SOURCE run's id so a reprojected DB carries the
+    same pass boundaries and is itself re-reprojectable.
     """
+    store.begin_run(run_id)
     ctx = CollectContext(
         gateway, store, settings, target, None, None, "stranger", log, profile,
         clock or LiveClock(),

--- a/src/paperboy/replay.py
+++ b/src/paperboy/replay.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Self
 
@@ -23,6 +24,24 @@ from paperboy.budget import SkipAndRecord
 from paperboy.clock import ReplayClock
 from paperboy.store.db import dumps
 from paperboy.targets import parse_target
+
+
+class ReprojectSourceError(Exception):
+    """The source raw log's run structure cannot be trusted (ADR-0005) — a
+    corrupt or hand-edited DB, never a data condition a normal collect could
+    produce. Operator-facing: `reproject.py`/`cli.py` catch it."""
+
+
+@dataclass(frozen=True)
+class ReplayRun:
+    """One historical collect pass (ADR-0005), as a contiguous `raw_records`
+    rowid range. `run_id` is the real stamped id for a post-migration pass,
+    or an inferred `legacy-NNNN` label (capture order) for pre-migration rows
+    — see `ReplaySource.runs()`."""
+
+    run_id: str
+    lo: int  # first raw rowid of the pass (inclusive)
+    hi: int  # last raw rowid of the pass (inclusive)
 
 
 def _kind_clause(kinds: tuple[str, ...]) -> tuple[str, tuple[str, ...]]:
@@ -65,55 +84,118 @@ class ReplaySource:
     def __exit__(self, *exc_info: object) -> None:
         self.close()
 
-    def resolve_targets(self) -> list[str]:
-        """Every distinct `target` a `resolve()` was recorded against, in
-        first-seen (capture) order — `reproject` re-runs a full collect per
-        target."""
+    def runs(self) -> list[ReplayRun]:
+        """Capture-ordered collect passes (ADR-0005). Stamped rows group by
+        `run_id`; legacy NULL rows are segmented at each `tier='self'` User
+        record — every collect pass's first raw write (`collectors/channel.py`
+        writes self before anything, and the CLI refuses dependent phases
+        without `channel`) — rows before the first marker join the first
+        segment. Runs must be contiguous rowid ranges (one sequential process
+        per pass); interleaving means a corrupt source and fails loudly."""
+        rows = self.conn.execute(
+            "SELECT id, run_id, tier, lower(kind) AS k FROM raw_records ORDER BY id"
+        ).fetchall()
+        runs: list[ReplayRun] = []
+        current_id: str | None = None
+        legacy_n = 0
+        lo: int | None = None
+        hi: int | None = None
+        seen_run_ids: set[str] = set()
+
+        def _flush() -> None:
+            nonlocal lo, hi
+            if lo is not None:
+                assert current_id is not None
+                assert hi is not None
+                runs.append(ReplayRun(current_id, lo, hi))
+                lo = hi = None
+
+        for row in rows:
+            next_id: str
+            if row["run_id"] is not None:
+                stamped_id: str = row["run_id"]
+                boundary = stamped_id != current_id
+                next_id = stamped_id
+            else:
+                is_marker = row["tier"] == "self" and (
+                    row["k"] == "user" or row["k"].endswith(".user")
+                )
+                boundary = is_marker or current_id is None
+                if boundary:
+                    next_id = f"legacy-{legacy_n + 1:04d}"
+                else:
+                    assert current_id is not None  # boundary is False => not the first row
+                    next_id = current_id
+            if boundary:
+                _flush()
+                if next_id in seen_run_ids:
+                    raise ReprojectSourceError(
+                        f"raw log run {next_id!r} is not contiguous — refusing to replay"
+                    )
+                seen_run_ids.add(next_id)
+                if row["run_id"] is None:
+                    legacy_n += 1
+                current_id = next_id
+                lo = row["id"]
+            hi = row["id"]
+        _flush()
+        return runs
+
+    def resolve_targets(self, run: ReplayRun) -> list[str]:
+        """Every distinct `target` a `resolve()` was recorded against WITHIN
+        `run`, in first-seen (capture) order — `reproject` re-runs a full
+        collect per target per historical run (ADR-0005)."""
         kind_sql, kind_params = _kind_clause(("resolvedpeer",))
         rows = self.conn.execute(
             "SELECT json_extract(context_json, '$.target') AS target FROM raw_records "
-            f"WHERE {kind_sql} AND target IS NOT NULL ORDER BY id",
-            kind_params,
+            f"WHERE {kind_sql} AND target IS NOT NULL AND id BETWEEN ? AND ? ORDER BY id",
+            (*kind_params, run.lo, run.hi),
         ).fetchall()
         seen: dict[str, None] = {}
         for r in rows:
             seen.setdefault(r["target"])
         return list(seen)
 
-    def linked_group_ids(self) -> set[int]:
+    def linked_group_ids(self, run: ReplayRun) -> set[int]:
         kind_sql, kind_params = _kind_clause(("chatfull",))
         rows = self.conn.execute(
             "SELECT json_extract(payload_json, '$.full_chat.linked_chat_id') AS g "
-            f"FROM raw_records WHERE {kind_sql}",
-            kind_params,
+            f"FROM raw_records WHERE {kind_sql} AND id BETWEEN ? AND ?",
+            (*kind_params, run.lo, run.hi),
         ).fetchall()
         return {r["g"] for r in rows if r["g"]}
 
-    def has_kind(self, *kinds: str) -> bool:
+    def has_kind(self, run: ReplayRun, *kinds: str) -> bool:
         kind_sql, kind_params = _kind_clause(kinds)
         return self.conn.execute(
-            f"SELECT 1 FROM raw_records WHERE {kind_sql} LIMIT 1",
-            kind_params,
+            f"SELECT 1 FROM raw_records WHERE {kind_sql} AND id BETWEEN ? AND ? LIMIT 1",
+            (*kind_params, run.lo, run.hi),
         ).fetchone() is not None
 
-    def has_context_channel(self, channel_ids: set[int]) -> bool:
+    def has_context_channel(self, run: ReplayRun, channel_ids: set[int]) -> bool:
         return any(
             self.conn.execute(
                 "SELECT 1 FROM raw_records "
-                "WHERE json_extract(context_json, '$.channel_id') = ? LIMIT 1",
-                (cid,),
+                "WHERE json_extract(context_json, '$.channel_id') = ? "
+                "AND id BETWEEN ? AND ? LIMIT 1",
+                (cid, run.lo, run.hi),
             ).fetchone() is not None
             for cid in channel_ids
         )
 
 
 class RawReplayGateway:
-    """`Gateway` served from a raw log. Never touches the network — there is
-    no client, no session, no `Budget` anywhere in this class."""
+    """`Gateway` served from a raw log, scoped to ONE historical `ReplayRun`
+    (ADR-0005) — every query below is additionally bounded to
+    `id BETWEEN run.lo AND run.hi`, so within one run each call site has at
+    most one matching record, same as a live RPC has one now. Never touches
+    the network — there is no client, no session, no `Budget` anywhere in
+    this class."""
 
-    def __init__(self, source: ReplaySource, clock: ReplayClock) -> None:
+    def __init__(self, source: ReplaySource, clock: ReplayClock, run: ReplayRun) -> None:
         self._src = source
         self._clock = clock
+        self._run = run
         # get_channel_difference is inherently sequential (a pts catch-up
         # loop); a per-channel cursor over the stored pages models that.
         self._diff_cursor: dict[int, int] = {}
@@ -124,8 +206,8 @@ class RawReplayGateway:
         kind_sql, kind_params = _kind_clause(kinds)
         return self._src.conn.execute(
             f"SELECT observed_at, payload_json FROM raw_records "
-            f"WHERE {kind_sql} AND {where} ORDER BY id DESC LIMIT 1",
-            (*kind_params, *params),
+            f"WHERE {kind_sql} AND {where} AND id BETWEEN ? AND ? ORDER BY id DESC LIMIT 1",
+            (*kind_params, *params, self._run.lo, self._run.hi),
         ).fetchone()
 
     def _serve(self, row: sqlite3.Row) -> dict:
@@ -139,8 +221,8 @@ class RawReplayGateway:
         rows = self._src.conn.execute(
             "SELECT observed_at, payload_json, "
             "json_extract(context_json, '$.target') AS target "
-            f"FROM raw_records WHERE {kind_sql} ORDER BY id DESC",
-            kind_params,
+            f"FROM raw_records WHERE {kind_sql} AND id BETWEEN ? AND ? ORDER BY id DESC",
+            (*kind_params, self._run.lo, self._run.hi),
         ).fetchall()
         for row in rows:
             raw_target = row["target"]
@@ -181,8 +263,12 @@ class RawReplayGateway:
             f"WHERE {kind_sql} "
             "AND json_extract(context_json, '$.channel_id') = ? "
             "AND (? = 0 OR CAST(json_extract(payload_json, '$.id') AS INTEGER) < ?) "
+            "AND id BETWEEN ? AND ? "
             "ORDER BY msg_id DESC, id ASC",
-            (*kind_params, input_channel["channel_id"], offset_id, offset_id),
+            (
+                *kind_params, input_channel["channel_id"], offset_id, offset_id,
+                self._run.lo, self._run.hi,
+            ),
         ).fetchall()
         # Never split one msg_id's records across pages: the collector's next
         # cursor is `min(page ids)` and the next page takes strictly-below,
@@ -232,8 +318,9 @@ class RawReplayGateway:
             "SELECT observed_at, payload_json FROM raw_records "
             "WHERE lower(kind) LIKE '%channeldifference%' "
             "AND json_extract(context_json, '$.channel_id') = ? "
+            "AND id BETWEEN ? AND ? "
             "ORDER BY id ASC LIMIT 1 OFFSET ?",
-            (channel_id, idx),
+            (channel_id, self._run.lo, self._run.hi, idx),
         ).fetchone()
         self._diff_cursor[channel_id] = idx + 1
 
@@ -244,8 +331,9 @@ class RawReplayGateway:
             # counts already applied this run.
             stamp = self._src.conn.execute(
                 "SELECT MAX(observed_at) AS t FROM raw_records "
-                "WHERE json_extract(context_json, '$.channel_id') = ?",
-                (channel_id,),
+                "WHERE json_extract(context_json, '$.channel_id') = ? "
+                "AND id BETWEEN ? AND ?",
+                (channel_id, self._run.lo, self._run.hi),
             ).fetchone()
             synthetic = {"_": "updates.channelDifferenceEmpty", "final": True, "pts": pts}
             self._clock.begin_batch()
@@ -348,8 +436,9 @@ class RawReplayGateway:
         rows = self._src.conn.execute(
             "SELECT observed_at, payload_json FROM raw_records "
             f"WHERE {kind_sql} "
-            "AND json_extract(context_json, '$.channel_id') = ? ORDER BY id ASC",
-            (*kind_params, input_channel["channel_id"]),
+            "AND json_extract(context_json, '$.channel_id') = ? "
+            "AND id BETWEEN ? AND ? ORDER BY id ASC",
+            (*kind_params, input_channel["channel_id"], self._run.lo, self._run.hi),
         ).fetchall()
         self._clock.begin_batch()
         if not rows:
@@ -365,27 +454,31 @@ class RawReplayGateway:
 
 
 class RawReplayWebClient:
-    """Serve stored `tme_page`/`wayback_cdx` captures as `httpx.Response`s.
+    """Serve stored `tme_page`/`wayback_cdx` captures as `httpx.Response`s,
+    scoped to ONE historical `ReplayRun` (ADR-0005).
 
     Keyed by exact URL — the web collector re-derives the same URL sequence
     from the same parsed posts, so replay requests exactly the recorded set.
-    Repeat captures of one URL (multi-run sources) serve in capture order.
-    An unrecorded URL is a definitive empty 404: the page loop must stop
-    cleanly there, exactly where the original run stopped.
+    Repeat captures of one URL WITHIN a run serve in capture order (a
+    reproject re-instantiates this client per run, so the cursor never
+    crosses a run boundary). An unrecorded URL is a definitive empty 404: the
+    page loop must stop cleanly there, exactly where the original run
+    stopped.
     """
 
-    def __init__(self, source: ReplaySource, clock: ReplayClock) -> None:
+    def __init__(self, source: ReplaySource, clock: ReplayClock, run: ReplayRun) -> None:
         self._src = source
         self._clock = clock
+        self._run = run
         self._served: dict[str, int] = {}  # url -> raw id already served
 
     def get(self, url: str) -> httpx.Response:
         row = self._src.conn.execute(
             "SELECT id, observed_at, payload_json FROM raw_records "
             "WHERE lower(kind) IN ('tme_page', 'wayback_cdx') "
-            "AND json_extract(payload_json, '$.url') = ? AND id > ? "
+            "AND json_extract(payload_json, '$.url') = ? AND id > ? AND id <= ? "
             "ORDER BY id ASC LIMIT 1",
-            (url, self._served.get(url, 0)),
+            (url, self._served.get(url, self._run.lo - 1), self._run.hi),
         ).fetchone()
         if row is None:
             return httpx.Response(404, text="")

--- a/src/paperboy/replay.py
+++ b/src/paperboy/replay.py
@@ -102,14 +102,27 @@ class ReplaySource:
         an archive can predate that invariant and write resolve/full before
         self — found running the R6 real-archive smoke, where it recurred at
         EVERY pass boundary throughout the archive's history, not just its
-        first). A new legacy segment starts at the first opening-cluster row
-        seen after at least one substantive (non-opening) row — so however
-        many of the three opening records are present, and in whatever
-        order, they all land in the SAME segment as each other, and that
-        segment is the one they actually belong to rather than being split
-        off as an orphan with no self record or no resolve to replay a
-        target from (both of which would silently drop that run's data on
-        replay). Runs must be contiguous rowid ranges (one sequential
+        first).
+
+        A candidate new segment starts at the first opening-kind row seen
+        after at least one substantive (non-opening) row, but it is not
+        committed as a boundary until the whole contiguous run of
+        opening-kind rows that follows is known — i.e. until the next
+        substantive row, a stamped row, or the log's end ends it. The
+        boundary is committed only if that cluster contains its own self
+        marker (`tier='self'` `User`); otherwise the cluster is a foreign
+        single-row intrusion — nothing in this codebase stops two `collect`
+        invocations from writing to the same profile concurrently, and a
+        lone `ResolvedPeer`/`ChatFull` from an unrelated short-lived process
+        can land mid-run — and folds into whichever segment is already open
+        instead of orphaning every row after it into a self-less segment
+        that silently fails replay at `get_self()` (found on the real
+        archive: a lone stray resolve mid-`MediaDownload`-loop discarded 157
+        rows, 156 of them genuine historical `MediaDownload` observations).
+        A genuine cluster still absorbs every opening-kind row in it
+        regardless of order, so all three land in the run they actually
+        belong to rather than splitting off an orphan with no target to
+        resolve. Runs must be contiguous rowid ranges (one sequential
         process per pass); interleaving means a corrupt source and fails
         loudly."""
         run_id_expr = "run_id" if self._has_run_id else "NULL AS run_id"
@@ -119,14 +132,24 @@ class ReplaySource:
         runs: list[ReplayRun] = []
         current_id: str | None = None
         legacy_n = 0
-        # True once a substantive (non-opening-cluster) legacy row has been
-        # seen since the last legacy boundary — arms the next opening-kind
-        # row to cut a new segment. Starts True so the very first row (of
-        # either kind) opens segment 1.
-        awaiting_boundary = True
         lo: int | None = None
         hi: int | None = None
         seen_run_ids: set[str] = set()
+        # A contiguous run of legacy opening-kind rows not yet committed to
+        # a boundary decision — see the docstring above.
+        pending: list[sqlite3.Row] = []
+
+        def _is_opening(row: sqlite3.Row) -> bool:
+            k = row["k"]
+            return (
+                (row["tier"] == "self" and (k == "user" or k.endswith(".user")))
+                or k == "resolvedpeer" or k.endswith(".resolvedpeer")
+                or k == "chatfull" or k.endswith(".chatfull")
+            )
+
+        def _is_self_marker(row: sqlite3.Row) -> bool:
+            k = row["k"]
+            return row["tier"] == "self" and (k == "user" or k.endswith(".user"))
 
         def _flush() -> None:
             nonlocal lo, hi
@@ -136,44 +159,56 @@ class ReplaySource:
                 runs.append(ReplayRun(current_id, lo, hi))
                 lo = hi = None
 
-        for row in rows:
-            next_id: str
-            if row["run_id"] is not None:
-                stamped_id: str = row["run_id"]
-                boundary = stamped_id != current_id
-                next_id = stamped_id
-            else:
-                k = row["k"]
-                is_opening = (
-                    (row["tier"] == "self" and (k == "user" or k.endswith(".user")))
-                    or k == "resolvedpeer" or k.endswith(".resolvedpeer")
-                    or k == "chatfull" or k.endswith(".chatfull")
+        def _open_new_legacy(first_id: int) -> None:
+            nonlocal current_id, legacy_n, lo
+            legacy_n += 1
+            next_id = f"legacy-{legacy_n:04d}"
+            if next_id in seen_run_ids:
+                raise ReprojectSourceError(
+                    f"raw log run {next_id!r} is not contiguous — refusing to replay"
                 )
-                boundary = current_id is None or (is_opening and awaiting_boundary)
-                if is_opening:
-                    if boundary:
-                        awaiting_boundary = False
-                    # else: another member of the same opening cluster —
-                    # awaiting_boundary is already False, leave it.
-                else:
-                    awaiting_boundary = True
-                if boundary:
-                    next_id = f"legacy-{legacy_n + 1:04d}"
-                else:
-                    assert current_id is not None  # boundary is False => not the first row
-                    next_id = current_id
-            if boundary:
+            seen_run_ids.add(next_id)
+            current_id = next_id
+            lo = first_id
+
+        def _resolve_pending() -> None:
+            nonlocal hi
+            if not pending:
+                return
+            # No open segment to fold noise into (the very start of the
+            # log) — the cluster must open segment 1 regardless of whether
+            # it happens to contain a self marker.
+            genuine = current_id is None or any(_is_self_marker(r) for r in pending)
+            if genuine:
                 _flush()
-                if next_id in seen_run_ids:
-                    raise ReprojectSourceError(
-                        f"raw log run {next_id!r} is not contiguous — refusing to replay"
-                    )
-                seen_run_ids.add(next_id)
-                if row["run_id"] is None:
-                    legacy_n += 1
-                current_id = next_id
-                lo = row["id"]
+                _open_new_legacy(pending[0]["id"])
+            hi = pending[-1]["id"]
+            pending.clear()
+
+        for row in rows:
+            if row["run_id"] is not None:
+                _resolve_pending()
+                stamped_id: str = row["run_id"]
+                if stamped_id != current_id:
+                    _flush()
+                    if stamped_id in seen_run_ids:
+                        raise ReprojectSourceError(
+                            f"raw log run {stamped_id!r} is not contiguous — "
+                            "refusing to replay"
+                        )
+                    seen_run_ids.add(stamped_id)
+                    current_id = stamped_id
+                    lo = row["id"]
+                hi = row["id"]
+                continue
+            if _is_opening(row):
+                pending.append(row)
+                continue
+            _resolve_pending()
+            if current_id is None:
+                _open_new_legacy(row["id"])
             hi = row["id"]
+        _resolve_pending()
         _flush()
         return runs
 

--- a/src/paperboy/replay.py
+++ b/src/paperboy/replay.py
@@ -25,6 +25,24 @@ from paperboy.store.db import dumps
 from paperboy.targets import parse_target
 
 
+def _kind_clause(kinds: tuple[str, ...]) -> tuple[str, tuple[str, ...]]:
+    """A `WHERE`-fragment matching `lower(kind)` against any of `kinds`,
+    tolerant of the dotted namespace prefix Telethon's `to_dict()` adds to
+    some RPC-result envelope types (`contacts.resolvedPeer` for
+    `ResolvedPeer`, `messages.chatFull` for `ChatFull`) but not others
+    (`Message`, `ChatInvite*`, `SponsoredMessage`, `MediaDownload`, ...).
+    Collectors record `payload.get("_", ...)` verbatim, so replay must match
+    whichever shape the source actually stored, not assume one.
+    """
+    parts: list[str] = []
+    params: list[str] = []
+    for k in kinds:
+        parts.append("(lower(kind) = ? OR lower(kind) LIKE ?)")
+        params.append(k)
+        params.append(f"%.{k}")
+    return "(" + " OR ".join(parts) + ")", tuple(params)
+
+
 class ReplaySource:
     """Read-only access to a source DB's raw log + its content-addressed media."""
 
@@ -51,9 +69,11 @@ class ReplaySource:
         """Every distinct `target` a `resolve()` was recorded against, in
         first-seen (capture) order — `reproject` re-runs a full collect per
         target."""
+        kind_sql, kind_params = _kind_clause(("resolvedpeer",))
         rows = self.conn.execute(
             "SELECT json_extract(context_json, '$.target') AS target FROM raw_records "
-            "WHERE lower(kind) = 'resolvedpeer' AND target IS NOT NULL ORDER BY id"
+            f"WHERE {kind_sql} AND target IS NOT NULL ORDER BY id",
+            kind_params,
         ).fetchall()
         seen: dict[str, None] = {}
         for r in rows:
@@ -61,17 +81,19 @@ class ReplaySource:
         return list(seen)
 
     def linked_group_ids(self) -> set[int]:
+        kind_sql, kind_params = _kind_clause(("chatfull",))
         rows = self.conn.execute(
             "SELECT json_extract(payload_json, '$.full_chat.linked_chat_id') AS g "
-            "FROM raw_records WHERE lower(kind) = 'chatfull'"
+            f"FROM raw_records WHERE {kind_sql}",
+            kind_params,
         ).fetchall()
         return {r["g"] for r in rows if r["g"]}
 
     def has_kind(self, *kinds: str) -> bool:
-        qmarks = ",".join("?" * len(kinds))
+        kind_sql, kind_params = _kind_clause(kinds)
         return self.conn.execute(
-            f"SELECT 1 FROM raw_records WHERE lower(kind) IN ({qmarks}) LIMIT 1",
-            kinds,
+            f"SELECT 1 FROM raw_records WHERE {kind_sql} LIMIT 1",
+            kind_params,
         ).fetchone() is not None
 
     def has_context_channel(self, channel_ids: set[int]) -> bool:
@@ -99,11 +121,11 @@ class RawReplayGateway:
     def _latest(
         self, kinds: tuple[str, ...], where: str, params: tuple
     ) -> sqlite3.Row | None:
-        qmarks = ",".join("?" * len(kinds))
+        kind_sql, kind_params = _kind_clause(kinds)
         return self._src.conn.execute(
             f"SELECT observed_at, payload_json FROM raw_records "
-            f"WHERE lower(kind) IN ({qmarks}) AND {where} ORDER BY id DESC LIMIT 1",
-            (*kinds, *params),
+            f"WHERE {kind_sql} AND {where} ORDER BY id DESC LIMIT 1",
+            (*kind_params, *params),
         ).fetchone()
 
     def _serve(self, row: sqlite3.Row) -> dict:
@@ -113,10 +135,12 @@ class RawReplayGateway:
         return payload
 
     async def resolve(self, target_value: str) -> dict:
+        kind_sql, kind_params = _kind_clause(("resolvedpeer",))
         rows = self._src.conn.execute(
             "SELECT observed_at, payload_json, "
             "json_extract(context_json, '$.target') AS target "
-            "FROM raw_records WHERE lower(kind) = 'resolvedpeer' ORDER BY id DESC"
+            f"FROM raw_records WHERE {kind_sql} ORDER BY id DESC",
+            kind_params,
         ).fetchall()
         for row in rows:
             raw_target = row["target"]
@@ -149,15 +173,16 @@ class RawReplayGateway:
         # cursor. Secondary order id ASC (capture order) so an edited
         # message's revisions replay oldest-first. MessageEmpty is excluded —
         # getHistory never yielded one; they came from the probe.
+        kind_sql, kind_params = _kind_clause(("message", "messageservice"))
         rows = self._src.conn.execute(
             "SELECT id, observed_at, payload_json, "
             "CAST(json_extract(payload_json, '$.id') AS INTEGER) AS msg_id "
             "FROM raw_records "
-            "WHERE lower(kind) IN ('message', 'messageservice') "
+            f"WHERE {kind_sql} "
             "AND json_extract(context_json, '$.channel_id') = ? "
             "AND (? = 0 OR CAST(json_extract(payload_json, '$.id') AS INTEGER) < ?) "
             "ORDER BY msg_id DESC, id ASC",
-            (input_channel["channel_id"], offset_id, offset_id),
+            (*kind_params, input_channel["channel_id"], offset_id, offset_id),
         ).fetchall()
         # Never split one msg_id's records across pages: the collector's next
         # cursor is `min(page ids)` and the next page takes strictly-below,
@@ -199,9 +224,13 @@ class RawReplayGateway:
         del limit
         channel_id = input_channel["channel_id"]
         idx = self._diff_cursor.get(channel_id, 0)
+        # Substring, not prefix/suffix: the stored kind is one of
+        # `updates.channelDifference`/`...Empty`/`...TooLong` — namespaced
+        # AND suffixed, so `_kind_clause`'s suffix tolerance doesn't cover
+        # it; a plain "contains" match does.
         row = self._src.conn.execute(
             "SELECT observed_at, payload_json FROM raw_records "
-            "WHERE lower(kind) LIKE 'channeldifference%' "
+            "WHERE lower(kind) LIKE '%channeldifference%' "
             "AND json_extract(context_json, '$.channel_id') = ? "
             "ORDER BY id ASC LIMIT 1 OFFSET ?",
             (channel_id, idx),
@@ -315,11 +344,12 @@ class RawReplayGateway:
         return {"_": "Updates", "updates": []}
 
     async def get_sponsored_messages(self, input_channel: dict) -> dict:
+        kind_sql, kind_params = _kind_clause(("sponsoredmessage",))
         rows = self._src.conn.execute(
             "SELECT observed_at, payload_json FROM raw_records "
-            "WHERE lower(kind) = 'sponsoredmessage' "
+            f"WHERE {kind_sql} "
             "AND json_extract(context_json, '$.channel_id') = ? ORDER BY id ASC",
-            (input_channel["channel_id"],),
+            (*kind_params, input_channel["channel_id"]),
         ).fetchall()
         self._clock.begin_batch()
         if not rows:

--- a/src/paperboy/replay.py
+++ b/src/paperboy/replay.py
@@ -108,9 +108,22 @@ class ReplaySource:
         after at least one substantive (non-opening) row, but it is not
         committed as a boundary until the whole contiguous run of
         opening-kind rows that follows is known — i.e. until the next
-        substantive row, a stamped row, or the log's end ends it. The
-        boundary is committed only if that cluster contains its own self
-        marker (`tier='self'` `User`); otherwise the cluster is a foreign
+        substantive row, a stamped row, or the log's end ends it.
+
+        One collect pass writes each opening role — self / ResolvedPeer /
+        ChatFull — AT MOST ONCE. A contiguous run of opening-kind rows can
+        therefore still span more than one pass (e.g. two back-to-back
+        `--phases channel` runs, which write nothing but their own opening
+        cluster and never hit a substantive row to end the pending cluster
+        in between) — found running this fix's own regression battery. The
+        pending cluster is split into one SUB-cluster per pass by cutting at
+        the first REPEATED role: a second `self`/`ResolvedPeer`/`ChatFull`
+        seen starts the next pass's sub-cluster rather than extending the
+        current one.
+
+        Each sub-cluster is then committed as a boundary only if it contains
+        its own self marker (`tier='self'` `User`) — or nothing is open yet
+        (the very start of the log); otherwise the sub-cluster is a foreign
         single-row intrusion — nothing in this codebase stops two `collect`
         invocations from writing to the same profile concurrently, and a
         lone `ResolvedPeer`/`ChatFull` from an unrelated short-lived process
@@ -119,7 +132,7 @@ class ReplaySource:
         that silently fails replay at `get_self()` (found on the real
         archive: a lone stray resolve mid-`MediaDownload`-loop discarded 157
         rows, 156 of them genuine historical `MediaDownload` observations).
-        A genuine cluster still absorbs every opening-kind row in it
+        A genuine sub-cluster still absorbs every opening-kind row in it
         regardless of order, so all three land in the run they actually
         belong to rather than splitting off an orphan with no target to
         resolve. Runs must be contiguous rowid ranges (one sequential
@@ -151,6 +164,16 @@ class ReplaySource:
             k = row["k"]
             return row["tier"] == "self" and (k == "user" or k.endswith(".user"))
 
+        def _opening_role(row: sqlite3.Row) -> str:
+            """Which opening role `row` is — self / resolvedpeer / chatfull.
+            Only ever called on rows `_is_opening()` already matched."""
+            if _is_self_marker(row):
+                return "self"
+            k = row["k"]
+            if k == "resolvedpeer" or k.endswith(".resolvedpeer"):
+                return "resolvedpeer"
+            return "chatfull"
+
         def _flush() -> None:
             nonlocal lo, hi
             if lo is not None:
@@ -175,14 +198,32 @@ class ReplaySource:
             nonlocal hi
             if not pending:
                 return
-            # No open segment to fold noise into (the very start of the
-            # log) — the cluster must open segment 1 regardless of whether
-            # it happens to contain a self marker.
-            genuine = current_id is None or any(_is_self_marker(r) for r in pending)
-            if genuine:
-                _flush()
-                _open_new_legacy(pending[0]["id"])
-            hi = pending[-1]["id"]
+            # Split the pending cluster into one sub-cluster per collect
+            # pass: walk it accumulating a sub-cluster, and when a row's
+            # opening role has already been seen in the CURRENT sub-cluster,
+            # that role is starting over — close the sub-cluster and start a
+            # new one at that row (see the docstring above).
+            sub_clusters: list[list[sqlite3.Row]] = []
+            sub: list[sqlite3.Row] = []
+            seen_roles: set[str] = set()
+            for row in pending:
+                role = _opening_role(row)
+                if role in seen_roles:
+                    sub_clusters.append(sub)
+                    sub, seen_roles = [], set()
+                sub.append(row)
+                seen_roles.add(role)
+            sub_clusters.append(sub)
+
+            for cluster in sub_clusters:
+                # No open segment to fold noise into (the very start of the
+                # log) — the cluster must open segment 1 regardless of
+                # whether it happens to contain a self marker.
+                genuine = current_id is None or any(_is_self_marker(r) for r in cluster)
+                if genuine:
+                    _flush()
+                    _open_new_legacy(cluster[0]["id"])
+                hi = cluster[-1]["id"]
             pending.clear()
 
         for row in rows:

--- a/src/paperboy/replay.py
+++ b/src/paperboy/replay.py
@@ -95,21 +95,23 @@ class ReplaySource:
 
     def runs(self) -> list[ReplayRun]:
         """Capture-ordered collect passes (ADR-0005). Stamped rows group by
-        `run_id`; legacy NULL rows are segmented at each `tier='self'` User
-        record — every collect pass's first raw write under the CURRENT
-        collector (`collectors/channel.py` writes self before anything, and
-        the CLI refuses dependent phases without `channel`).
-
-        A real archive can predate that invariant (found running the R6
-        real-archive smoke, ADR-0005): its earliest pass(es) wrote
-        resolve/full BEFORE self. Only the SECOND and later self markers cut
-        a new segment — the first one encountered confirms/continues
-        whatever segment is already open, so any pre-invariant leading rows
-        stay attached to the run they actually belong to instead of forming
-        an orphan segment with no self record (which would then have no
-        target to resolve on replay, silently dropping that run's data).
-        Runs must be contiguous rowid ranges (one sequential process per
-        pass); interleaving means a corrupt source and fails loudly."""
+        `run_id`. Legacy NULL rows are segmented at each collect pass's
+        OPENING CLUSTER — `resolve()`'s `ResolvedPeer`, `getFullChannel()`'s
+        `ChatFull`, and the self `User` record, whatever order the collector
+        version that captured them wrote them in (current code: self first;
+        an archive can predate that invariant and write resolve/full before
+        self — found running the R6 real-archive smoke, where it recurred at
+        EVERY pass boundary throughout the archive's history, not just its
+        first). A new legacy segment starts at the first opening-cluster row
+        seen after at least one substantive (non-opening) row — so however
+        many of the three opening records are present, and in whatever
+        order, they all land in the SAME segment as each other, and that
+        segment is the one they actually belong to rather than being split
+        off as an orphan with no self record or no resolve to replay a
+        target from (both of which would silently drop that run's data on
+        replay). Runs must be contiguous rowid ranges (one sequential
+        process per pass); interleaving means a corrupt source and fails
+        loudly."""
         run_id_expr = "run_id" if self._has_run_id else "NULL AS run_id"
         rows = self.conn.execute(
             f"SELECT id, {run_id_expr}, tier, lower(kind) AS k FROM raw_records ORDER BY id"
@@ -117,7 +119,11 @@ class ReplaySource:
         runs: list[ReplayRun] = []
         current_id: str | None = None
         legacy_n = 0
-        seen_legacy_marker = False
+        # True once a substantive (non-opening-cluster) legacy row has been
+        # seen since the last legacy boundary — arms the next opening-kind
+        # row to cut a new segment. Starts True so the very first row (of
+        # either kind) opens segment 1.
+        awaiting_boundary = True
         lo: int | None = None
         hi: int | None = None
         seen_run_ids: set[str] = set()
@@ -137,12 +143,20 @@ class ReplaySource:
                 boundary = stamped_id != current_id
                 next_id = stamped_id
             else:
-                is_marker = row["tier"] == "self" and (
-                    row["k"] == "user" or row["k"].endswith(".user")
+                k = row["k"]
+                is_opening = (
+                    (row["tier"] == "self" and (k == "user" or k.endswith(".user")))
+                    or k == "resolvedpeer" or k.endswith(".resolvedpeer")
+                    or k == "chatfull" or k.endswith(".chatfull")
                 )
-                boundary = True if is_marker and seen_legacy_marker else current_id is None
-                if is_marker:
-                    seen_legacy_marker = True
+                boundary = current_id is None or (is_opening and awaiting_boundary)
+                if is_opening:
+                    if boundary:
+                        awaiting_boundary = False
+                    # else: another member of the same opening cluster —
+                    # awaiting_boundary is already False, leave it.
+                else:
+                    awaiting_boundary = True
                 if boundary:
                     next_id = f"legacy-{legacy_n + 1:04d}"
                 else:

--- a/src/paperboy/replay.py
+++ b/src/paperboy/replay.py
@@ -68,6 +68,15 @@ class ReplaySource:
     def __init__(self, conn: sqlite3.Connection, media_root: Path) -> None:
         self.conn = conn
         self.media_root = media_root
+        # A real archive captured before this feature existed (ADR-0005) has
+        # only pre-0003 migrations applied — `raw_records` has no `run_id`
+        # column at all yet, not merely NULL values in it. `ReplaySource` is
+        # strictly read-only and never applies migrations to the source, so
+        # `runs()` must fall back to treating the whole log as legacy rather
+        # than querying a column that may not exist.
+        self._has_run_id = any(
+            r[1] == "run_id" for r in conn.execute("PRAGMA table_info(raw_records)")
+        )
 
     @classmethod
     def open(cls, db_path: Path, media_root: Path) -> Self:
@@ -87,17 +96,28 @@ class ReplaySource:
     def runs(self) -> list[ReplayRun]:
         """Capture-ordered collect passes (ADR-0005). Stamped rows group by
         `run_id`; legacy NULL rows are segmented at each `tier='self'` User
-        record — every collect pass's first raw write (`collectors/channel.py`
-        writes self before anything, and the CLI refuses dependent phases
-        without `channel`) — rows before the first marker join the first
-        segment. Runs must be contiguous rowid ranges (one sequential process
-        per pass); interleaving means a corrupt source and fails loudly."""
+        record — every collect pass's first raw write under the CURRENT
+        collector (`collectors/channel.py` writes self before anything, and
+        the CLI refuses dependent phases without `channel`).
+
+        A real archive can predate that invariant (found running the R6
+        real-archive smoke, ADR-0005): its earliest pass(es) wrote
+        resolve/full BEFORE self. Only the SECOND and later self markers cut
+        a new segment — the first one encountered confirms/continues
+        whatever segment is already open, so any pre-invariant leading rows
+        stay attached to the run they actually belong to instead of forming
+        an orphan segment with no self record (which would then have no
+        target to resolve on replay, silently dropping that run's data).
+        Runs must be contiguous rowid ranges (one sequential process per
+        pass); interleaving means a corrupt source and fails loudly."""
+        run_id_expr = "run_id" if self._has_run_id else "NULL AS run_id"
         rows = self.conn.execute(
-            "SELECT id, run_id, tier, lower(kind) AS k FROM raw_records ORDER BY id"
+            f"SELECT id, {run_id_expr}, tier, lower(kind) AS k FROM raw_records ORDER BY id"
         ).fetchall()
         runs: list[ReplayRun] = []
         current_id: str | None = None
         legacy_n = 0
+        seen_legacy_marker = False
         lo: int | None = None
         hi: int | None = None
         seen_run_ids: set[str] = set()
@@ -120,7 +140,9 @@ class ReplaySource:
                 is_marker = row["tier"] == "self" and (
                     row["k"] == "user" or row["k"].endswith(".user")
                 )
-                boundary = is_marker or current_id is None
+                boundary = True if is_marker and seen_legacy_marker else current_id is None
+                if is_marker:
+                    seen_legacy_marker = True
                 if boundary:
                     next_id = f"legacy-{legacy_n + 1:04d}"
                 else:

--- a/src/paperboy/replay.py
+++ b/src/paperboy/replay.py
@@ -1,0 +1,366 @@
+"""Replay `Gateway`/web-client pair (spec §2–§4): serve `raw_records` back to
+the real collectors, so a reproject is the same code path as a live collect.
+
+`ReplaySource` is strictly read-only (`mode=ro` URI); every serve registers
+the record's original `observed_at` on the shared `ReplayClock` so
+projections carry capture-time stamps (spec §5). A method with no matching
+raw raises `SkipAndRecord`, reproducing the phase set the original run
+executed (spec §3) — with the documented deviations D4.1–D4.4 in
+`docs/superpowers/plans/2026-08-26-reproject.md`.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Self
+
+import httpx
+
+from paperboy.budget import SkipAndRecord
+from paperboy.clock import ReplayClock
+from paperboy.store.db import dumps
+from paperboy.targets import parse_target
+
+
+class ReplaySource:
+    """Read-only access to a source DB's raw log + its content-addressed media."""
+
+    def __init__(self, conn: sqlite3.Connection, media_root: Path) -> None:
+        self.conn = conn
+        self.media_root = media_root
+
+    @classmethod
+    def open(cls, db_path: Path, media_root: Path) -> Self:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        return cls(conn, media_root)
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def resolve_targets(self) -> list[str]:
+        """Every distinct `target` a `resolve()` was recorded against, in
+        first-seen (capture) order — `reproject` re-runs a full collect per
+        target."""
+        rows = self.conn.execute(
+            "SELECT json_extract(context_json, '$.target') AS target FROM raw_records "
+            "WHERE lower(kind) = 'resolvedpeer' AND target IS NOT NULL ORDER BY id"
+        ).fetchall()
+        seen: dict[str, None] = {}
+        for r in rows:
+            seen.setdefault(r["target"])
+        return list(seen)
+
+    def linked_group_ids(self) -> set[int]:
+        rows = self.conn.execute(
+            "SELECT json_extract(payload_json, '$.full_chat.linked_chat_id') AS g "
+            "FROM raw_records WHERE lower(kind) = 'chatfull'"
+        ).fetchall()
+        return {r["g"] for r in rows if r["g"]}
+
+    def has_kind(self, *kinds: str) -> bool:
+        qmarks = ",".join("?" * len(kinds))
+        return self.conn.execute(
+            f"SELECT 1 FROM raw_records WHERE lower(kind) IN ({qmarks}) LIMIT 1",
+            kinds,
+        ).fetchone() is not None
+
+    def has_context_channel(self, channel_ids: set[int]) -> bool:
+        return any(
+            self.conn.execute(
+                "SELECT 1 FROM raw_records "
+                "WHERE json_extract(context_json, '$.channel_id') = ? LIMIT 1",
+                (cid,),
+            ).fetchone() is not None
+            for cid in channel_ids
+        )
+
+
+class RawReplayGateway:
+    """`Gateway` served from a raw log. Never touches the network — there is
+    no client, no session, no `Budget` anywhere in this class."""
+
+    def __init__(self, source: ReplaySource, clock: ReplayClock) -> None:
+        self._src = source
+        self._clock = clock
+        # get_channel_difference is inherently sequential (a pts catch-up
+        # loop); a per-channel cursor over the stored pages models that.
+        self._diff_cursor: dict[int, int] = {}
+
+    def _latest(
+        self, kinds: tuple[str, ...], where: str, params: tuple
+    ) -> sqlite3.Row | None:
+        qmarks = ",".join("?" * len(kinds))
+        return self._src.conn.execute(
+            f"SELECT observed_at, payload_json FROM raw_records "
+            f"WHERE lower(kind) IN ({qmarks}) AND {where} ORDER BY id DESC LIMIT 1",
+            (*kinds, *params),
+        ).fetchone()
+
+    def _serve(self, row: sqlite3.Row) -> dict:
+        payload = json.loads(row["payload_json"])
+        self._clock.begin_batch()
+        self._clock.serve_json(row["observed_at"], row["payload_json"])
+        return payload
+
+    async def resolve(self, target_value: str) -> dict:
+        rows = self._src.conn.execute(
+            "SELECT observed_at, payload_json, "
+            "json_extract(context_json, '$.target') AS target "
+            "FROM raw_records WHERE lower(kind) = 'resolvedpeer' ORDER BY id DESC"
+        ).fetchall()
+        for row in rows:
+            raw_target = row["target"]
+            if raw_target and parse_target(raw_target).value == target_value:
+                return self._serve(row)
+        raise SkipAndRecord(f"replay: no ResolvedPeer recorded for {target_value!r}")
+
+    async def get_full_channel(self, input_channel: dict) -> dict:
+        row = self._latest(
+            ("chatfull",),
+            "json_extract(context_json, '$.channel_id') = ?",
+            (input_channel["channel_id"],),
+        )
+        if row is None:
+            raise SkipAndRecord(
+                f"replay: no ChatFull recorded for channel {input_channel['channel_id']}"
+            )
+        return self._serve(row)
+
+    async def get_self(self) -> dict:
+        row = self._latest(("user",), "tier = 'self'", ())
+        if row is None:
+            raise SkipAndRecord("replay: no self User recorded")
+        return self._serve(row)
+
+    async def iter_history(
+        self, input_channel: dict, *, offset_id: int, limit: int
+    ) -> AsyncIterator[dict]:
+        # Reconstructs the original paging (spec §3): id DESC below the
+        # cursor. Secondary order id ASC (capture order) so an edited
+        # message's revisions replay oldest-first. MessageEmpty is excluded —
+        # getHistory never yielded one; they came from the probe.
+        rows = self._src.conn.execute(
+            "SELECT id, observed_at, payload_json, "
+            "CAST(json_extract(payload_json, '$.id') AS INTEGER) AS msg_id "
+            "FROM raw_records "
+            "WHERE lower(kind) IN ('message', 'messageservice') "
+            "AND json_extract(context_json, '$.channel_id') = ? "
+            "AND (? = 0 OR CAST(json_extract(payload_json, '$.id') AS INTEGER) < ?) "
+            "ORDER BY msg_id DESC, id ASC",
+            (input_channel["channel_id"], offset_id, offset_id),
+        ).fetchall()
+        # Never split one msg_id's records across pages: the collector's next
+        # cursor is `min(page ids)` and the next page takes strictly-below,
+        # so a split id's tail records would be unreachable forever.
+        page = list(rows[:limit])
+        while len(rows) > len(page) and rows[len(page)]["msg_id"] == page[-1]["msg_id"]:
+            page.append(rows[len(page)])
+        self._clock.begin_batch()
+        for row in page:
+            self._clock.serve_json(row["observed_at"], row["payload_json"])
+            yield json.loads(row["payload_json"])
+
+    async def get_messages(self, input_channel: dict, ids: list[int]) -> list[dict]:
+        channel_id = input_channel["channel_id"]
+        self._clock.begin_batch()
+        out: list[dict] = []
+        for i in ids:
+            row = self._latest(
+                ("message", "messageservice", "messageempty"),
+                "json_extract(context_json, '$.channel_id') = ? "
+                "AND CAST(json_extract(payload_json, '$.id') AS INTEGER) = ?",
+                (channel_id, i),
+            )
+            if row is None:
+                # D4.1: a placeholder, NOT a synthetic messageEmpty — that
+                # would fabricate deletion evidence (mark_deleted evidence=
+                # 'empty') for ids the original run never observed as
+                # deleted (a gap the probe found alive, or a range only
+                # reachable via replayed catch-up). The collector skips any
+                # non-messageEmpty shape, so this projects nothing — exactly
+                # the original source's state.
+                out.append({"_": "ReplayUnknownMessage", "id": i})
+                continue
+            self._clock.serve_json(row["observed_at"], row["payload_json"])
+            out.append(json.loads(row["payload_json"]))
+        return out
+
+    async def get_channel_difference(self, input_channel: dict, pts: int, limit: int) -> dict:
+        del limit
+        channel_id = input_channel["channel_id"]
+        idx = self._diff_cursor.get(channel_id, 0)
+        row = self._src.conn.execute(
+            "SELECT observed_at, payload_json FROM raw_records "
+            "WHERE lower(kind) LIKE 'channeldifference%' "
+            "AND json_extract(context_json, '$.channel_id') = ? "
+            "ORDER BY id ASC LIMIT 1 OFFSET ?",
+            (channel_id, idx),
+        ).fetchone()
+        self._diff_cursor[channel_id] = idx + 1
+
+        if row is None:
+            # D4.4: exhausted the stored pages — a synthetic final EMPTY
+            # diff, not SkipAndRecord. A mid-catch_up SkipAndRecord would
+            # mark the whole history phase skipped and discard the backfill
+            # counts already applied this run.
+            stamp = self._src.conn.execute(
+                "SELECT MAX(observed_at) AS t FROM raw_records "
+                "WHERE json_extract(context_json, '$.channel_id') = ?",
+                (channel_id,),
+            ).fetchone()
+            synthetic = {"_": "updates.channelDifferenceEmpty", "final": True, "pts": pts}
+            self._clock.begin_batch()
+            self._clock.serve(stamp["t"], synthetic)
+            return synthetic
+
+        payload = json.loads(row["payload_json"])
+        self._clock.begin_batch()
+        self._clock.serve_json(row["observed_at"], row["payload_json"])
+        # Also register every nested message on the clock, keyed by its OWN
+        # raw record (each is also individually stored by history.py's
+        # _observe_message) — so `_observe_message` gets a per-message stamp
+        # rather than falling back to the envelope's.
+        nested = [
+            *payload.get("new_messages", []),
+            *payload.get("messages", []),
+            *(u["message"] for u in payload.get("other_updates", [])
+              if isinstance(u.get("message"), dict)),
+        ]
+        for m in nested:
+            m_row = self._latest(
+                ("message", "messageservice", "messageempty"),
+                "json_extract(context_json, '$.channel_id') = ? AND payload_json = ?",
+                (channel_id, dumps(m)),
+            )
+            if m_row is not None:
+                self._clock.serve_json(m_row["observed_at"], m_row["payload_json"])
+        return payload
+
+    async def get_authorizations(self) -> dict:
+        raise SkipAndRecord("replay: doctor state is not recorded; reproject never runs doctor")
+
+    async def get_password_state(self) -> dict:
+        raise SkipAndRecord("replay: doctor state is not recorded; reproject never runs doctor")
+
+    async def get_privacy(self, key: str) -> dict:
+        del key
+        raise SkipAndRecord("replay: doctor state is not recorded; reproject never runs doctor")
+
+    async def download_media(self, input_channel: dict, message: dict) -> bytes | None:
+        row = self._latest(
+            ("mediadownload",),
+            "json_extract(context_json, '$.channel_id') = ? "
+            "AND json_extract(context_json, '$.msg_id') = ?",
+            (input_channel["channel_id"], message["id"]),
+        )
+        if row is None:
+            return None
+        payload = json.loads(row["payload_json"])
+        sha = payload["sha256"]
+        path = Path(payload["path"])
+        # A small local disk stat/read on an offline, single-user CLI tool —
+        # not worth a trio/anyio dependency for.
+        if not path.exists():  # noqa: ASYNC240
+            # A different profile than the one that captured it (spec §4):
+            # re-derive the content-addressed location under THIS source's
+            # media root rather than trusting the stored (possibly foreign)
+            # absolute path.
+            path = self._src.media_root / sha[:2] / (sha + Path(payload["path"]).suffix)
+        if not path.exists():
+            raise SkipAndRecord(f"replay: media file missing for sha {sha}")
+        data = path.read_bytes()
+        self._clock.begin_batch()
+        self._clock.serve_json(row["observed_at"], row["payload_json"])
+        return data
+
+    async def get_channel_recommendations(self, input_channel: dict) -> dict:
+        row = self._latest(
+            ("chats", "chatsslice"),
+            "json_extract(context_json, '$.channel_id') = ?",
+            (input_channel["channel_id"],),
+        )
+        if row is None:
+            raise SkipAndRecord(
+                "replay: no channel recommendations recorded for channel "
+                f"{input_channel['channel_id']}"
+            )
+        return self._serve(row)
+
+    async def check_chat_invite(self, hash_: str) -> dict:
+        row = self._latest(
+            ("chatinvite", "chatinvitealready", "chatinvitepeek"),
+            "json_extract(context_json, '$.hash') = ?",
+            (hash_,),
+        )
+        if row is None:
+            raise SkipAndRecord(f"replay: no ChatInvite recorded for hash {hash_!r}")
+        return self._serve(row)
+
+    async def join_channel(self, input_channel: dict) -> dict:
+        # D4.3: reproject always runs with allow_join=True so a source whose
+        # original run used --join still replays its discussion sweep — but
+        # nothing is actually joined. No network, no session, no real write
+        # anywhere in this class.
+        del input_channel
+        return {"_": "Updates", "updates": []}
+
+    async def get_sponsored_messages(self, input_channel: dict) -> dict:
+        rows = self._src.conn.execute(
+            "SELECT observed_at, payload_json FROM raw_records "
+            "WHERE lower(kind) = 'sponsoredmessage' "
+            "AND json_extract(context_json, '$.channel_id') = ? ORDER BY id ASC",
+            (input_channel["channel_id"],),
+        ).fetchall()
+        self._clock.begin_batch()
+        if not rows:
+            # D4.2: the original collector never stores the envelope, only
+            # each SponsoredMessage individually — empty-and-skipped
+            # originals are indistinguishable, so both project nothing.
+            return {"_": "sponsoredMessagesEmpty"}
+        messages = []
+        for row in rows:
+            self._clock.serve_json(row["observed_at"], row["payload_json"])
+            messages.append(json.loads(row["payload_json"]))
+        return {"_": "SponsoredMessages", "messages": messages}
+
+
+class RawReplayWebClient:
+    """Serve stored `tme_page`/`wayback_cdx` captures as `httpx.Response`s.
+
+    Keyed by exact URL — the web collector re-derives the same URL sequence
+    from the same parsed posts, so replay requests exactly the recorded set.
+    Repeat captures of one URL (multi-run sources) serve in capture order.
+    An unrecorded URL is a definitive empty 404: the page loop must stop
+    cleanly there, exactly where the original run stopped.
+    """
+
+    def __init__(self, source: ReplaySource, clock: ReplayClock) -> None:
+        self._src = source
+        self._clock = clock
+        self._served: dict[str, int] = {}  # url -> raw id already served
+
+    def get(self, url: str) -> httpx.Response:
+        row = self._src.conn.execute(
+            "SELECT id, observed_at, payload_json FROM raw_records "
+            "WHERE lower(kind) IN ('tme_page', 'wayback_cdx') "
+            "AND json_extract(payload_json, '$.url') = ? AND id > ? "
+            "ORDER BY id ASC LIMIT 1",
+            (url, self._served.get(url, 0)),
+        ).fetchone()
+        if row is None:
+            return httpx.Response(404, text="")
+        self._served[url] = row["id"]
+        payload = json.loads(row["payload_json"])
+        self._clock.begin_batch()
+        self._clock.serve_json(row["observed_at"], row["payload_json"])
+        return httpx.Response(payload["status_code"], text=payload["text"])

--- a/src/paperboy/reproject.py
+++ b/src/paperboy/reproject.py
@@ -17,7 +17,7 @@ from paperboy.collectors.media import MediaCollector
 from paperboy.collectors.web import WebCollector
 from paperboy.config import Settings
 from paperboy.recipes import collect_channel
-from paperboy.replay import RawReplayGateway, RawReplayWebClient, ReplaySource
+from paperboy.replay import RawReplayGateway, RawReplayWebClient, ReplayRun, ReplaySource
 from paperboy.store.db import Store
 from paperboy.targets import parse_target
 
@@ -40,25 +40,26 @@ class ReprojectSummary:
     table_counts: dict[str, tuple[int, int]]
 
 
-def detect_phases(source: ReplaySource) -> list[str]:
-    """The phase set the original run(s) executed, inferred from raw kinds
-    (spec §3: a source that never ran graph reprojects without graph). The
-    inference is necessarily raw-only (spec §8) and conservative: a phase
-    whose every RPC was skipped leaves no raw and is treated as never-run;
-    --phases overrides.
+def detect_phases(source: ReplaySource, run: ReplayRun) -> list[str]:
+    """The phase set ONE historical run executed, inferred from the raw kinds
+    it left behind (spec §3: a run that never did graph reprojects without
+    graph; ADR-0005: scoped to `run`, not the whole source — a source can mix
+    runs with different phase sets). The inference is necessarily raw-only
+    (spec §8) and conservative: a phase whose every RPC was skipped leaves no
+    raw and is treated as never-run for that run; --phases overrides.
     """
     phases = ["channel", "history"]
-    linked = source.linked_group_ids()
-    if linked and source.has_context_channel(linked):
+    linked = source.linked_group_ids(run)
+    if linked and source.has_context_channel(run, linked):
         phases.append("discussion")
     if source.has_kind(
-        "chats", "chatsslice", "chatinvite", "chatinvitealready",
+        run, "chats", "chatsslice", "chatinvite", "chatinvitealready",
         "chatinvitepeek", "sponsoredmessage",
     ):
         phases.append("graph")
-    if source.has_kind("tme_page", "wayback_cdx"):
+    if source.has_kind(run, "tme_page", "wayback_cdx"):
         phases.append("web")
-    if source.has_kind("mediadownload"):
+    if source.has_kind(run, "mediadownload"):
         phases.append("media")
     return phases
 
@@ -71,48 +72,72 @@ async def reproject(
     phases: list[str] | None,
     log: logging.Logger,
 ) -> ReprojectSummary:
-    targets = source.resolve_targets()
-    if not targets:
-        raise ReprojectError(
-            "source has no resolve records in raw_records — nothing to reproject"
-        )
-    active_phases = phases if phases is not None else detect_phases(source)
+    """Replay every historical collect pass in the source, one run at a time
+    (ADR-0005): each run gets its own `ReplayClock`/`RawReplayGateway`/
+    `RawReplayWebClient` scoped to that run's raw_records rowid range, and
+    stamps the target store with that run's own `run_id` — so a reprojected
+    DB carries the same pass structure as its source and is itself
+    faithfully re-reprojectable. `out_store` accumulates state across
+    replayed runs exactly as the live store did across the real runs
+    (`sync_state`, snapshot/metric time series, ...).
+    """
+    runs = source.runs()
+    if not runs:
+        raise ReprojectError("source raw log is empty — nothing to reproject")
     # allow_join=True so a source whose original run used --join replays its
     # discussion sweep; RawReplayGateway.join_channel is a synthetic no-op
     # (D4.3) — nothing is joined, nothing leaves this machine.
     replay_settings = settings.model_copy(update={"allow_join": True})
 
     results: dict[str, list[CollectResult]] = {}
-    for raw_target in targets:
-        clock = ReplayClock()
-        gateway = RawReplayGateway(source, clock)
-        web_client = RawReplayWebClient(source, clock)
-        collectors = [
-            ChannelCollector(), HistoryCollector(), DiscussionCollector(),
-            GraphCollector(),
-            WebCollector(client=web_client, min_interval=0.0, sleep=lambda s: None),
-            MediaCollector(),
-        ]
-        try:
-            results[raw_target] = await collect_channel(
-                gateway, out_store, replay_settings, parse_target(raw_target),
-                list(active_phases), log,
-                collectors=collectors, profile=profile, clock=clock,
-            )
-        except Exception as exc:
-            # collect_channel was designed for exactly one target per run and
-            # has no notion of "this target, among several, turned out bad" —
-            # e.g. a historically-resolved target that later resolves to a
-            # non-channel peer crashes channel.collect with a bare
-            # ValueError even on a live run (found exercising this against a
-            # real archive — DoD smoke, docs/features/reproject.md). A
-            # multi-target reproject must not let one such target discard
-            # every other target's projections already committed to
-            # out_store this run. The failure is recorded, not swallowed.
-            log.error("reproject: target %r failed: %s", raw_target, exc)
-            results[raw_target] = [
-                CollectResult(name="target", counts={}, stopped=f"error: {exc}")
+    phases_seen: list[str] = []
+    replayed_any = False
+    for run in runs:
+        run_phases = phases if phases is not None else detect_phases(source, run)
+        for p in run_phases:
+            if p not in phases_seen:
+                phases_seen.append(p)
+        for raw_target in source.resolve_targets(run):
+            replayed_any = True
+            clock = ReplayClock()
+            gateway = RawReplayGateway(source, clock, run)
+            web_client = RawReplayWebClient(source, clock, run)
+            collectors = [
+                ChannelCollector(), HistoryCollector(), DiscussionCollector(),
+                GraphCollector(),
+                WebCollector(client=web_client, min_interval=0.0, sleep=lambda s: None),
+                MediaCollector(),
             ]
+            try:
+                run_results = await collect_channel(
+                    gateway, out_store, replay_settings, parse_target(raw_target),
+                    list(run_phases), log,
+                    collectors=collectors, profile=profile, clock=clock,
+                    run_id=run.run_id,
+                )
+            except Exception as exc:
+                # collect_channel was designed for exactly one target per run
+                # and has no notion of "this target, among several, turned
+                # out bad" — e.g. a historically-resolved target that later
+                # resolves to a non-channel peer crashes channel.collect
+                # even on a live run (found exercising this against a real
+                # archive — DoD smoke, docs/features/reproject.md). A
+                # multi-target, multi-run reproject must not let one such
+                # target/run discard every other target's or run's
+                # projections already committed to out_store. The failure is
+                # recorded, not swallowed.
+                log.error(
+                    "reproject: target %r (run %s) failed: %s",
+                    raw_target, run.run_id, exc,
+                )
+                run_results = [
+                    CollectResult(name="target", counts={}, stopped=f"error: {exc}")
+                ]
+            results.setdefault(raw_target, []).extend(run_results)
+    if not replayed_any:
+        raise ReprojectError(
+            "source has no resolve records in raw_records — nothing to reproject"
+        )
 
     counts = {
         t: (
@@ -121,4 +146,4 @@ async def reproject(
         )
         for t in REPROJECT_TABLES
     }
-    return ReprojectSummary(list(active_phases), results, counts)
+    return ReprojectSummary(phases_seen, results, counts)

--- a/src/paperboy/reproject.py
+++ b/src/paperboy/reproject.py
@@ -1,0 +1,109 @@
+"""The reproject recipe (spec §6): enumerate targets and phases from the raw
+log, then run the NORMAL collectors against the replay pair into a fresh
+store. Everything collector-shaped is reused; this module only wires."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from paperboy.clock import ReplayClock
+from paperboy.collectors.base import CollectResult
+from paperboy.collectors.channel import ChannelCollector
+from paperboy.collectors.discussion import DiscussionCollector
+from paperboy.collectors.graph import GraphCollector
+from paperboy.collectors.history import HistoryCollector
+from paperboy.collectors.media import MediaCollector
+from paperboy.collectors.web import WebCollector
+from paperboy.config import Settings
+from paperboy.recipes import collect_channel
+from paperboy.replay import RawReplayGateway, RawReplayWebClient, ReplaySource
+from paperboy.store.db import Store
+from paperboy.targets import parse_target
+
+
+class ReprojectError(Exception):
+    """Operator-facing reproject failure (empty source, bad --out)."""
+
+
+REPROJECT_TABLES = (
+    "raw_records", "channels", "channel_snapshots", "peers", "messages",
+    "message_revisions", "message_metrics", "message_tombstones", "edges",
+    "media", "custody_log", "web_snapshots",
+)
+
+
+@dataclass
+class ReprojectSummary:
+    phases: list[str]
+    results: dict[str, list[CollectResult]]
+    table_counts: dict[str, tuple[int, int]]
+
+
+def detect_phases(source: ReplaySource) -> list[str]:
+    """The phase set the original run(s) executed, inferred from raw kinds
+    (spec §3: a source that never ran graph reprojects without graph). The
+    inference is necessarily raw-only (spec §8) and conservative: a phase
+    whose every RPC was skipped leaves no raw and is treated as never-run;
+    --phases overrides.
+    """
+    phases = ["channel", "history"]
+    linked = source.linked_group_ids()
+    if linked and source.has_context_channel(linked):
+        phases.append("discussion")
+    if source.has_kind(
+        "chats", "chatsslice", "chatinvite", "chatinvitealready",
+        "chatinvitepeek", "sponsoredmessage",
+    ):
+        phases.append("graph")
+    if source.has_kind("tme_page", "wayback_cdx"):
+        phases.append("web")
+    if source.has_kind("mediadownload"):
+        phases.append("media")
+    return phases
+
+
+async def reproject(
+    source: ReplaySource,
+    out_store: Store,
+    settings: Settings,
+    profile: str,
+    phases: list[str] | None,
+    log: logging.Logger,
+) -> ReprojectSummary:
+    targets = source.resolve_targets()
+    if not targets:
+        raise ReprojectError(
+            "source has no resolve records in raw_records — nothing to reproject"
+        )
+    active_phases = phases if phases is not None else detect_phases(source)
+    # allow_join=True so a source whose original run used --join replays its
+    # discussion sweep; RawReplayGateway.join_channel is a synthetic no-op
+    # (D4.3) — nothing is joined, nothing leaves this machine.
+    replay_settings = settings.model_copy(update={"allow_join": True})
+
+    results: dict[str, list[CollectResult]] = {}
+    for raw_target in targets:
+        clock = ReplayClock()
+        gateway = RawReplayGateway(source, clock)
+        web_client = RawReplayWebClient(source, clock)
+        collectors = [
+            ChannelCollector(), HistoryCollector(), DiscussionCollector(),
+            GraphCollector(),
+            WebCollector(client=web_client, min_interval=0.0, sleep=lambda s: None),
+            MediaCollector(),
+        ]
+        results[raw_target] = await collect_channel(
+            gateway, out_store, replay_settings, parse_target(raw_target),
+            list(active_phases), log,
+            collectors=collectors, profile=profile, clock=clock,
+        )
+
+    counts = {
+        t: (
+            source.conn.execute(f"SELECT count(*) FROM {t}").fetchone()[0],
+            out_store.conn.execute(f"SELECT count(*) FROM {t}").fetchone()[0],
+        )
+        for t in REPROJECT_TABLES
+    }
+    return ReprojectSummary(list(active_phases), results, counts)

--- a/src/paperboy/reproject.py
+++ b/src/paperboy/reproject.py
@@ -4,6 +4,7 @@ store. Everything collector-shaped is reused; this module only wires."""
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 
@@ -18,7 +19,7 @@ from paperboy.collectors.web import WebCollector
 from paperboy.config import Settings
 from paperboy.recipes import collect_channel
 from paperboy.replay import RawReplayGateway, RawReplayWebClient, ReplayRun, ReplaySource
-from paperboy.store.db import Store
+from paperboy.store.db import Store, dumps
 from paperboy.targets import parse_target
 
 
@@ -42,7 +43,9 @@ class ReprojectSummary:
 
 def _reset_incremental_backfill_state(out_store: Store) -> None:
     """Clear `HistoryCollector`'s incremental-vs-full-sweep bookkeeping
-    (`sync_state` scopes `history`/`history_sweep`) before replaying a run.
+    before replaying a run — `sync_state('history', ...)`'s resume cursor
+    entirely, `sync_state('history_sweep', ...)`'s per-run-artifact flags
+    only (see below).
 
     Found running the R6 real-archive smoke (ADR-0005): `RawReplayGateway.
     iter_history` is scoped to ONE run's own raw_records window, so it
@@ -57,13 +60,38 @@ def _reset_incremental_backfill_state(out_store: Store) -> None:
     sweep to incremental-only (ids above the previous run's high-water
     mark) — silently dropping every one of that run's own, all-older
     messages, which is exactly the shape a real multi-session backward
-    backfill takes. Resetting before every run costs nothing here (no
-    network, no rate limit to economize on the way live incremental sync
-    does) and makes each run independently sweep its own full raw window;
+    backfill takes. `history`'s resume cursor (`offset_id`) is entirely a
+    REPLAY-run-scoped artifact too — a fresh full sweep must always restart
+    each run's own window from its newest message, never resume from
+    wherever a DIFFERENT run's window left its cursor — so that scope is
+    always cleared outright.
+
+    `history_sweep`'s `max_id_seen`/`pending_high` are NOT a replay
+    artifact, though: they are the true high-water mark of the highest
+    message id ever observed for the channel, and must keep monotonically
+    widening across replayed runs exactly as they would across live
+    sessions (a live multi-session backward backfill never resets them
+    either — only a completed sweep's own two flags reset per run). Blanket-
+    deleting the whole scope here — as an earlier revision did — collapsed
+    the final reprojected `history_sweep` down to only the LAST run's own
+    local window (found in review: a two-run backward backfill of ids
+    851..1000 then 701..850 reprojected to `max_id_seen=850`, discarding the
+    source's true 1000). Only the two per-run-artifact flags reset here; the
+    high-water mark columns are read back unchanged and carried forward —
     idempotent projection upserts make any resulting re-processing of
-    already-seen messages harmless.
+    already-seen messages harmless regardless.
     """
-    out_store.conn.execute("DELETE FROM sync_state WHERE scope IN ('history', 'history_sweep')")
+    out_store.conn.execute("DELETE FROM sync_state WHERE scope = 'history'")
+    for row in out_store.conn.execute(
+        "SELECT key, value_json FROM sync_state WHERE scope = 'history_sweep'"
+    ).fetchall():
+        value = json.loads(row["value_json"])
+        value["backfill_complete"] = False
+        value["incremental_in_progress"] = False
+        out_store.conn.execute(
+            "UPDATE sync_state SET value_json = ? WHERE scope = 'history_sweep' AND key = ?",
+            (dumps(value), row["key"]),
+        )
 
 
 def detect_phases(source: ReplaySource, run: ReplayRun) -> list[str]:
@@ -124,7 +152,21 @@ async def reproject(
         for p in run_phases:
             if p not in phases_seen:
                 phases_seen.append(p)
-        for raw_target in source.resolve_targets(run):
+        run_targets = source.resolve_targets(run)
+        if not run_targets:
+            # A run with no ResolvedPeer at all — no target to replay a
+            # collect against, so every raw row in its window is silently
+            # dropped from the reprojected DB. `replayed_any` below only
+            # catches the case where NO run anywhere resolved a target;
+            # without a per-run warning a single zero-target run in an
+            # otherwise healthy source vanishes with no signal to the
+            # operator (adversarial-reviewer, round 2).
+            log.warning(
+                "reproject: run %s (raw ids %d-%d) has no resolve records — "
+                "skipping %d raw rows",
+                run.run_id, run.lo, run.hi, run.hi - run.lo + 1,
+            )
+        for raw_target in run_targets:
             replayed_any = True
             clock = ReplayClock()
             gateway = RawReplayGateway(source, clock, run)

--- a/src/paperboy/reproject.py
+++ b/src/paperboy/reproject.py
@@ -93,11 +93,26 @@ async def reproject(
             WebCollector(client=web_client, min_interval=0.0, sleep=lambda s: None),
             MediaCollector(),
         ]
-        results[raw_target] = await collect_channel(
-            gateway, out_store, replay_settings, parse_target(raw_target),
-            list(active_phases), log,
-            collectors=collectors, profile=profile, clock=clock,
-        )
+        try:
+            results[raw_target] = await collect_channel(
+                gateway, out_store, replay_settings, parse_target(raw_target),
+                list(active_phases), log,
+                collectors=collectors, profile=profile, clock=clock,
+            )
+        except Exception as exc:
+            # collect_channel was designed for exactly one target per run and
+            # has no notion of "this target, among several, turned out bad" —
+            # e.g. a historically-resolved target that later resolves to a
+            # non-channel peer crashes channel.collect with a bare
+            # ValueError even on a live run (found exercising this against a
+            # real archive — DoD smoke, docs/features/reproject.md). A
+            # multi-target reproject must not let one such target discard
+            # every other target's projections already committed to
+            # out_store this run. The failure is recorded, not swallowed.
+            log.error("reproject: target %r failed: %s", raw_target, exc)
+            results[raw_target] = [
+                CollectResult(name="target", counts={}, stopped=f"error: {exc}")
+            ]
 
     counts = {
         t: (

--- a/src/paperboy/reproject.py
+++ b/src/paperboy/reproject.py
@@ -40,6 +40,32 @@ class ReprojectSummary:
     table_counts: dict[str, tuple[int, int]]
 
 
+def _reset_incremental_backfill_state(out_store: Store) -> None:
+    """Clear `HistoryCollector`'s incremental-vs-full-sweep bookkeeping
+    (`sync_state` scopes `history`/`history_sweep`) before replaying a run.
+
+    Found running the R6 real-archive smoke (ADR-0005): `RawReplayGateway.
+    iter_history` is scoped to ONE run's own raw_records window, so it
+    naturally runs out ("no more pages") the moment that window is
+    exhausted — a purely REPLAY artifact of the run boundary, not a
+    Telegram-side fact. `history.py` reads that natural end as "reached the
+    real end of the channel's history" and commits `backfill_complete=True`
+    for a LIVE gateway that is correct (Telegram's history can only grow
+    forward; a later session can never legitimately find OLDER messages
+    than a completed full sweep already saw). Left uncleared across REPLAYED
+    runs, that flag wrongly survives into the next run and switches its
+    sweep to incremental-only (ids above the previous run's high-water
+    mark) — silently dropping every one of that run's own, all-older
+    messages, which is exactly the shape a real multi-session backward
+    backfill takes. Resetting before every run costs nothing here (no
+    network, no rate limit to economize on the way live incremental sync
+    does) and makes each run independently sweep its own full raw window;
+    idempotent projection upserts make any resulting re-processing of
+    already-seen messages harmless.
+    """
+    out_store.conn.execute("DELETE FROM sync_state WHERE scope IN ('history', 'history_sweep')")
+
+
 def detect_phases(source: ReplaySource, run: ReplayRun) -> list[str]:
     """The phase set ONE historical run executed, inferred from the raw kinds
     it left behind (spec §3: a run that never did graph reprojects without
@@ -93,6 +119,7 @@ async def reproject(
     phases_seen: list[str] = []
     replayed_any = False
     for run in runs:
+        _reset_incremental_backfill_state(out_store)
         run_phases = phases if phases is not None else detect_phases(source, run)
         for p in run_phases:
             if p not in phases_seen:

--- a/src/paperboy/store/channels.py
+++ b/src/paperboy/store/channels.py
@@ -58,6 +58,12 @@ def upsert_channel(
     Writes current state to `channels` and always appends a `channel_snapshots`
     row — snapshots are an observation time series, not deduplicated, so
     counters like `participants_count` can be plotted over time.
+
+    Newest-observation-wins, not last-write-wins (ADR-0005 §6): observations
+    can arrive out of order (a live re-run, or replay processing historical
+    runs one at a time), so current-state columns only move when this
+    observation is at least as new as the stored `last_seen`, while
+    `first_seen`/`last_seen` always widen to the true min/max window.
     """
     id_ = chan["id"]
     uri = channel_uri(id_)
@@ -83,16 +89,31 @@ def upsert_channel(
             first_seen, last_seen
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
-            username=excluded.username,
-            title=excluded.title,
-            about=excluded.about,
-            kind=excluded.kind,
-            linked_chat_id=excluded.linked_chat_id,
-            participants_count=excluded.participants_count,
-            flags_json=excluded.flags_json,
-            restriction_json=excluded.restriction_json,
-            source_raw_id=excluded.source_raw_id,
-            last_seen=excluded.last_seen
+            -- newest-observation-wins (ADR-0005 §6): current-state columns
+            -- only move forward when this observation is at least as new as
+            -- what is stored; the seen window always widens (MIN/MAX below).
+            username = CASE WHEN excluded.last_seen >= channels.last_seen
+                            THEN excluded.username ELSE channels.username END,
+            title = CASE WHEN excluded.last_seen >= channels.last_seen
+                         THEN excluded.title ELSE channels.title END,
+            about = CASE WHEN excluded.last_seen >= channels.last_seen
+                         THEN excluded.about ELSE channels.about END,
+            kind = CASE WHEN excluded.last_seen >= channels.last_seen
+                        THEN excluded.kind ELSE channels.kind END,
+            linked_chat_id = CASE WHEN excluded.last_seen >= channels.last_seen
+                                  THEN excluded.linked_chat_id ELSE channels.linked_chat_id END,
+            participants_count = CASE WHEN excluded.last_seen >= channels.last_seen
+                                      THEN excluded.participants_count
+                                      ELSE channels.participants_count END,
+            flags_json = CASE WHEN excluded.last_seen >= channels.last_seen
+                              THEN excluded.flags_json ELSE channels.flags_json END,
+            restriction_json = CASE WHEN excluded.last_seen >= channels.last_seen
+                                    THEN excluded.restriction_json
+                                    ELSE channels.restriction_json END,
+            source_raw_id = CASE WHEN excluded.last_seen >= channels.last_seen
+                                 THEN excluded.source_raw_id ELSE channels.source_raw_id END,
+            first_seen = MIN(channels.first_seen, excluded.first_seen),
+            last_seen = MAX(channels.last_seen, excluded.last_seen)
         """,
         (
             id_, uri, username, title, about, kind, created_at, linked_chat_id,

--- a/src/paperboy/store/db.py
+++ b/src/paperboy/store/db.py
@@ -83,14 +83,27 @@ class Store:
                 (stem, utc_now_iso()),
             )
 
-    def add_raw(self, kind: str, payload: dict, tier: str, context: dict | None) -> int:
-        """Append one TL object (as `to_dict()`) to the raw log; returns its rowid."""
+    def add_raw(
+        self,
+        kind: str,
+        payload: dict,
+        tier: str,
+        context: dict | None,
+        observed_at: str | None = None,
+    ) -> int:
+        """Append one TL object (as `to_dict()`) to the raw log; returns its rowid.
+
+        `observed_at` is the caller's per-record observation stamp — the same
+        value the caller passes to every projection of this record, so raw and
+        projection agree (spec §5, the reproject clock seam). `None` (legacy
+        callers, tests) stamps now.
+        """
         cur = self.conn.execute(
             "INSERT INTO raw_records(kind, observed_at, tier, context_json, payload_json) "
             "VALUES (?, ?, ?, ?, ?)",
             (
                 kind,
-                utc_now_iso(),
+                observed_at if observed_at is not None else utc_now_iso(),
                 tier,
                 dumps(context) if context is not None else None,
                 dumps(payload),

--- a/src/paperboy/store/db.py
+++ b/src/paperboy/store/db.py
@@ -25,6 +25,7 @@ from datetime import date, datetime
 from pathlib import Path
 from types import TracebackType
 from typing import Self
+from uuid import uuid4
 
 from paperboy.ids import to_iso, utc_now_iso
 
@@ -54,6 +55,7 @@ class Store:
 
     def __init__(self, conn: sqlite3.Connection) -> None:
         self.conn = conn
+        self._run_id: str | None = None
 
     @classmethod
     def open(cls, path: Path) -> Self:
@@ -83,6 +85,14 @@ class Store:
                 (stem, utc_now_iso()),
             )
 
+    def begin_run(self, run_id: str | None = None) -> str:
+        """Mark the start of one collect pass (ADR-0005): every subsequent
+        `add_raw` carries this id, so replay can reconstruct pass boundaries.
+        Replay injects the SOURCE run's id, making a reprojected DB itself
+        re-reprojectable; live runs take a fresh opaque id."""
+        self._run_id = run_id if run_id is not None else uuid4().hex
+        return self._run_id
+
     def add_raw(
         self,
         kind: str,
@@ -96,17 +106,21 @@ class Store:
         `observed_at` is the caller's per-record observation stamp — the same
         value the caller passes to every projection of this record, so raw and
         projection agree (spec §5, the reproject clock seam). `None` (legacy
-        callers, tests) stamps now.
+        callers, tests) stamps now. `run_id` (ADR-0005) is whatever
+        `begin_run` last set — `None` until a run is begun, which is how
+        legacy pre-migration rows and any caller that skips `begin_run` stay
+        NULL, distinguishable from a stamped run at replay time.
         """
         cur = self.conn.execute(
-            "INSERT INTO raw_records(kind, observed_at, tier, context_json, payload_json) "
-            "VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO raw_records(kind, observed_at, tier, context_json, payload_json, run_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
             (
                 kind,
                 observed_at if observed_at is not None else utc_now_iso(),
                 tier,
                 dumps(context) if context is not None else None,
                 dumps(payload),
+                self._run_id,
             ),
         )
         assert cur.lastrowid is not None

--- a/src/paperboy/store/migrations/0003_run_id.sql
+++ b/src/paperboy/store/migrations/0003_run_id.sql
@@ -1,0 +1,5 @@
+-- 0003_run_id: which collect pass produced each raw record (ADR-0005).
+-- Nullable: legacy rows predate the column and are segmented at replay
+-- time by the tier='self' marker rule — never rewritten here.
+ALTER TABLE raw_records ADD COLUMN run_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_raw_records_run ON raw_records(run_id);

--- a/src/paperboy/store/peers.py
+++ b/src/paperboy/store/peers.py
@@ -97,32 +97,56 @@ def upsert_peer(
             first_seen, last_seen
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(uri) DO UPDATE SET
-            -- newest-observation-wins (ADR-0005 §6): current-state columns
-            -- only move forward when this observation is at least as new as
-            -- what is stored; the seen window always widens (MIN/MAX below).
+            -- Composed richness ∘ recency (ADR-0005 §6, amended 2026-08-26,
+            -- round-2 finding A): identity/profile columns (plus
+            -- source_raw_id, which records the observation that produced
+            -- them) move on recency ALONE between two full observations, but
+            -- richness overrides recency when the stored row is currently
+            -- `min` and this observation is `full` — the best profile data
+            -- known wins even if the full observation is older, because a
+            -- min row never had trustworthy profile data to defend. Between
+            -- two `min` observations recency alone applies (no richness
+            -- distinction between them). Provenance columns
+            -- (`seen_in_chat`/`seen_in_msg`) always keep the plain recency
+            -- guard — they record where THIS observation was witnessed, not
+            -- how rich it was. `full ← min` (existing full row, incoming
+            -- min) never reaches this INSERT..ON CONFLICT at all; it is
+            -- handled by the early-return branch above, which never moves
+            -- identity/profile and gates provenance on recency alone — the
+            -- other half of the same composed lattice.
             kind = CASE WHEN excluded.last_seen >= peers.last_seen
+                        OR (peers.is_min AND NOT excluded.is_min)
                         THEN excluded.kind ELSE peers.kind END,
             id = CASE WHEN excluded.last_seen >= peers.last_seen
+                      OR (peers.is_min AND NOT excluded.is_min)
                       THEN excluded.id ELSE peers.id END,
             access_hash = CASE WHEN excluded.last_seen >= peers.last_seen
+                               OR (peers.is_min AND NOT excluded.is_min)
                                THEN excluded.access_hash ELSE peers.access_hash END,
             is_min = CASE WHEN excluded.last_seen >= peers.last_seen
+                          OR (peers.is_min AND NOT excluded.is_min)
                           THEN excluded.is_min ELSE peers.is_min END,
             seen_in_chat = CASE WHEN excluded.last_seen >= peers.last_seen
                                 THEN excluded.seen_in_chat ELSE peers.seen_in_chat END,
             seen_in_msg = CASE WHEN excluded.last_seen >= peers.last_seen
                                THEN excluded.seen_in_msg ELSE peers.seen_in_msg END,
             username = CASE WHEN excluded.last_seen >= peers.last_seen
+                            OR (peers.is_min AND NOT excluded.is_min)
                             THEN excluded.username ELSE peers.username END,
             first_name = CASE WHEN excluded.last_seen >= peers.last_seen
+                              OR (peers.is_min AND NOT excluded.is_min)
                               THEN excluded.first_name ELSE peers.first_name END,
             last_name = CASE WHEN excluded.last_seen >= peers.last_seen
+                             OR (peers.is_min AND NOT excluded.is_min)
                              THEN excluded.last_name ELSE peers.last_name END,
             title = CASE WHEN excluded.last_seen >= peers.last_seen
+                         OR (peers.is_min AND NOT excluded.is_min)
                          THEN excluded.title ELSE peers.title END,
             flags_json = CASE WHEN excluded.last_seen >= peers.last_seen
+                              OR (peers.is_min AND NOT excluded.is_min)
                               THEN excluded.flags_json ELSE peers.flags_json END,
             source_raw_id = CASE WHEN excluded.last_seen >= peers.last_seen
+                                 OR (peers.is_min AND NOT excluded.is_min)
                                  THEN excluded.source_raw_id ELSE peers.source_raw_id END,
             first_seen = MIN(peers.first_seen, excluded.first_seen),
             last_seen = MAX(peers.last_seen, excluded.last_seen)

--- a/src/paperboy/store/peers.py
+++ b/src/paperboy/store/peers.py
@@ -76,11 +76,12 @@ def upsert_peer(
             "seen_in_chat = CASE WHEN ? >= last_seen THEN ? ELSE seen_in_chat END, "
             "seen_in_msg  = CASE WHEN ? >= last_seen THEN ? ELSE seen_in_msg  END, "
             "source_raw_id = CASE WHEN ? >= last_seen THEN ? ELSE source_raw_id END, "
+            "first_seen = MIN(first_seen, ?), "
             "last_seen = MAX(last_seen, ?) "
             "WHERE uri=?",
             (
                 observed_at, seen_in_chat, observed_at, seen_in_msg,
-                observed_at, source_raw_id, observed_at, uri,
+                observed_at, source_raw_id, observed_at, observed_at, uri,
             ),
         )
         return uri

--- a/src/paperboy/store/peers.py
+++ b/src/paperboy/store/peers.py
@@ -6,6 +6,14 @@ authoritative. If a fuller (non-min) row already exists, a `min` observation
 updates only *where we last saw it referenced* (`seen_in_chat`/`seen_in_msg`,
 used later for `inputPeerFromMessage`) and `last_seen`, never clobbering the
 richer stored profile with blanks.
+
+Observations can arrive out of order — a live re-run, and especially replay
+(ADR-0005 §6, which replays one historical run at a time and can revisit an
+id observed earlier by a later run) — so every upsert here is
+newest-observation-wins, not last-write-wins: current-state columns only
+move when the incoming `observed_at` is at least as new as the stored
+`last_seen`, while `first_seen`/`last_seen` themselves always widen to the
+true min/max window regardless of arrival order.
 """
 
 from __future__ import annotations
@@ -60,10 +68,20 @@ def upsert_peer(
 
     existing = store.conn.execute("SELECT is_min FROM peers WHERE uri=?", (uri,)).fetchone()
     if is_min and existing is not None and not existing["is_min"]:
+        # Newest-observation-wins (ADR-0005 §6): only move provenance forward
+        # when this observation is at least as new as what is stored; the
+        # window always widens.
         store.conn.execute(
-            "UPDATE peers SET seen_in_chat=?, seen_in_msg=?, source_raw_id=?, last_seen=? "
+            "UPDATE peers SET "
+            "seen_in_chat = CASE WHEN ? >= last_seen THEN ? ELSE seen_in_chat END, "
+            "seen_in_msg  = CASE WHEN ? >= last_seen THEN ? ELSE seen_in_msg  END, "
+            "source_raw_id = CASE WHEN ? >= last_seen THEN ? ELSE source_raw_id END, "
+            "last_seen = MAX(last_seen, ?) "
             "WHERE uri=?",
-            (seen_in_chat, seen_in_msg, source_raw_id, observed_at, uri),
+            (
+                observed_at, seen_in_chat, observed_at, seen_in_msg,
+                observed_at, source_raw_id, observed_at, uri,
+            ),
         )
         return uri
 
@@ -78,19 +96,35 @@ def upsert_peer(
             first_seen, last_seen
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(uri) DO UPDATE SET
-            kind=excluded.kind,
-            id=excluded.id,
-            access_hash=excluded.access_hash,
-            is_min=excluded.is_min,
-            seen_in_chat=excluded.seen_in_chat,
-            seen_in_msg=excluded.seen_in_msg,
-            username=excluded.username,
-            first_name=excluded.first_name,
-            last_name=excluded.last_name,
-            title=excluded.title,
-            flags_json=excluded.flags_json,
-            source_raw_id=excluded.source_raw_id,
-            last_seen=excluded.last_seen
+            -- newest-observation-wins (ADR-0005 §6): current-state columns
+            -- only move forward when this observation is at least as new as
+            -- what is stored; the seen window always widens (MIN/MAX below).
+            kind = CASE WHEN excluded.last_seen >= peers.last_seen
+                        THEN excluded.kind ELSE peers.kind END,
+            id = CASE WHEN excluded.last_seen >= peers.last_seen
+                      THEN excluded.id ELSE peers.id END,
+            access_hash = CASE WHEN excluded.last_seen >= peers.last_seen
+                               THEN excluded.access_hash ELSE peers.access_hash END,
+            is_min = CASE WHEN excluded.last_seen >= peers.last_seen
+                          THEN excluded.is_min ELSE peers.is_min END,
+            seen_in_chat = CASE WHEN excluded.last_seen >= peers.last_seen
+                                THEN excluded.seen_in_chat ELSE peers.seen_in_chat END,
+            seen_in_msg = CASE WHEN excluded.last_seen >= peers.last_seen
+                               THEN excluded.seen_in_msg ELSE peers.seen_in_msg END,
+            username = CASE WHEN excluded.last_seen >= peers.last_seen
+                            THEN excluded.username ELSE peers.username END,
+            first_name = CASE WHEN excluded.last_seen >= peers.last_seen
+                              THEN excluded.first_name ELSE peers.first_name END,
+            last_name = CASE WHEN excluded.last_seen >= peers.last_seen
+                             THEN excluded.last_name ELSE peers.last_name END,
+            title = CASE WHEN excluded.last_seen >= peers.last_seen
+                         THEN excluded.title ELSE peers.title END,
+            flags_json = CASE WHEN excluded.last_seen >= peers.last_seen
+                              THEN excluded.flags_json ELSE peers.flags_json END,
+            source_raw_id = CASE WHEN excluded.last_seen >= peers.last_seen
+                                 THEN excluded.source_raw_id ELSE peers.source_raw_id END,
+            first_seen = MIN(peers.first_seen, excluded.first_seen),
+            last_seen = MAX(peers.last_seen, excluded.last_seen)
         """,
         (
             uri, kind, id_, obj.get("access_hash"), int(is_min), seen_in_chat, seen_in_msg,

--- a/src/paperboy/store/repliers.py
+++ b/src/paperboy/store/repliers.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import json
 
-from paperboy.ids import msg_uri, peer_ref_uri, utc_now_iso
+from paperboy.ids import msg_uri, peer_ref_uri
 from paperboy.store.db import Store
 from paperboy.store.edges import add_edge_once
 from paperboy.store.peers import upsert_peer
@@ -50,7 +50,7 @@ def backfill_recent_repliers(store: Store, channel_id: int, tier: str) -> int:
         # describe what happens to be in the table. `kind` is matched
         # case-insensitively — `add_raw` records the TL discriminator verbatim,
         # and both `Message` and `message` occur in practice.
-        "SELECT id, payload_json FROM raw_records "
+        "SELECT id, observed_at, payload_json FROM raw_records "
         "WHERE lower(kind) = 'message' "
         "AND json_extract(context_json, '$.channel_id') = ?",
         (channel_id,),
@@ -64,7 +64,10 @@ def backfill_recent_repliers(store: Store, channel_id: int, tier: str) -> int:
         if not repliers or post_id is None:
             continue
 
-        observed_at = utc_now_iso()
+        # The stamp of the message OBSERVATION that carried this replier
+        # sample (D3) — projecting it costs no RPC, so "now" would make the
+        # edge unreproducible from raw alone on reproject.
+        observed_at = row["observed_at"]
         post_uri = msg_uri(channel_id, post_id)
         for peer in repliers:
             stub = _peer_stub(peer)

--- a/src/paperboy/web/client.py
+++ b/src/paperboy/web/client.py
@@ -16,6 +16,7 @@ request. A disallowed host — initial or redirected-to — raises
 
 from __future__ import annotations
 
+from typing import Protocol
 from urllib.parse import urlsplit
 
 import httpx
@@ -30,6 +31,13 @@ _MAX_REDIRECTS = 5
 
 class DisallowedHostError(Exception):
     """Raised for a URL (initial or a redirect target) whose host isn't allow-listed."""
+
+
+class WebGetter(Protocol):
+    """The shape `WebCollector` needs from an HTTP client — satisfied by the
+    real `WebClient` and by `replay.RawReplayWebClient` (spec §4)."""
+
+    def get(self, url: str) -> httpx.Response: ...
 
 
 def _host_of(url: str) -> str:

--- a/tests/fixtures/reproject/parity_golden.json
+++ b/tests/fixtures/reproject/parity_golden.json
@@ -290,6 +290,7 @@
    "kind": "MediaDownload",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"file_name\": \"a.txt\", \"kind\": \"document\", \"message_uri\": \"tg:msg:5/2\", \"mime_type\": \"text/plain\", \"path\": \"<DATA_DIR>/default/media/7b/7bb6f9f7a47a63e684925af3608c059edcc371eb81188c48c9714896fb1091fd.txt\", \"sha256\": \"7bb6f9f7a47a63e684925af3608c059edcc371eb81188c48c9714896fb1091fd\", \"size\": 13}",
+   "run_id": "run-0001",
    "tier": "stranger"
   },
   {
@@ -298,6 +299,7 @@
    "kind": "SponsoredMessage",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"_\": \"SponsoredMessage\", \"additional_info\": \"Promoted\", \"button_text\": \"View\", \"message\": \"Check this out\", \"random_id\": \"AAAAAAAA\", \"sponsor_info\": \"Acme Corp\", \"title\": \"Sponsor Title\", \"url\": \"https://t.me/sponsorchannel\"}",
+   "run_id": "run-0001",
    "tier": "stranger"
   },
   {
@@ -306,6 +308,7 @@
    "kind": "messages.chatFull",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"_\": \"messages.chatFull\", \"chats\": [{\"_\": \"channel\", \"access_hash\": 99, \"broadcast\": true, \"id\": 5, \"title\": \"Durov\", \"username\": \"durov\"}], \"full_chat\": {\"_\": \"channelFull\", \"about\": \"x\", \"id\": 5, \"linked_chat_id\": 0, \"participants_count\": 100, \"pts\": 42}, \"users\": []}",
+   "run_id": "run-0001",
    "tier": "stranger"
   },
   {
@@ -314,6 +317,7 @@
    "kind": "message",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"_\": \"message\", \"date\": 1767322500, \"entities\": [{\"_\": \"MessageEntityUrl\", \"length\": 24, \"offset\": 4}], \"id\": 3, \"message\": \"see https://t.me/other_channel\", \"views\": 10}",
+   "run_id": "run-0001",
    "tier": "stranger"
   },
   {
@@ -322,6 +326,7 @@
    "kind": "message",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"_\": \"message\", \"date\": 1767322445, \"id\": 2, \"media\": {\"_\": \"MessageMediaDocument\", \"document\": {\"_\": \"Document\", \"access_hash\": 1, \"attributes\": [{\"_\": \"DocumentAttributeFilename\", \"file_name\": \"a.txt\"}], \"id\": 9, \"mime_type\": \"text/plain\"}}, \"message\": \"\"}",
+   "run_id": "run-0001",
    "tier": "stranger"
   },
   {
@@ -330,6 +335,7 @@
    "kind": "message",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"_\": \"message\", \"date\": 1767322400, \"id\": 1, \"message\": \"m1\"}",
+   "run_id": "run-0001",
    "tier": "stranger"
   },
   {
@@ -338,6 +344,7 @@
    "kind": "updates.channelDifference",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"_\": \"updates.channelDifference\", \"final\": true, \"new_messages\": [{\"_\": \"message\", \"date\": 1767322400, \"edit_date\": 1767322600, \"id\": 1, \"message\": \"m1 edited\"}], \"other_updates\": [], \"pts\": 43}",
+   "run_id": "run-0001",
    "tier": "stranger"
   },
   {
@@ -346,6 +353,7 @@
    "kind": "message",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"_\": \"message\", \"date\": 1767322400, \"edit_date\": 1767322600, \"id\": 1, \"message\": \"m1 edited\"}",
+   "run_id": "run-0001",
    "tier": "stranger"
   },
   {
@@ -354,6 +362,7 @@
    "kind": "ChatsSlice",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"_\": \"ChatsSlice\", \"chats\": [{\"_\": \"Channel\", \"access_hash\": 1001, \"broadcast\": true, \"id\": 501, \"title\": \"Similar One\", \"username\": \"similarone\"}, {\"_\": \"Channel\", \"access_hash\": 1002, \"broadcast\": true, \"id\": 502, \"title\": \"Similar Two\", \"username\": \"similartwo\"}], \"count\": 37}",
+   "run_id": "run-0001",
    "tier": "stranger"
   },
   {
@@ -362,6 +371,7 @@
    "kind": "tme_page",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"status_code\": 200, \"text\": \"<html><body>\\n<div class=\\\"tgme_widget_message\\\" data-post=\\\"durov/1\\\">\\n  <div class=\\\"tgme_widget_message_text\\\">m1</div>\\n  <time datetime=\\\"2026-01-01T00:00:00+00:00\\\"></time>\\n</div>\\n</body></html>\", \"url\": \"https://t.me/s/durov\"}",
+   "run_id": "run-0001",
    "tier": "stranger"
   },
   {
@@ -370,6 +380,7 @@
    "kind": "tme_page",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"status_code\": 200, \"text\": \"<html><body></body></html>\", \"url\": \"https://t.me/s/durov?before=1\"}",
+   "run_id": "run-0001",
    "tier": "stranger"
   },
   {
@@ -378,6 +389,7 @@
    "kind": "wayback_cdx",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"status_code\": 200, \"text\": \"[[\\\"urlkey\\\", \\\"timestamp\\\", \\\"original\\\", \\\"mimetype\\\", \\\"statuscode\\\", \\\"digest\\\", \\\"length\\\"], [\\\"me,t)/s/durov\\\", \\\"20260101000000\\\", \\\"https://t.me/s/durov\\\", \\\"text/html\\\", \\\"200\\\", \\\"DIGEST1\\\", \\\"1234\\\"]]\", \"url\": \"https://web.archive.org/cdx/search/cdx?url=t.me/s/durov*&output=json&filter=statuscode:200&collapse=digest&limit=10000\"}",
+   "run_id": "run-0001",
    "tier": "stranger"
   },
   {
@@ -386,6 +398,7 @@
    "kind": "contacts.resolvedPeer",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"_\": \"contacts.resolvedPeer\", \"chats\": [{\"_\": \"channel\", \"access_hash\": 99, \"broadcast\": true, \"id\": 5, \"title\": \"Durov\", \"username\": \"durov\"}], \"peer\": {\"_\": \"PeerChannel\", \"channel_id\": 5}, \"users\": []}",
+   "run_id": "run-0001",
    "tier": "stranger"
   },
   {
@@ -394,6 +407,7 @@
    "kind": "user",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"_\": \"user\", \"id\": 1, \"self\": true}",
+   "run_id": "run-0001",
    "tier": "self"
   }
  ],

--- a/tests/fixtures/reproject/parity_golden.json
+++ b/tests/fixtures/reproject/parity_golden.json
@@ -1,0 +1,511 @@
+{
+ "channel_snapshots": [
+  {
+   "about_hash": "2d711642b726b04401627ca9fbac32f5c8530fb1903cc4db02258717921a4881",
+   "channel_id": 5,
+   "id": 1,
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "online_count": null,
+   "participants_count": 100,
+   "source_raw_id": 3,
+   "title": "Durov",
+   "username": "durov"
+  }
+ ],
+ "channels": [
+  {
+   "about": "x",
+   "created_at": null,
+   "first_seen": "2026-01-01T00:00:00+00:00",
+   "flags_json": "{\"broadcast\": true}",
+   "id": 5,
+   "kind": "broadcast",
+   "last_seen": "2026-01-01T00:00:00+00:00",
+   "linked_chat_id": null,
+   "participants_count": 100,
+   "restriction_json": null,
+   "source_raw_id": 3,
+   "title": "Durov",
+   "uri": "tg:channel:5",
+   "username": "durov"
+  }
+ ],
+ "custody_log": [
+  {
+   "id": 1,
+   "path": "<DATA_DIR>/default/media/7b/7bb6f9f7a47a63e684925af3608c059edcc371eb81188c48c9714896fb1091fd.txt",
+   "recorded_at": "2026-01-01T00:00:00+00:00",
+   "sha256": "7bb6f9f7a47a63e684925af3608c059edcc371eb81188c48c9714896fb1091fd",
+   "source_message_uri": "tg:msg:5/2"
+  }
+ ],
+ "edges": [
+  {
+   "evidence_json": "{\"entity\": \"MessageEntityUrl\", \"url\": \"https://t.me/other_chann\"}",
+   "id": 3,
+   "object_uri": "tg:username:other_chann",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "predicate": "mentions",
+   "source_raw_id": 4,
+   "subject_uri": "tg:msg:5/3",
+   "tier": "stranger"
+  },
+  {
+   "evidence_json": "{\"source\": \"sponsored\", \"sponsor_info\": \"Acme Corp\", \"title\": \"Sponsor Title\", \"url\": \"https://t.me/sponsorchannel\"}",
+   "id": 4,
+   "object_uri": "tg:username:sponsorchannel",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "predicate": "mentions",
+   "source_raw_id": 10,
+   "subject_uri": "tg:channel:5",
+   "tier": "stranger"
+  },
+  {
+   "evidence_json": "{\"total_count\": 37}",
+   "id": 1,
+   "object_uri": "tg:channel:501",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "predicate": "recommended_with",
+   "source_raw_id": 9,
+   "subject_uri": "tg:channel:5",
+   "tier": "stranger"
+  },
+  {
+   "evidence_json": "{\"total_count\": 37}",
+   "id": 2,
+   "object_uri": "tg:channel:502",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "predicate": "recommended_with",
+   "source_raw_id": 9,
+   "subject_uri": "tg:channel:5",
+   "tier": "stranger"
+  }
+ ],
+ "media": [
+  {
+   "attributes_json": "[{\"_\": \"DocumentAttributeFilename\", \"file_name\": \"a.txt\"}]",
+   "downloaded_at": "2026-01-01T00:00:00+00:00",
+   "exif_json": null,
+   "file_name": "a.txt",
+   "kind": "document",
+   "message_uri": "tg:msg:5/2",
+   "mime_type": "text/plain",
+   "path": "<DATA_DIR>/default/media/7b/7bb6f9f7a47a63e684925af3608c059edcc371eb81188c48c9714896fb1091fd.txt",
+   "sha256": "7bb6f9f7a47a63e684925af3608c059edcc371eb81188c48c9714896fb1091fd",
+   "size": 13
+  }
+ ],
+ "message_metrics": [
+  {
+   "forwards": null,
+   "id": 1,
+   "message_uri": "tg:msg:5/3",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "reactions_json": null,
+   "replies": null,
+   "views": 10
+  }
+ ],
+ "message_revisions": [
+  {
+   "content_hash": "b8383b252cc26516dbeb87c69fe748e07f993ebfba2a96ccfeabd21e63fcd906",
+   "edit_date": null,
+   "entities_json": "[{\"_\": \"MessageEntityUrl\", \"length\": 24, \"offset\": 4}]",
+   "id": 1,
+   "media_json": null,
+   "message_uri": "tg:msg:5/3",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "source_raw_id": 4,
+   "text": "see https://t.me/other_channel"
+  },
+  {
+   "content_hash": "c9a6f3d62c0fc4d3d70b0a279e52e404ba7ebd44de82f7ad784a89800f09e322",
+   "edit_date": null,
+   "entities_json": null,
+   "id": 3,
+   "media_json": null,
+   "message_uri": "tg:msg:5/1",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "source_raw_id": 6,
+   "text": "m1"
+  },
+  {
+   "content_hash": "d9b8e2f1d655c91e6216db7882860bd91daf169c58790140aa5f7e2231232e75",
+   "edit_date": null,
+   "entities_json": null,
+   "id": 2,
+   "media_json": "{\"_\": \"MessageMediaDocument\", \"document\": {\"_\": \"Document\", \"access_hash\": 1, \"attributes\": [{\"_\": \"DocumentAttributeFilename\", \"file_name\": \"a.txt\"}], \"id\": 9, \"mime_type\": \"text/plain\"}}",
+   "message_uri": "tg:msg:5/2",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "source_raw_id": 5,
+   "text": ""
+  },
+  {
+   "content_hash": "dda82ba9e87abca05597a883a3bf57a79e24f9ea42cb75a8f34f3fce2ab051ea",
+   "edit_date": "2026-01-02T02:56:40+00:00",
+   "entities_json": null,
+   "id": 4,
+   "media_json": null,
+   "message_uri": "tg:msg:5/1",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "source_raw_id": 8,
+   "text": "m1 edited"
+  }
+ ],
+ "message_tombstones": [],
+ "messages": [
+  {
+   "action_json": null,
+   "channel_id": 5,
+   "content_hash": "b8383b252cc26516dbeb87c69fe748e07f993ebfba2a96ccfeabd21e63fcd906",
+   "date": "2026-01-02T02:55:00+00:00",
+   "deleted_at": null,
+   "edit_date": null,
+   "entities_json": "[{\"_\": \"MessageEntityUrl\", \"length\": 24, \"offset\": 4}]",
+   "first_seen": "2026-01-01T00:00:00+00:00",
+   "from_uri": null,
+   "fwd_json": null,
+   "grouped_id": null,
+   "is_service": 0,
+   "last_seen": "2026-01-01T00:00:00+00:00",
+   "media_json": null,
+   "media_kind": null,
+   "msg_id": 3,
+   "post_author": null,
+   "reply_to_msg_id": null,
+   "reply_to_top_id": null,
+   "source_raw_id": 4,
+   "text": "see https://t.me/other_channel",
+   "uri": "tg:msg:5/3",
+   "via_bot_id": null
+  },
+  {
+   "action_json": null,
+   "channel_id": 5,
+   "content_hash": "d9b8e2f1d655c91e6216db7882860bd91daf169c58790140aa5f7e2231232e75",
+   "date": "2026-01-02T02:54:05+00:00",
+   "deleted_at": null,
+   "edit_date": null,
+   "entities_json": null,
+   "first_seen": "2026-01-01T00:00:00+00:00",
+   "from_uri": null,
+   "fwd_json": null,
+   "grouped_id": null,
+   "is_service": 0,
+   "last_seen": "2026-01-01T00:00:00+00:00",
+   "media_json": "{\"_\": \"MessageMediaDocument\", \"document\": {\"_\": \"Document\", \"access_hash\": 1, \"attributes\": [{\"_\": \"DocumentAttributeFilename\", \"file_name\": \"a.txt\"}], \"id\": 9, \"mime_type\": \"text/plain\"}}",
+   "media_kind": "MessageMediaDocument",
+   "msg_id": 2,
+   "post_author": null,
+   "reply_to_msg_id": null,
+   "reply_to_top_id": null,
+   "source_raw_id": 5,
+   "text": "",
+   "uri": "tg:msg:5/2",
+   "via_bot_id": null
+  },
+  {
+   "action_json": null,
+   "channel_id": 5,
+   "content_hash": "dda82ba9e87abca05597a883a3bf57a79e24f9ea42cb75a8f34f3fce2ab051ea",
+   "date": "2026-01-02T02:53:20+00:00",
+   "deleted_at": null,
+   "edit_date": "2026-01-02T02:56:40+00:00",
+   "entities_json": null,
+   "first_seen": "2026-01-01T00:00:00+00:00",
+   "from_uri": null,
+   "fwd_json": null,
+   "grouped_id": null,
+   "is_service": 0,
+   "last_seen": "2026-01-01T00:00:00+00:00",
+   "media_json": null,
+   "media_kind": null,
+   "msg_id": 1,
+   "post_author": null,
+   "reply_to_msg_id": null,
+   "reply_to_top_id": null,
+   "source_raw_id": 8,
+   "text": "m1 edited",
+   "uri": "tg:msg:5/1",
+   "via_bot_id": null
+  }
+ ],
+ "peers": [
+  {
+   "access_hash": 1001,
+   "first_name": null,
+   "first_seen": "2026-01-01T00:00:00+00:00",
+   "flags_json": "{\"broadcast\": true}",
+   "id": 501,
+   "is_min": 0,
+   "kind": "channel",
+   "last_name": null,
+   "last_seen": "2026-01-01T00:00:00+00:00",
+   "seen_in_chat": null,
+   "seen_in_msg": null,
+   "source_raw_id": 9,
+   "title": "Similar One",
+   "uri": "tg:channel:501",
+   "username": "similarone"
+  },
+  {
+   "access_hash": 1002,
+   "first_name": null,
+   "first_seen": "2026-01-01T00:00:00+00:00",
+   "flags_json": "{\"broadcast\": true}",
+   "id": 502,
+   "is_min": 0,
+   "kind": "channel",
+   "last_name": null,
+   "last_seen": "2026-01-01T00:00:00+00:00",
+   "seen_in_chat": null,
+   "seen_in_msg": null,
+   "source_raw_id": 9,
+   "title": "Similar Two",
+   "uri": "tg:channel:502",
+   "username": "similartwo"
+  },
+  {
+   "access_hash": 99,
+   "first_name": null,
+   "first_seen": "2026-01-01T00:00:00+00:00",
+   "flags_json": "{\"broadcast\": true}",
+   "id": 5,
+   "is_min": 0,
+   "kind": "channel",
+   "last_name": null,
+   "last_seen": "2026-01-01T00:00:00+00:00",
+   "seen_in_chat": null,
+   "seen_in_msg": null,
+   "source_raw_id": 3,
+   "title": "Durov",
+   "uri": "tg:channel:5",
+   "username": "durov"
+  }
+ ],
+ "raw_records": [
+  {
+   "context_json": "{\"channel_id\": 5, \"msg_id\": 2}",
+   "id": 14,
+   "kind": "MediaDownload",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "payload_json": "{\"file_name\": \"a.txt\", \"kind\": \"document\", \"message_uri\": \"tg:msg:5/2\", \"mime_type\": \"text/plain\", \"path\": \"<DATA_DIR>/default/media/7b/7bb6f9f7a47a63e684925af3608c059edcc371eb81188c48c9714896fb1091fd.txt\", \"sha256\": \"7bb6f9f7a47a63e684925af3608c059edcc371eb81188c48c9714896fb1091fd\", \"size\": 13}",
+   "tier": "stranger"
+  },
+  {
+   "context_json": "{\"channel_id\": 5}",
+   "id": 10,
+   "kind": "SponsoredMessage",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "payload_json": "{\"_\": \"SponsoredMessage\", \"additional_info\": \"Promoted\", \"button_text\": \"View\", \"message\": \"Check this out\", \"random_id\": \"AAAAAAAA\", \"sponsor_info\": \"Acme Corp\", \"title\": \"Sponsor Title\", \"url\": \"https://t.me/sponsorchannel\"}",
+   "tier": "stranger"
+  },
+  {
+   "context_json": "{\"channel_id\": 5}",
+   "id": 3,
+   "kind": "messages.chatFull",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "payload_json": "{\"_\": \"messages.chatFull\", \"chats\": [{\"_\": \"channel\", \"access_hash\": 99, \"broadcast\": true, \"id\": 5, \"title\": \"Durov\", \"username\": \"durov\"}], \"full_chat\": {\"_\": \"channelFull\", \"about\": \"x\", \"id\": 5, \"linked_chat_id\": 0, \"participants_count\": 100, \"pts\": 42}, \"users\": []}",
+   "tier": "stranger"
+  },
+  {
+   "context_json": "{\"channel_id\": 5}",
+   "id": 4,
+   "kind": "message",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "payload_json": "{\"_\": \"message\", \"date\": 1767322500, \"entities\": [{\"_\": \"MessageEntityUrl\", \"length\": 24, \"offset\": 4}], \"id\": 3, \"message\": \"see https://t.me/other_channel\", \"views\": 10}",
+   "tier": "stranger"
+  },
+  {
+   "context_json": "{\"channel_id\": 5}",
+   "id": 5,
+   "kind": "message",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "payload_json": "{\"_\": \"message\", \"date\": 1767322445, \"id\": 2, \"media\": {\"_\": \"MessageMediaDocument\", \"document\": {\"_\": \"Document\", \"access_hash\": 1, \"attributes\": [{\"_\": \"DocumentAttributeFilename\", \"file_name\": \"a.txt\"}], \"id\": 9, \"mime_type\": \"text/plain\"}}, \"message\": \"\"}",
+   "tier": "stranger"
+  },
+  {
+   "context_json": "{\"channel_id\": 5}",
+   "id": 6,
+   "kind": "message",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "payload_json": "{\"_\": \"message\", \"date\": 1767322400, \"id\": 1, \"message\": \"m1\"}",
+   "tier": "stranger"
+  },
+  {
+   "context_json": "{\"channel_id\": 5}",
+   "id": 7,
+   "kind": "updates.channelDifference",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "payload_json": "{\"_\": \"updates.channelDifference\", \"final\": true, \"new_messages\": [{\"_\": \"message\", \"date\": 1767322400, \"edit_date\": 1767322600, \"id\": 1, \"message\": \"m1 edited\"}], \"other_updates\": [], \"pts\": 43}",
+   "tier": "stranger"
+  },
+  {
+   "context_json": "{\"channel_id\": 5}",
+   "id": 8,
+   "kind": "message",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "payload_json": "{\"_\": \"message\", \"date\": 1767322400, \"edit_date\": 1767322600, \"id\": 1, \"message\": \"m1 edited\"}",
+   "tier": "stranger"
+  },
+  {
+   "context_json": "{\"channel_id\": 5}",
+   "id": 9,
+   "kind": "ChatsSlice",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "payload_json": "{\"_\": \"ChatsSlice\", \"chats\": [{\"_\": \"Channel\", \"access_hash\": 1001, \"broadcast\": true, \"id\": 501, \"title\": \"Similar One\", \"username\": \"similarone\"}, {\"_\": \"Channel\", \"access_hash\": 1002, \"broadcast\": true, \"id\": 502, \"title\": \"Similar Two\", \"username\": \"similartwo\"}], \"count\": 37}",
+   "tier": "stranger"
+  },
+  {
+   "context_json": "{\"channel_username\": \"durov\"}",
+   "id": 11,
+   "kind": "tme_page",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "payload_json": "{\"status_code\": 200, \"text\": \"<html><body>\\n<div class=\\\"tgme_widget_message\\\" data-post=\\\"durov/1\\\">\\n  <div class=\\\"tgme_widget_message_text\\\">m1</div>\\n  <time datetime=\\\"2026-01-01T00:00:00+00:00\\\"></time>\\n</div>\\n</body></html>\", \"url\": \"https://t.me/s/durov\"}",
+   "tier": "stranger"
+  },
+  {
+   "context_json": "{\"channel_username\": \"durov\"}",
+   "id": 12,
+   "kind": "tme_page",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "payload_json": "{\"status_code\": 200, \"text\": \"<html><body></body></html>\", \"url\": \"https://t.me/s/durov?before=1\"}",
+   "tier": "stranger"
+  },
+  {
+   "context_json": "{\"channel_username\": \"durov\"}",
+   "id": 13,
+   "kind": "wayback_cdx",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "payload_json": "{\"status_code\": 200, \"text\": \"[[\\\"urlkey\\\", \\\"timestamp\\\", \\\"original\\\", \\\"mimetype\\\", \\\"statuscode\\\", \\\"digest\\\", \\\"length\\\"], [\\\"me,t)/s/durov\\\", \\\"20260101000000\\\", \\\"https://t.me/s/durov\\\", \\\"text/html\\\", \\\"200\\\", \\\"DIGEST1\\\", \\\"1234\\\"]]\", \"url\": \"https://web.archive.org/cdx/search/cdx?url=t.me/s/durov*&output=json&filter=statuscode:200&collapse=digest&limit=10000\"}",
+   "tier": "stranger"
+  },
+  {
+   "context_json": "{\"target\": \"@durov\"}",
+   "id": 2,
+   "kind": "contacts.resolvedPeer",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "payload_json": "{\"_\": \"contacts.resolvedPeer\", \"chats\": [{\"_\": \"channel\", \"access_hash\": 99, \"broadcast\": true, \"id\": 5, \"title\": \"Durov\", \"username\": \"durov\"}], \"peer\": {\"_\": \"PeerChannel\", \"channel_id\": 5}, \"users\": []}",
+   "tier": "stranger"
+  },
+  {
+   "context_json": null,
+   "id": 1,
+   "kind": "user",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "payload_json": "{\"_\": \"user\", \"id\": 1, \"self\": true}",
+   "tier": "self"
+  }
+ ],
+ "run_events": [
+  {
+   "channel_id": 5,
+   "detail_json": "{\"counts\": {\"backfilled_peers\": 0, \"edges\": 0, \"messages\": 0, \"revisions\": 0, \"tombstones\": 0, \"unmapped\": 0}, \"stopped\": \"no linked discussion group\"}",
+   "id": 3,
+   "kind": "complete",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "phase": "discussion"
+  },
+  {
+   "channel_id": 5,
+   "detail_json": "{\"counts\": {\"channels\": 1, \"peers\": 1}, \"stopped\": null}",
+   "id": 1,
+   "kind": "complete",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "phase": "channel"
+  },
+  {
+   "channel_id": 5,
+   "detail_json": "{\"counts\": {\"deleted_recovered\": 0, \"tme_posts\": 1, \"wayback_rows\": 1}, \"stopped\": null}",
+   "id": 5,
+   "kind": "complete",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "phase": "web"
+  },
+  {
+   "channel_id": 5,
+   "detail_json": "{\"counts\": {\"downloaded\": 1, \"duplicates\": 0, \"skipped\": 0, \"skipped_kind\": 0, \"unavailable\": 0}, \"stopped\": null}",
+   "id": 6,
+   "kind": "complete",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "phase": "media"
+  },
+  {
+   "channel_id": 5,
+   "detail_json": "{\"counts\": {\"edges\": 0, \"messages\": 4, \"revisions\": 4, \"tombstones\": 0}, \"stopped\": null}",
+   "id": 2,
+   "kind": "complete",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "phase": "history"
+  },
+  {
+   "channel_id": 5,
+   "detail_json": "{\"counts\": {\"edges\": 4, \"peers\": 2, \"raw\": 2, \"skipped\": 0}, \"stopped\": null}",
+   "id": 4,
+   "kind": "complete",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "phase": "graph"
+  }
+ ],
+ "sync_ranges": [
+  {
+   "channel_id": 5,
+   "hi": 3,
+   "id": 1,
+   "lo": 1
+  }
+ ],
+ "sync_state": [
+  {
+   "key": "5",
+   "scope": "channel",
+   "value_json": "{\"pts\": 43}"
+  },
+  {
+   "key": "5",
+   "scope": "history",
+   "value_json": "{\"offset_id\": 1}"
+  },
+  {
+   "key": "5",
+   "scope": "history_sweep",
+   "value_json": "{\"backfill_complete\": true, \"incremental_in_progress\": false, \"max_id_seen\": 3, \"pending_high\": 3}"
+  },
+  {
+   "key": "durov",
+   "scope": "web_tme",
+   "value_json": "{\"newest_seen\": 1}"
+  },
+  {
+   "key": "self",
+   "scope": "account",
+   "value_json": "{\"id\": 1, \"uri\": \"tg:user:1\"}"
+  }
+ ],
+ "web_snapshots": [
+  {
+   "channel_username": "durov",
+   "content_hash": "DIGEST1",
+   "fetched_at": "2026-01-01T00:00:00+00:00",
+   "id": 2,
+   "meta_json": "{\"length\": \"1234\", \"mimetype\": \"text/html\", \"statuscode\": \"200\"}",
+   "msg_id": null,
+   "raw": "{\"digest\": \"DIGEST1\", \"length\": \"1234\", \"mimetype\": \"text/html\", \"original\": \"https://t.me/s/durov\", \"statuscode\": \"200\", \"timestamp\": \"20260101000000\", \"urlkey\": \"me,t)/s/durov\"}",
+   "source": "wayback",
+   "timestamp": "2026-01-01T00:00:00+00:00",
+   "url": "https://t.me/s/durov"
+  },
+  {
+   "channel_username": "durov",
+   "content_hash": "ca0df2c95aa144c1d0ff2ff3c8f967fdc1de9ef0c4120b3726416701b519d619",
+   "fetched_at": "2026-01-01T00:00:00+00:00",
+   "id": 1,
+   "meta_json": "{\"author_signature\": null, \"forwarded_from\": null, \"tombstoned_in_store\": false, \"views\": null}",
+   "msg_id": 1,
+   "raw": "{\"author_signature\": null, \"datetime\": \"2026-01-01T00:00:00+00:00\", \"forwarded_from\": null, \"post_id\": \"durov/1\", \"text\": \"m1\", \"views\": null}",
+   "source": "tme",
+   "timestamp": "2026-01-01T00:00:00+00:00",
+   "url": "https://t.me/durov/1"
+  }
+ ]
+}

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -1,0 +1,68 @@
+"""tests/test_clock.py"""
+
+from __future__ import annotations
+
+import pytest
+
+from paperboy.clock import LiveClock, ReplayClock, ReplayClockError
+from paperboy.store.db import Store, dumps
+
+
+def test_live_clock_returns_fresh_iso_utc():
+    t = LiveClock().for_payload({"_": "Message", "id": 1})
+    assert t.endswith("+00:00")
+
+
+def test_replay_clock_returns_served_payloads_stamp():
+    clock = ReplayClock()
+    m1, m2 = {"_": "Message", "id": 1}, {"_": "Message", "id": 2}
+    clock.serve("2026-01-01T00:00:01+00:00", m1)
+    clock.serve("2026-01-01T00:00:02+00:00", m2)
+    # Payload-keyed: order of lookup does not matter (history consumes a
+    # whole page before projecting each message).
+    assert clock.for_payload(m2) == "2026-01-01T00:00:02+00:00"
+    assert clock.for_payload(m1) == "2026-01-01T00:00:01+00:00"
+    # Lookup is by value, not object identity — a re-parsed equal dict hits.
+    assert clock.for_payload({"_": "Message", "id": 1}) == "2026-01-01T00:00:01+00:00"
+
+
+def test_replay_clock_serve_json_matches_dict_lookup():
+    clock = ReplayClock()
+    payload = {"sha256": "ab", "kind": "photo"}
+    clock.serve_json("2026-01-01T00:00:03+00:00", dumps(payload))
+    assert clock.for_payload(payload) == "2026-01-01T00:00:03+00:00"
+
+
+def test_replay_clock_unknown_payload_falls_back_to_last_served():
+    clock = ReplayClock()
+    clock.serve("2026-01-01T00:00:04+00:00", {"_": "ChannelDifference"})
+    # A nested dict with no individually-stored record inherits its
+    # envelope's stamp.
+    assert clock.for_payload({"_": "novel"}) == "2026-01-01T00:00:04+00:00"
+
+
+def test_replay_clock_raises_before_anything_served():
+    with pytest.raises(ReplayClockError):
+        ReplayClock().for_payload({"_": "x"})
+
+
+def test_begin_batch_clears_registry_but_keeps_current():
+    clock = ReplayClock()
+    clock.serve("2026-01-01T00:00:05+00:00", {"_": "a"})
+    clock.begin_batch()
+    assert clock.for_payload({"_": "a"}) == "2026-01-01T00:00:05+00:00"  # fallback
+
+
+def test_add_raw_accepts_explicit_observed_at(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as store:
+        store.add_raw("Message", {"_": "Message", "id": 1}, "stranger",
+                      {"channel_id": 5}, observed_at="2026-01-01T00:00:06+00:00")
+        row = store.conn.execute("SELECT observed_at FROM raw_records").fetchone()
+        assert row["observed_at"] == "2026-01-01T00:00:06+00:00"
+
+
+def test_add_raw_defaults_to_now(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as store:
+        store.add_raw("Message", {"_": "Message", "id": 1}, "stranger", None)
+        row = store.conn.execute("SELECT observed_at FROM raw_records").fetchone()
+        assert row["observed_at"].endswith("+00:00")

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -66,3 +66,24 @@ def test_add_raw_defaults_to_now(tmp_path):
         store.add_raw("Message", {"_": "Message", "id": 1}, "stranger", None)
         row = store.conn.execute("SELECT observed_at FROM raw_records").fetchone()
         assert row["observed_at"].endswith("+00:00")
+
+
+def test_add_raw_stamps_the_begun_run(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as store:
+        rid = store.begin_run()
+        store.add_raw("Message", {"_": "Message", "id": 1}, "stranger", None)
+        row = store.conn.execute("SELECT run_id FROM raw_records").fetchone()
+        assert row["run_id"] == rid and len(rid) == 32
+
+
+def test_add_raw_without_begin_run_leaves_null(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as store:
+        store.add_raw("Message", {"_": "Message", "id": 1}, "stranger", None)
+        assert store.conn.execute(
+            "SELECT run_id FROM raw_records"
+        ).fetchone()["run_id"] is None
+
+
+def test_begin_run_accepts_injected_id(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as store:
+        assert store.begin_run("legacy-0001") == "legacy-0001"

--- a/tests/test_collector_channel.py
+++ b/tests/test_collector_channel.py
@@ -4,9 +4,11 @@ from pathlib import Path
 
 import pytest
 
+from paperboy.budget import SkipAndRecord
 from paperboy.collectors.base import CollectContext
 from paperboy.collectors.channel import ChannelCollector
 from paperboy.config import load_settings
+from paperboy.recipes import collect_channel
 from paperboy.store.db import Store
 from paperboy.store.sync import get_state
 from paperboy.targets import parse_target
@@ -135,8 +137,10 @@ async def test_channel_collector_picks_the_target_not_the_first_channel(tmp_path
 
 @pytest.mark.asyncio
 async def test_channel_collector_trusts_peer_over_the_chats_vector(tmp_path):
-    # A resolution whose `peer` is not a channel must fail loudly even when a
-    # channel happens to sit in `chats` — position is never identity.
+    # A resolution whose `peer` is not a channel must not be misattributed
+    # to whatever channel happens to sit in `chats` — position is never
+    # identity. A username can legitimately resolve to a user or basic group
+    # (issue #34), so this is a clean skip, not a crash (SkipAndRecord).
     fx = _fixtures()
     fx["resolve"] = {
         "_": "contacts.resolvedPeer",
@@ -149,8 +153,29 @@ async def test_channel_collector_trusts_peer_over_the_chats_vector(tmp_path):
             gw, st, load_settings("default", {}), parse_target("@durov"),
             None, None, "stranger", logging.getLogger("t"),
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(SkipAndRecord):
             await ChannelCollector().collect(ctx)
+
+
+@pytest.mark.asyncio
+async def test_non_channel_resolution_skips_cleanly_through_collect_channel(tmp_path):
+    # #34, run end-to-end: the whole run must not crash — the channel phase
+    # is recorded as a clean skip and later phases (none applicable here,
+    # since `history` needs `channel_id`) do not raise either.
+    fx = _fixtures()
+    fx["resolve"] = {
+        "_": "contacts.resolvedPeer",
+        "peer": {"_": "PeerUser", "user_id": 42},
+        "chats": fx["resolve"]["chats"], "users": [],
+    }
+    gw = FakeGateway(fx)
+    with Store.open(tmp_path / "p.sqlite") as st:
+        results = await collect_channel(
+            gw, st, load_settings("default", {}), parse_target("@durov"),
+            phases=["channel", "history"], log=logging.getLogger("t"),
+        )
+    channel_result = next(r for r in results if r.name == "channel")
+    assert channel_result.stopped == "skip"
 
 
 @pytest.mark.asyncio
@@ -182,7 +207,8 @@ async def test_channel_collector_rejects_resolve_full_identity_mismatch(tmp_path
 @pytest.mark.asyncio
 async def test_channel_collector_rejects_a_resolution_without_peer(tmp_path):
     # `contacts.ResolvedPeer` always carries `peer` in the wild; a response
-    # without it gives us no authoritative identity, so guessing is refused.
+    # without it gives us no authoritative identity, so guessing is refused —
+    # a clean skip (#34), not a crash.
     fx = _fixtures()
     del fx["resolve"]["peer"]
     gw = FakeGateway(fx)
@@ -191,5 +217,5 @@ async def test_channel_collector_rejects_a_resolution_without_peer(tmp_path):
             gw, st, load_settings("default", {}), parse_target("@durov"),
             None, None, "stranger", logging.getLogger("t"),
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(SkipAndRecord):
             await ChannelCollector().collect(ctx)

--- a/tests/test_replay_gateway.py
+++ b/tests/test_replay_gateway.py
@@ -384,6 +384,45 @@ def test_runs_raises_on_a_genuinely_interleaved_stamped_run_id(tmp_path):
         src.runs()
 
 
+def test_runs_splits_consecutive_all_opening_passes(tmp_path):
+    # `paperboy collect @x --phases channel` writes exactly self/Resolved-
+    # Peer/ChatFull — all three opening-kind — and nothing substantive. Two
+    # or more such passes in a row leave NO non-opening row between them to
+    # end the pending cluster, so the whole run of opening rows must be cut
+    # at each REPEATED role rather than folded into one giant cluster
+    # (correctness-reviewer, round 2): three back-to-back channel-only
+    # passes must yield three runs, not one.
+    db = tmp_path / "src.sqlite"
+    with Store.open(db) as st:  # no begin_run: run_id stays NULL (legacy)
+        for _ in range(3):
+            st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+            st.add_raw("ResolvedPeer", {"_": "contacts.resolvedPeer"}, "stranger",
+                       {"target": "@x"})
+            st.add_raw("ChatFull", {"_": "messages.chatFull"}, "stranger", {"channel_id": 5})
+    src = ReplaySource.open(db, tmp_path / "media")
+    assert [(r.run_id, r.lo, r.hi) for r in src.runs()] == [
+        ("legacy-0001", 1, 3), ("legacy-0002", 4, 6), ("legacy-0003", 7, 9),
+    ]
+
+
+def test_runs_splits_consecutive_resolve_full_self_passes(tmp_path):
+    # Same failure class as above, with the pre-invariant resolve/full/self
+    # ordering (see `test_runs_absorbs_resolve_before_self_at_every_
+    # boundary`): two back-to-back passes, each opening-only, must still cut
+    # at the second pass's `ResolvedPeer` (the first repeated role).
+    db = tmp_path / "src.sqlite"
+    with Store.open(db) as st:
+        for _ in range(2):
+            st.add_raw("ResolvedPeer", {"_": "contacts.resolvedPeer"}, "stranger",
+                       {"target": "@x"})
+            st.add_raw("ChatFull", {"_": "messages.chatFull"}, "stranger", {"channel_id": 5})
+            st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+    src = ReplaySource.open(db, tmp_path / "media")
+    assert [(r.run_id, r.lo, r.hi) for r in src.runs()] == [
+        ("legacy-0001", 1, 3), ("legacy-0002", 4, 6),
+    ]
+
+
 def test_runs_mixed_legacy_then_stamped(tmp_path):
     # Legacy segment(s) precede stamped runs — the migration boundary shape.
     db = tmp_path / "src.sqlite"

--- a/tests/test_replay_gateway.py
+++ b/tests/test_replay_gateway.py
@@ -5,6 +5,7 @@ involved."""
 from __future__ import annotations
 
 import sqlite3
+from pathlib import Path
 
 import pytest
 
@@ -222,6 +223,60 @@ def test_runs_segments_legacy_rows_at_self_markers(tmp_path):
     src = ReplaySource.open(db, tmp_path / "media")
     assert [(r.run_id, r.lo, r.hi) for r in src.runs()] == [
         ("legacy-0001", 1, 2), ("legacy-0002", 3, 4),
+    ]
+
+
+def test_runs_handles_a_source_predating_the_run_id_column(tmp_path):
+    # A real archive captured before this feature existed has only
+    # 0001_init/0002_web applied — raw_records has NO run_id column at all
+    # (found running the R6 real-archive smoke, ADR-0005). Every migration up
+    # through 0002 is applied by hand (not via Store.open, which would also
+    # apply 0003 and add the column) to reproduce that exact pre-migration
+    # shape; runs() must treat the whole log as legacy, not crash.
+    db = tmp_path / "pre_migration.sqlite"
+    conn = sqlite3.connect(db)
+    migrations_dir = Path("src/paperboy/store/migrations")
+    conn.executescript((migrations_dir / "0001_init.sql").read_text())
+    conn.executescript((migrations_dir / "0002_web.sql").read_text())
+    conn.execute(
+        "INSERT INTO raw_records(kind, observed_at, tier, context_json, payload_json) "
+        "VALUES ('user', '2026-01-01T00:00:00+00:00', 'self', NULL, '{}')"
+    )
+    conn.execute(
+        "INSERT INTO raw_records(kind, observed_at, tier, context_json, payload_json) "
+        "VALUES ('message', '2026-01-01T00:00:01+00:00', 'stranger', "
+        "'{\"channel_id\": 5}', '{\"id\": 1}')"
+    )
+    conn.commit()
+    conn.close()
+
+    src = ReplaySource.open(db, tmp_path / "media")
+    runs = src.runs()
+    assert [(r.run_id, r.lo, r.hi) for r in runs] == [("legacy-0001", 1, 2)]
+
+
+def test_runs_absorbs_leading_rows_written_before_the_first_self_marker(tmp_path):
+    # Found running the R6 real-archive smoke (ADR-0005): a real archive's
+    # earliest collect pass(es) predate the "self written first" invariant —
+    # its first raw writes are resolve/full, THEN self. Only the SECOND and
+    # later self markers may cut a new segment; the first one just confirms
+    # the segment already open, so these leading rows stay attached to the
+    # run they belong to rather than becoming an orphan segment with no self
+    # record (which would have no target to resolve on replay, silently
+    # dropping that whole run).
+    db = tmp_path / "src.sqlite"
+    with Store.open(db) as st:  # no begin_run: run_id stays NULL (legacy)
+        st.add_raw("ResolvedPeer", {"_": "contacts.resolvedPeer"}, "stranger",
+                   {"target": "@x"})
+        st.add_raw("ChatFull", {"_": "messages.chatFull"}, "stranger", {"channel_id": 5})
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw("Message", {"_": "message", "id": 1}, "stranger", {"channel_id": 5})
+        # A genuinely new pass: its own self marker cuts a real boundary.
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw("Message", {"_": "message", "id": 2}, "stranger", {"channel_id": 5})
+    src = ReplaySource.open(db, tmp_path / "media")
+    assert [(r.run_id, r.lo, r.hi) for r in src.runs()] == [
+        ("legacy-0001", 1, 4), ("legacy-0002", 5, 6),
     ]
 
 

--- a/tests/test_replay_gateway.py
+++ b/tests/test_replay_gateway.py
@@ -71,8 +71,13 @@ def _seed(tmp_path):
 
 def _gateway(tmp_path):
     db, media_root = _seed(tmp_path)
+    src = ReplaySource.open(db, media_root)
     clock = ReplayClock()
-    return RawReplayGateway(ReplaySource.open(db, media_root), clock), clock
+    # The seeded fixtures are single-run (no begin_run/run_id involved), so
+    # this is the source's one (legacy-labeled) run — behavior is unchanged
+    # from before per-run scoping.
+    run = src.runs()[0]
+    return RawReplayGateway(src, clock, run), clock
 
 
 @pytest.mark.asyncio
@@ -176,9 +181,10 @@ async def test_doctor_methods_are_not_replayable(tmp_path):
 def test_source_helpers(tmp_path):
     db, media_root = _seed(tmp_path)
     src = ReplaySource.open(db, media_root)
-    assert src.resolve_targets() == ["@durov"]
-    assert src.linked_group_ids() == {555}
-    assert src.has_kind("mediadownload") and not src.has_kind("tme_page")
+    run = src.runs()[0]
+    assert src.resolve_targets(run) == ["@durov"]
+    assert src.linked_group_ids(run) == {555}
+    assert src.has_kind(run, "mediadownload") and not src.has_kind(run, "tme_page")
 
 
 def test_source_is_read_only(tmp_path):
@@ -186,3 +192,49 @@ def test_source_is_read_only(tmp_path):
     src = ReplaySource.open(db, media_root)
     with pytest.raises(sqlite3.OperationalError):
         src.conn.execute("DELETE FROM raw_records")
+
+
+# ---------------------------------------------------------------------------
+# Revision R (ADR-0005): per-run replay — ReplaySource.runs()
+# ---------------------------------------------------------------------------
+
+
+def test_runs_groups_by_run_id_in_capture_order(tmp_path):
+    db = tmp_path / "src.sqlite"
+    with Store.open(db) as st:
+        st.begin_run("aaa")
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw("Message", {"_": "message", "id": 1}, "stranger", {"channel_id": 5})
+        st.begin_run("bbb")
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+    src = ReplaySource.open(db, tmp_path / "media")
+    runs = src.runs()
+    assert [(r.run_id, r.lo, r.hi) for r in runs] == [("aaa", 1, 2), ("bbb", 3, 3)]
+
+
+def test_runs_segments_legacy_rows_at_self_markers(tmp_path):
+    db = tmp_path / "src.sqlite"
+    with Store.open(db) as st:  # no begin_run: run_id stays NULL (legacy)
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw("Message", {"_": "message", "id": 1}, "stranger", {"channel_id": 5})
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw("Message", {"_": "message", "id": 2}, "stranger", {"channel_id": 5})
+    src = ReplaySource.open(db, tmp_path / "media")
+    assert [(r.run_id, r.lo, r.hi) for r in src.runs()] == [
+        ("legacy-0001", 1, 2), ("legacy-0002", 3, 4),
+    ]
+
+
+def test_runs_mixed_legacy_then_stamped(tmp_path):
+    # Legacy segment(s) precede stamped runs — the migration boundary shape.
+    db = tmp_path / "src.sqlite"
+    with Store.open(db) as st:
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw("Message", {"_": "message", "id": 1}, "stranger", {"channel_id": 5})
+        st.begin_run("ccc")
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw("Message", {"_": "message", "id": 2}, "stranger", {"channel_id": 5})
+    src = ReplaySource.open(db, tmp_path / "media")
+    assert [(r.run_id, r.lo, r.hi) for r in src.runs()] == [
+        ("legacy-0001", 1, 2), ("ccc", 3, 4),
+    ]

--- a/tests/test_replay_gateway.py
+++ b/tests/test_replay_gateway.py
@@ -1,0 +1,188 @@
+"""Unit tests for `RawReplayGateway`/`ReplaySource` (spec §2–§3): each Gateway
+method is tested in isolation against a hand-built raw log — no collector
+involved."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from paperboy.budget import SkipAndRecord
+from paperboy.clock import ReplayClock
+from paperboy.replay import RawReplayGateway, ReplaySource
+from paperboy.store.db import Store
+
+CID = 100
+IC = {"channel_id": CID, "access_hash": 7}
+
+
+def _seed(tmp_path):
+    """A minimal raw log: self, resolve, full, three messages (one edited),
+    a probe MessageEmpty, one diff, one recommendation set, one MediaDownload."""
+    db = tmp_path / "src.sqlite"
+    media_root = tmp_path / "media"
+    with Store.open(db) as st:
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None,
+                   observed_at="2026-01-01T00:00:00+00:00")
+        st.add_raw("ResolvedPeer",
+                   {"_": "contacts.ResolvedPeer",
+                    "peer": {"_": "PeerChannel", "channel_id": CID},
+                    "chats": [{"_": "Channel", "id": CID, "access_hash": 7}]},
+                   "stranger", {"target": "@durov"},
+                   observed_at="2026-01-01T00:00:01+00:00")
+        st.add_raw("ChatFull",
+                   {"_": "messages.ChatFull",
+                    "full_chat": {"_": "ChannelFull", "id": CID, "pts": 40,
+                                  "linked_chat_id": 555},
+                    "chats": [{"_": "Channel", "id": CID, "access_hash": 7}]},
+                   "stranger", {"channel_id": CID},
+                   observed_at="2026-01-01T00:00:02+00:00")
+        for mid, text, t in [
+            (3, "m3", "2026-01-01T00:01:03+00:00"),
+            (2, "m2", "2026-01-01T00:01:02+00:00"),
+            (1, "m1", "2026-01-01T00:01:01+00:00"),
+            (1, "m1 edited", "2026-01-01T00:02:00+00:00"),  # later revision
+        ]:
+            st.add_raw("Message", {"_": "message", "id": mid, "message": text},
+                       "stranger", {"channel_id": CID}, observed_at=t)
+        st.add_raw("MessageEmpty", {"_": "MessageEmpty", "id": 4}, "stranger",
+                   {"channel_id": CID}, observed_at="2026-01-01T00:03:00+00:00")
+        st.add_raw("ChannelDifference",
+                   {"_": "updates.channelDifferenceEmpty", "final": True, "pts": 41},
+                   "stranger", {"channel_id": CID},
+                   observed_at="2026-01-01T00:04:00+00:00")
+        st.add_raw("Chats", {"_": "messages.chats",
+                             "chats": [{"_": "Channel", "id": 200, "access_hash": 9}]},
+                   "stranger", {"channel_id": CID},
+                   observed_at="2026-01-01T00:05:00+00:00")
+        sha = "ab" + "0" * 62
+        path = media_root / sha[:2] / f"{sha}.txt"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"file contents")
+        st.add_raw("MediaDownload",
+                   {"sha256": sha, "kind": "document", "size": 13,
+                    "mime_type": "text/plain", "file_name": "a.txt",
+                    "path": str(path), "message_uri": f"tg:msg:{CID}/2"},
+                   "stranger", {"channel_id": CID, "msg_id": 2},
+                   observed_at="2026-01-01T00:06:00+00:00")
+    return db, media_root
+
+
+def _gateway(tmp_path):
+    db, media_root = _seed(tmp_path)
+    clock = ReplayClock()
+    return RawReplayGateway(ReplaySource.open(db, media_root), clock), clock
+
+
+@pytest.mark.asyncio
+async def test_resolve_matches_target_and_stamps_clock(tmp_path):
+    gw, clock = _gateway(tmp_path)
+    resolved = await gw.resolve("durov")
+    assert resolved["peer"]["channel_id"] == CID
+    assert clock.for_payload(resolved) == "2026-01-01T00:00:01+00:00"
+
+
+@pytest.mark.asyncio
+async def test_resolve_unknown_target_skips(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    with pytest.raises(SkipAndRecord):
+        await gw.resolve("someone_else")
+
+
+@pytest.mark.asyncio
+async def test_get_self_serves_self_tier_record(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    assert (await gw.get_self())["id"] == 1
+
+
+@pytest.mark.asyncio
+async def test_iter_history_pages_newest_first_excluding_empties(tmp_path):
+    gw, clock = _gateway(tmp_path)
+    page = [m async for m in gw.iter_history(IC, offset_id=0, limit=100)]
+    # id DESC; both revisions of msg 1 in capture order; MessageEmpty excluded.
+    assert [(m["id"], m["message"]) for m in page] == [
+        (3, "m3"), (2, "m2"), (1, "m1"), (1, "m1 edited"),
+    ]
+    assert clock.for_payload(page[3]) == "2026-01-01T00:02:00+00:00"
+    assert clock.for_payload(page[1]) == "2026-01-01T00:01:02+00:00"
+
+
+@pytest.mark.asyncio
+async def test_iter_history_never_splits_an_id_group_across_pages(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    # limit=3 would cut between msg 1's two revisions; the page extends.
+    page = [m async for m in gw.iter_history(IC, offset_id=0, limit=3)]
+    assert [m["id"] for m in page] == [3, 2, 1, 1]
+    next_page = [m async for m in gw.iter_history(IC, offset_id=1, limit=3)]
+    assert next_page == []
+
+
+@pytest.mark.asyncio
+async def test_get_messages_serves_stored_and_placeholder(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    out = await gw.get_messages(IC, [4, 99])
+    assert out[0]["_"] == "MessageEmpty"          # stored probe result
+    assert out[1] == {"_": "ReplayUnknownMessage", "id": 99}  # D4.1: no fabricated evidence
+
+
+@pytest.mark.asyncio
+async def test_channel_difference_serves_stored_then_synthetic_final(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    first = await gw.get_channel_difference(IC, 40, 100)
+    assert first["pts"] == 41 and first["final"]
+    again = await gw.get_channel_difference(IC, 41, 100)
+    assert again == {"_": "updates.channelDifferenceEmpty", "final": True, "pts": 41}
+
+
+@pytest.mark.asyncio
+async def test_recommendations_served_and_missing_raw_skips(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    recs = await gw.get_channel_recommendations(IC)
+    assert recs["chats"][0]["id"] == 200
+    with pytest.raises(SkipAndRecord):
+        await gw.get_channel_recommendations({"channel_id": 999, "access_hash": 0})
+
+
+@pytest.mark.asyncio
+async def test_sponsored_reconstructs_envelope_or_empty(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    assert (await gw.get_sponsored_messages(IC))["_"] == "sponsoredMessagesEmpty"
+
+
+@pytest.mark.asyncio
+async def test_download_media_reads_content_addressed_file(tmp_path):
+    gw, clock = _gateway(tmp_path)
+    del clock
+    data = await gw.download_media(IC, {"id": 2})
+    assert data == b"file contents"
+    assert await gw.download_media(IC, {"id": 3}) is None  # no record -> unavailable
+
+
+@pytest.mark.asyncio
+async def test_join_channel_is_synthetic_and_offline(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    assert (await gw.join_channel(IC))["_"] == "Updates"
+
+
+@pytest.mark.asyncio
+async def test_doctor_methods_are_not_replayable(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    for coro in (gw.get_authorizations(), gw.get_password_state(), gw.get_privacy("phone")):
+        with pytest.raises(SkipAndRecord):
+            await coro
+
+
+def test_source_helpers(tmp_path):
+    db, media_root = _seed(tmp_path)
+    src = ReplaySource.open(db, media_root)
+    assert src.resolve_targets() == ["@durov"]
+    assert src.linked_group_ids() == {555}
+    assert src.has_kind("mediadownload") and not src.has_kind("tme_page")
+
+
+def test_source_is_read_only(tmp_path):
+    db, media_root = _seed(tmp_path)
+    src = ReplaySource.open(db, media_root)
+    with pytest.raises(sqlite3.OperationalError):
+        src.conn.execute("DELETE FROM raw_records")

--- a/tests/test_replay_gateway.py
+++ b/tests/test_replay_gateway.py
@@ -11,7 +11,7 @@ import pytest
 
 from paperboy.budget import SkipAndRecord
 from paperboy.clock import ReplayClock
-from paperboy.replay import RawReplayGateway, ReplaySource
+from paperboy.replay import RawReplayGateway, ReplaySource, ReprojectSourceError
 from paperboy.store.db import Store
 
 CID = 100
@@ -305,6 +305,83 @@ def test_runs_absorbs_resolve_before_self_at_every_boundary(tmp_path):
         ("legacy-0001", 1, 4), ("legacy-0002", 5, 8),
     ]
     assert src.resolve_targets(src.runs()[1]) == ["@x"]
+
+
+def test_runs_does_not_split_a_run_on_a_foreign_single_row_intrusion(tmp_path):
+    # Found running the R6 real-archive smoke a second time (ADR-0005, post
+    # revision R): the archive's `default` profile has no file lock stopping
+    # two `collect` invocations from writing to the same profile
+    # concurrently, and a lone `ResolvedPeer`/`ChatFull` from some unrelated,
+    # short-lived process can land mid-run, between two rows of the SAME
+    # legitimate run's own substantive activity (there: a `MediaDownload`
+    # loop, interrupted by a stray resolve of `@atom8388`). The OPENING-
+    # CLUSTER rule (see the absorption tests above) treated that lone row as
+    # an unconditional new-segment boundary on its own -- with no self
+    # marker anywhere near it, the synthetic segment then fails replay at
+    # `get_self()` ('no self User recorded'), silently discarding every row
+    # from the intrusion up to the NEXT genuine opening cluster (there: 157
+    # rows, 156 of them real historical `MediaDownload` observations).
+    # A cluster only cuts a new boundary once it's confirmed genuine -- i.e.
+    # it contains its own self marker before the run of opening-kind rows
+    # ends -- so a lone foreign row with no self anywhere near it folds into
+    # whichever run is already open instead of orphaning everything after it.
+    db = tmp_path / "src.sqlite"
+    with Store.open(db) as st:  # no begin_run: run_id stays NULL (legacy)
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw("ResolvedPeer", {"_": "contacts.resolvedPeer"}, "stranger",
+                   {"target": "@target"})
+        st.add_raw("ChatFull", {"_": "messages.chatFull"}, "stranger", {"channel_id": 5})
+        st.add_raw("MediaDownload", {"sha256": "a" * 64}, "stranger",
+                   {"channel_id": 5, "msg_id": 1})
+        # A foreign, short-lived process's resolve lands mid-run -- no self
+        # anywhere near it, so it is NOT a genuine new pass.
+        st.add_raw("ResolvedPeer", {"_": "contacts.resolvedPeer"}, "stranger",
+                   {"target": "@atom8388"})
+        st.add_raw("MediaDownload", {"sha256": "b" * 64}, "stranger",
+                   {"channel_id": 5, "msg_id": 2})
+        st.add_raw("MediaDownload", {"sha256": "c" * 64}, "stranger",
+                   {"channel_id": 5, "msg_id": 3})
+    src = ReplaySource.open(db, tmp_path / "media")
+    assert [(r.run_id, r.lo, r.hi) for r in src.runs()] == [("legacy-0001", 1, 7)]
+
+
+def test_runs_still_cuts_a_genuine_boundary_after_a_foreign_intrusion(tmp_path):
+    # The fix above must not swallow a REAL run boundary -- a cluster that
+    # DOES contain its own self marker still cuts, even if a foreign
+    # intrusion happened earlier in the same log.
+    db = tmp_path / "src.sqlite"
+    with Store.open(db) as st:
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw("Message", {"_": "message", "id": 1}, "stranger", {"channel_id": 5})
+        # Foreign intrusion, no self nearby -- absorbed into run 1.
+        st.add_raw("ResolvedPeer", {"_": "contacts.resolvedPeer"}, "stranger",
+                   {"target": "@atom8388"})
+        st.add_raw("Message", {"_": "message", "id": 2}, "stranger", {"channel_id": 5})
+        # A genuine second pass: its own self marker cuts a real boundary.
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw("Message", {"_": "message", "id": 3}, "stranger", {"channel_id": 5})
+    src = ReplaySource.open(db, tmp_path / "media")
+    assert [(r.run_id, r.lo, r.hi) for r in src.runs()] == [
+        ("legacy-0001", 1, 4), ("legacy-0002", 5, 6),
+    ]
+
+
+def test_runs_raises_on_a_genuinely_interleaved_stamped_run_id(tmp_path):
+    # ADR-0005 point 3: "ReplaySource asserts contiguity and fails loudly if
+    # ever violated" -- previously unexercised by any test. A source whose
+    # `run_id` sequence is aaa, bbb, aaa (bbb's rows are not a contiguous
+    # rowid range) is corrupt/hand-edited; refuse to replay it silently.
+    db = tmp_path / "src.sqlite"
+    with Store.open(db) as st:
+        st.begin_run("aaa")
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.begin_run("bbb")
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.begin_run("aaa")
+        st.add_raw("Message", {"_": "message", "id": 1}, "stranger", {"channel_id": 5})
+    src = ReplaySource.open(db, tmp_path / "media")
+    with pytest.raises(ReprojectSourceError, match="aaa"):
+        src.runs()
 
 
 def test_runs_mixed_legacy_then_stamped(tmp_path):

--- a/tests/test_replay_gateway.py
+++ b/tests/test_replay_gateway.py
@@ -280,6 +280,33 @@ def test_runs_absorbs_leading_rows_written_before_the_first_self_marker(tmp_path
     ]
 
 
+def test_runs_absorbs_resolve_before_self_at_every_boundary(tmp_path):
+    # The real archive's resolve/full-before-self ordering (see the test
+    # above) turned out to recur at EVERY historical pass boundary
+    # throughout its whole history, not just the first — a MID-log
+    # transition must attach its own opening cluster to the run it starts,
+    # not leave it behind in the run that precedes it (which silently
+    # dropped the entire final run — 3154 of 6258 raw records — in the
+    # first cut of this fix, caught before commit by re-running the smoke).
+    db = tmp_path / "src.sqlite"
+    with Store.open(db) as st:
+        st.add_raw("ResolvedPeer", {"_": "contacts.resolvedPeer"}, "stranger", {"target": "@x"})
+        st.add_raw("ChatFull", {"_": "messages.chatFull"}, "stranger", {"channel_id": 5})
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw("Message", {"_": "message", "id": 1}, "stranger", {"channel_id": 5})
+        # Pass 2's own opening cluster, same old ordering — must land in
+        # pass 2, not stay attached to pass 1's tail.
+        st.add_raw("ResolvedPeer", {"_": "contacts.resolvedPeer"}, "stranger", {"target": "@x"})
+        st.add_raw("ChatFull", {"_": "messages.chatFull"}, "stranger", {"channel_id": 5})
+        st.add_raw("User", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw("Message", {"_": "message", "id": 2}, "stranger", {"channel_id": 5})
+    src = ReplaySource.open(db, tmp_path / "media")
+    assert [(r.run_id, r.lo, r.hi) for r in src.runs()] == [
+        ("legacy-0001", 1, 4), ("legacy-0002", 5, 8),
+    ]
+    assert src.resolve_targets(src.runs()[1]) == ["@x"]
+
+
 def test_runs_mixed_legacy_then_stamped(tmp_path):
     # Legacy segment(s) precede stamped runs — the migration boundary shape.
     db = tmp_path / "src.sqlite"

--- a/tests/test_replay_web.py
+++ b/tests/test_replay_web.py
@@ -27,8 +27,10 @@ def _seed(tmp_path):
 
 
 def _client(tmp_path):
+    src = ReplaySource.open(_seed(tmp_path), tmp_path / "media")
     clock = ReplayClock()
-    return RawReplayWebClient(ReplaySource.open(_seed(tmp_path), tmp_path / "media"), clock), clock
+    run = src.runs()[0]
+    return RawReplayWebClient(src, clock, run), clock
 
 
 def test_serves_stored_response_and_stamps_clock(tmp_path):

--- a/tests/test_replay_web.py
+++ b/tests/test_replay_web.py
@@ -1,0 +1,61 @@
+"""tests/test_replay_web.py"""
+
+from __future__ import annotations
+
+from paperboy.clock import ReplayClock
+from paperboy.replay import RawReplayWebClient, ReplaySource
+from paperboy.store.db import Store
+
+
+def _seed(tmp_path):
+    db = tmp_path / "src.sqlite"
+    with Store.open(db) as st:
+        for i, t in enumerate(["2026-01-01T00:00:01+00:00", "2026-01-01T00:00:02+00:00"]):
+            st.add_raw(
+                "tme_page",
+                {"url": "https://t.me/s/durov", "status_code": 200,
+                 "text": f"<html>page capture {i}</html>"},
+                "stranger", {"channel_username": "durov"}, observed_at=t,
+            )
+        st.add_raw("wayback_cdx",
+                   {"url": "https://web.archive.org/cdx/search/cdx?url=t.me/s/durov*"
+                           "&output=json&filter=statuscode:200&collapse=digest&limit=10000",
+                    "status_code": 200, "text": "[]"},
+                   "stranger", {"channel_username": "durov"},
+                   observed_at="2026-01-01T00:00:03+00:00")
+    return db
+
+
+def _client(tmp_path):
+    clock = ReplayClock()
+    return RawReplayWebClient(ReplaySource.open(_seed(tmp_path), tmp_path / "media"), clock), clock
+
+
+def test_serves_stored_response_and_stamps_clock(tmp_path):
+    client, clock = _client(tmp_path)
+    resp = client.get("https://t.me/s/durov")
+    assert resp.status_code == 200
+    assert clock.for_payload(
+        {"url": "https://t.me/s/durov", "status_code": 200, "text": resp.text}
+    ) == "2026-01-01T00:00:01+00:00"
+
+
+def test_same_url_serves_captures_in_order(tmp_path):
+    client, _ = _client(tmp_path)
+    assert client.get("https://t.me/s/durov").text == "<html>page capture 0</html>"
+    assert client.get("https://t.me/s/durov").text == "<html>page capture 1</html>"
+
+
+def test_unrecorded_url_is_a_definitive_404(tmp_path):
+    client, _ = _client(tmp_path)
+    resp = client.get("https://t.me/s/durov?before=5")
+    # 404, not 5xx: an unambiguous "nothing there", so the collector's page
+    # loop stops cleanly instead of reporting a failure (web.py's
+    # _is_ambiguous_failure treats 404 as an answer).
+    assert resp.status_code == 404 and resp.text == ""
+
+
+def test_web_client_satisfies_web_getter():
+    from paperboy.web.client import WebClient, WebGetter
+    client: WebGetter = WebClient()  # structural check exercised by pyright too
+    client.close()

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -85,6 +85,23 @@ def test_cli_reproject_empty_source_exits_1(tmp_path, monkeypatch):
     assert "no resolve records" in result.output
 
 
+def test_cli_reproject_cleans_up_out_on_unexpected_source_error(tmp_path, monkeypatch):
+    # A corrupted/unreadable source DB fails deep inside
+    # `ReplaySource.resolve_targets` (a bare `sqlite3.DatabaseError`), not
+    # `ReprojectError` — found running reproject against a hand-corrupted
+    # file during DoD smoke testing. `build_reproject` already created and
+    # migrated `out_path` by this point; the CLI's cleanup must not be
+    # narrowed to only the `ReprojectError` branch, or a half-made file is
+    # left behind and a retry against the default --out spuriously hits
+    # "refusing to overwrite existing" for a file that was never usable.
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    (tmp_path / "default").mkdir(parents=True)
+    (tmp_path / "default" / "paperboy.sqlite").write_bytes(b"not a real sqlite file")
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code != 0
+    assert not (tmp_path / "default" / "paperboy.reprojected.sqlite").exists()
+
+
 def test_cli_reproject_phases_override(tmp_path, monkeypatch):
     asyncio.run(run_full_collect(tmp_path))
     monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -1,0 +1,107 @@
+"""CLI/orchestration tests for `reproject` (Task 6). The round-trip identity
++ guardrail battery (spec §7) is appended in Task 7, in the same file."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+from typer.testing import CliRunner
+
+from paperboy.cli import app
+from paperboy.config import load_settings
+from paperboy.recipes import collect_channel
+from paperboy.replay import ReplaySource
+from paperboy.reproject import detect_phases
+from paperboy.store.db import Store
+from paperboy.targets import parse_target
+from tests.fakes import FakeGateway
+from tests.test_reproject_parity import full_collect_fixtures, run_full_collect
+
+runner = CliRunner()
+
+
+@pytest.mark.asyncio
+async def test_detect_phases_reflects_recorded_raw_kinds(tmp_path):
+    db = await run_full_collect(tmp_path)
+    src = ReplaySource.open(db, tmp_path / "default" / "media")
+    phases = detect_phases(src)
+    assert phases[:2] == ["channel", "history"]
+    assert "graph" in phases and "web" in phases and "media" in phases
+
+
+@pytest.mark.asyncio
+async def test_detect_phases_minimal_source(tmp_path):
+    # channel+history-only raw log -> no graph/web/media/discussion phases.
+    settings = load_settings("default", {"data_dir": tmp_path})
+    db = tmp_path / "default" / "paperboy.sqlite"
+    with Store.open(db) as store:
+        await collect_channel(
+            FakeGateway(full_collect_fixtures()), store, settings,
+            parse_target("@durov"), phases=["channel", "history"],
+            log=logging.getLogger("t"),
+        )
+    src = ReplaySource.open(db, tmp_path / "default" / "media")
+    assert detect_phases(src) == ["channel", "history"]
+
+
+def test_cli_reproject_writes_fresh_db_and_prints_diff(tmp_path, monkeypatch):
+    # NOT `async def`: `runner.invoke` runs the CLI command, which calls
+    # `asyncio.run()` internally — nesting that inside a pytest-asyncio
+    # test's own running loop raises "asyncio.run() cannot be called from a
+    # running event loop". `run_full_collect` is a plain coroutine, driven
+    # here with its own asyncio.run() instead of `await`.
+    asyncio.run(run_full_collect(tmp_path))
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    out_db = tmp_path / "default" / "paperboy.reprojected.sqlite"
+    assert out_db.exists()
+    assert "channels" in result.output and "messages" in result.output
+
+
+def test_cli_reproject_refuses_existing_out(tmp_path, monkeypatch):
+    asyncio.run(run_full_collect(tmp_path))
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    out = tmp_path / "default" / "paperboy.reprojected.sqlite"
+    out.write_bytes(b"")
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 1
+    assert "refusing" in result.output.lower()
+
+
+def test_cli_reproject_empty_source_exits_1(tmp_path, monkeypatch):
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    (tmp_path / "default").mkdir(parents=True)
+    with Store.open(tmp_path / "default" / "paperboy.sqlite"):
+        pass  # schema only, no raws
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 1
+    assert "no resolve records" in result.output
+
+
+def test_cli_reproject_phases_override(tmp_path, monkeypatch):
+    asyncio.run(run_full_collect(tmp_path))
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(
+        app, ["reproject", "--profile", "default", "--phases", "channel,history"]
+    )
+    assert result.exit_code == 0, result.output
+    out = tmp_path / "default" / "paperboy.reprojected.sqlite"
+    with Store.open(out) as store:
+        edges_n = store.conn.execute("SELECT count(*) FROM edges").fetchone()[0]
+    # graph never ran, so no mention edges were reprojected either.
+    assert edges_n == 0
+
+
+def test_cli_reproject_custom_out_path(tmp_path, monkeypatch):
+    asyncio.run(run_full_collect(tmp_path))
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    custom_out = tmp_path / "custom.sqlite"
+    result = runner.invoke(
+        app, ["reproject", "--profile", "default", "--out", str(custom_out)]
+    )
+    assert result.exit_code == 0, result.output
+    assert custom_out.exists()
+    assert not (tmp_path / "default" / "paperboy.reprojected.sqlite").exists()

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -182,6 +182,73 @@ def test_one_bad_historical_target_does_not_abort_other_targets(tmp_path, monkey
     assert "notachannel" in result.output
 
 
+def test_reproject_warns_on_a_zero_target_run(tmp_path, monkeypatch, caplog):
+    # A run with no ResolvedPeer at all has no target to replay a collect
+    # against, so every raw row in its window is silently dropped from the
+    # reprojected DB. `replayed_any` only catches the all-runs-empty case;
+    # a single zero-target run in an otherwise healthy source must still
+    # surface a warning (adversarial-reviewer, round 2), and the good run
+    # must still reproject. `reproject`'s own `log.warning` reaches the
+    # `paperboy.cli` logger's RichHandler (console output goes through a
+    # separate `rich.Console`, never `CliRunner`'s captured `result.output`
+    # — see `configure_logging`), so this asserts on `caplog`, not output.
+    db = tmp_path / "default" / "paperboy.sqlite"
+    resolve = json.loads(Path("tests/fixtures/tl/resolve_durov.json").read_text())
+    full_channel = json.loads(Path("tests/fixtures/tl/full_channel.json").read_text())
+    with Store.open(db) as st:
+        st.begin_run("good")
+        st.add_raw("user", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw(resolve.get("_"), resolve, "stranger", {"target": "@durov"})
+        st.add_raw(full_channel.get("_"), full_channel, "stranger", {"channel_id": 5})
+        st.begin_run("orphan")
+        st.add_raw("user", {"_": "user", "id": 1, "self": True}, "self", None)
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger="paperboy.cli"):
+        result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    assert "orphan" in caplog.text and "no resolve records" in caplog.text
+    out = sqlite3.connect(tmp_path / "default" / "paperboy.reprojected.sqlite")
+    assert out.execute("SELECT count(*) FROM channels WHERE id=5").fetchone()[0] == 1
+    out.close()
+
+
+def test_reproject_preserves_every_pass_of_consecutive_channel_only_runs(tmp_path, monkeypatch):
+    # `paperboy collect @x --phases channel` (a legal phase set — cli.py only
+    # rejects *dependent* phases without `channel`) writes exactly self /
+    # ResolvedPeer / ChatFull — all opening-kind rows, nothing substantive.
+    # Two or more such passes in a row leave no non-opening row between them
+    # to end the pending cluster, so a segmentation bug that only cuts once
+    # per contiguous run of opening rows collapses all three passes into one
+    # run (correctness-reviewer, round 2) — silently discarding two of three
+    # real historical `channel_snapshots` observations. Verified directly
+    # against `replay.py`'s `_resolve_pending`: reverting the per-pass-role
+    # split back to a single cut per cluster drops this from 3 to 1 run.
+    db = tmp_path / "default" / "paperboy.sqlite"
+    resolve = json.loads(Path("tests/fixtures/tl/resolve_durov.json").read_text())
+    full_channel = json.loads(Path("tests/fixtures/tl/full_channel.json").read_text())
+    counts = (1000, 1001, 1002)
+    with Store.open(db) as st:  # no begin_run: run_id stays NULL (legacy)
+        for n in counts:
+            full = {
+                **full_channel,
+                "full_chat": {**full_channel["full_chat"], "participants_count": n},
+            }
+            st.add_raw("user", {"_": "user", "id": 1, "self": True}, "self", None)
+            st.add_raw(resolve.get("_"), resolve, "stranger", {"target": "@durov"})
+            st.add_raw(full_channel.get("_"), full, "stranger", {"channel_id": 5})
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    out = sqlite3.connect(tmp_path / "default" / "paperboy.reprojected.sqlite")
+    seen = [
+        r[0] for r in out.execute(
+            "SELECT participants_count FROM channel_snapshots ORDER BY id"
+        )
+    ]
+    out.close()
+    assert seen == list(counts)
+
+
 # ---------------------------------------------------------------------------
 # Task 7: the correctness battery — round-trip identity + guardrails (spec §7)
 # ---------------------------------------------------------------------------
@@ -189,16 +256,20 @@ def test_one_bad_historical_target_does_not_abort_other_targets(tmp_path, monkey
 # D5 (plan): equality modulo autoincrement pks and source_raw_id, compared as
 # DISTINCT row sets — replay legitimately serves one observation through two
 # paths (getHistory + getChannelDifference), duplicating byte-identical rows.
-# `raw_records.run_id` (ADR-0005) is excluded too, same spirit as `id`: it is
-# a synthetic pass-grouping identifier, not observed content. A legacy
-# (pre-migration) source's rows carry NULL run_id but replay LABELS their
-# inferred segment `legacy-0001...` when writing the target, so literal
-# run_id equality would never hold for a real archive predating this column
-# even though the replay is faithful; for a stamped source the source's own
-# run_id is threaded straight through to the target, so excluding it here
-# loses no real signal either way.
+# `raw_records.run_id` is NOT excluded: every source these tests build goes
+# through `collect_channel`, which always calls `store.begin_run(...)`, so
+# every source here is STAMPED — the source's own run_id is threaded straight
+# through to the target (recipes.py's `run_id` parameter / `reproject.py`
+# passing `run.run_id`), and literal equality is exactly ADR-0005's headline
+# invariant ("a reprojected DB carries the same pass structure as its source
+# and is itself faithfully re-reprojectable"). A genuinely legacy (pre-
+# migration, unstamped) source would need its NULL run_ids mapped through
+# replay's inferred `legacy-NNNN` labels before comparing — see
+# `test_reproject_parity.py`'s `_norm_run_id` for that normalisation — but no
+# round-trip source built here is legacy, so excluding the column would only
+# hide a regression, not accommodate a real case.
 ROUND_TRIP_EXCLUDE = {
-    "raw_records": {"id", "run_id"},
+    "raw_records": {"id"},
     "channels": {"source_raw_id"},
     "channel_snapshots": {"id", "source_raw_id"},
     "peers": {"source_raw_id"},
@@ -484,5 +555,21 @@ def test_reproject_does_not_truncate_a_backward_multi_run_backfill(tmp_path, mon
     assert result.exit_code == 0, result.output
     out = sqlite3.connect(tmp_path / "default" / "paperboy.reprojected.sqlite")
     reprojected_ids = {r[0] for r in out.execute("SELECT msg_id FROM messages")}
+    sweep = json.loads(
+        out.execute(
+            "SELECT value_json FROM sync_state WHERE scope='history_sweep' AND key='5'"
+        ).fetchone()[0]
+    )
     out.close()
     assert reprojected_ids == source_ids
+    # adversarial-reviewer, round 2: `_reset_incremental_backfill_state`
+    # used to blanket-DELETE `history_sweep` before EVERY replayed run,
+    # discarding run 1's high-water mark before run 2 ran — the
+    # reprojected DB ended with `max_id_seen=850` (run 2's own local
+    # window) instead of the true global maximum (1000, from run 1). The
+    # high-water mark must now survive across runs, widening monotonically
+    # exactly as a live multi-session backfill's does; only the per-run
+    # completeness flags reset.
+    assert sweep["max_id_seen"] == 1000
+    assert sweep["pending_high"] == 1000
+    assert sweep["backfill_complete"] is True

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -75,6 +75,17 @@ def test_cli_reproject_refuses_existing_out(tmp_path, monkeypatch):
     assert "refusing" in result.output.lower()
 
 
+def test_cli_reproject_nonexistent_profile_creates_no_dir(tmp_path, monkeypatch):
+    """#33 round-2 smoke case 8: a rejected profile must not leave a ghost
+    profile directory behind (configure_logging used to mkdir it before
+    build_reproject ever validated that a source DB exists)."""
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "ghost"])
+    assert result.exit_code == 1
+    assert "ghost" in result.output
+    assert not (tmp_path / "ghost").exists()
+
+
 def test_cli_reproject_empty_source_exits_1(tmp_path, monkeypatch):
     # Zero raw_records at all -> zero runs -> the "empty log" message
     # (ADR-0005): distinct from "has runs but none resolved anything",

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -507,6 +507,75 @@ def test_two_run_round_trip_identity(tmp_path, monkeypatch):
     assert_round_trip(db1, tmp_path / "default" / "paperboy.reprojected.sqlite")
 
 
+def _run1_with_full_peer(fx: dict) -> dict:
+    return {**fx, "full_channel": {
+        **fx["full_channel"],
+        "users": [{"_": "user", "id": 42, "access_hash": 777,
+                   "username": "peer42", "first_name": "Peer"}],
+    }}
+
+
+def _run2_with_min_stub_message(fx: dict) -> dict:
+    # The new message also carries FRESH media (a distinct document, unseen
+    # in run 1) — deliberately, matching `_second_run_fixtures` above: with
+    # no raw-detectable media activity of its own, run 2's media phase would
+    # leave no raw trace at all and reproject's phase detection would skip
+    # it outright, silently sidestepping (not exercising) what this test is
+    # for. It would also spuriously collide with the OTHER, already-tracked
+    # residual this same gap in phase detection causes (ADR-0005 "Residual
+    # #36": a message's media re-scanned across runs without ANY fresh raw
+    # activity in that run produces a `duplicate` custody_log row live has
+    # no way to replay) — a false failure unrelated to this test's actual
+    # subject, peer richness composition.
+    return {**fx, "history": [
+        {
+            "_": "message", "id": 5, "message": "peer42 posts again",
+            "date": 1769322500, "from_id": {"_": "PeerUser", "user_id": 42},
+            "media": {
+                "_": "MessageMediaDocument",
+                "document": {
+                    "_": "Document", "id": 88, "access_hash": 1,
+                    "mime_type": "text/plain",
+                    "attributes": [
+                        {"_": "DocumentAttributeFilename", "file_name": "c.txt"}
+                    ],
+                },
+            },
+        },
+        *fx["history"],
+    ], "media": {**fx["media"], 5: b"run 2 fresh bytes"}}
+
+
+def test_two_run_round_trip_preserves_full_peer_over_a_later_min_stub(tmp_path, monkeypatch):
+    """ADR-0005 §6 (amended) R7 Step 4, #33 round 3: a peer observed FULL in
+    run 1 (the `ChatFull` users vector) and only as a `min` author stub in
+    run 2 must reproject with the full profile intact and the seen window
+    widened. This is the real-collector-path companion to
+    `test_upsert_peer_composed_lattice`'s `full_stored-min_incoming` cells —
+    round 2's own two-run gate never actually reached peer projection with a
+    real richness conflict (its second target, `@atom8388`, bailed at
+    resolve with a `SkipAndRecord` before any peer upsert)."""
+    asyncio.run(run_full_collect(tmp_path, mutate_fixtures=_run1_with_full_peer))
+    db1 = asyncio.run(run_full_collect(tmp_path, mutate_fixtures=_run2_with_min_stub_message))
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    assert_round_trip(db1, tmp_path / "default" / "paperboy.reprojected.sqlite")
+
+    out = sqlite3.connect(tmp_path / "default" / "paperboy.reprojected.sqlite")
+    out.row_factory = sqlite3.Row
+    row = out.execute(
+        "SELECT username, first_name, is_min, first_seen, last_seen "
+        "FROM peers WHERE uri='tg:user:42'"
+    ).fetchone()
+    out.close()
+    assert row is not None, "peer 42 (full in run 1) was not projected at all"
+    assert row["username"] == "peer42"
+    assert row["first_name"] == "Peer"
+    assert row["is_min"] == 0  # the richer profile survives the later min stub
+    assert row["last_seen"] > row["first_seen"]  # window widened by run 2's stub
+
+
 def _seed_backward_backfill_source(db: Path, *, run1_ids: range, run2_ids: range) -> None:
     """A hand-built raw log matching the real archive's shape (found running
     the R6 smoke, ADR-0005): two collect passes against the SAME channel,

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -362,3 +362,49 @@ def test_reproject_never_rewrites_media_files(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "write_bytes", _no_write)
     result = runner.invoke(app, ["reproject", "--profile", "default"])
     assert result.exit_code == 0, result.output
+
+
+# ---------------------------------------------------------------------------
+# Revision R (ADR-0005): the two-run round-trip gate (#33)
+# ---------------------------------------------------------------------------
+
+
+def _second_run_fixtures(fx: dict) -> dict:
+    """Run 2 observes one NEW message carrying NEW media, on top of
+    everything run 1 saw — so run 2 exercises incremental backfill, repeat
+    snapshots/metrics/web captures, AND a fresh MediaDownload (which is what
+    makes run 2's media phase raw-detectable, spec D4.5/ADR-0005 residual)."""
+    fx = {**fx, "history": [
+        {
+            "_": "message", "id": 4, "message": "new in run 2",
+            "date": 1769322400, "views": 3,
+            "media": {
+                "_": "MessageMediaDocument",
+                "document": {
+                    "_": "Document", "id": 77, "access_hash": 1,
+                    "mime_type": "text/plain",
+                    "attributes": [
+                        {"_": "DocumentAttributeFilename", "file_name": "b.txt"}
+                    ],
+                },
+            },
+        },
+        *fx["history"],
+    ]}
+    fx["media"] = {**fx["media"], 4: b"second run bytes"}
+    return fx
+
+
+@pytest.mark.xfail(
+    reason="#33 / ADR-0005: multi-run replay lands in tasks R2-R5",
+    strict=True,
+)
+def test_two_run_round_trip_identity(tmp_path, monkeypatch):
+    """ADR-0005 gate: a source built from TWO collect passes — the ordinary
+    real-archive shape — must round-trip identically, time series included."""
+    asyncio.run(run_full_collect(tmp_path))
+    db1 = asyncio.run(run_full_collect(tmp_path, mutate_fixtures=_second_run_fixtures))
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    assert_round_trip(db1, tmp_path / "default" / "paperboy.reprojected.sqlite")

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -4,11 +4,15 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import sqlite3
+from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
 
+from paperboy.budget import PhaseStop
 from paperboy.cli import app
 from paperboy.config import load_settings
 from paperboy.recipes import collect_channel
@@ -105,3 +109,207 @@ def test_cli_reproject_custom_out_path(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.output
     assert custom_out.exists()
     assert not (tmp_path / "default" / "paperboy.reprojected.sqlite").exists()
+
+
+# ---------------------------------------------------------------------------
+# Task 7: the correctness battery — round-trip identity + guardrails (spec §7)
+# ---------------------------------------------------------------------------
+
+# D5 (plan): equality modulo autoincrement pks and source_raw_id, compared as
+# DISTINCT row sets — replay legitimately serves one observation through two
+# paths (getHistory + getChannelDifference), duplicating byte-identical rows.
+ROUND_TRIP_EXCLUDE = {
+    "raw_records": {"id"},
+    "channels": {"source_raw_id"},
+    "channel_snapshots": {"id", "source_raw_id"},
+    "peers": {"source_raw_id"},
+    "messages": {"source_raw_id"},
+    "message_revisions": {"id", "source_raw_id"},
+    "message_metrics": {"id"},
+    "message_tombstones": {"id"},
+    "edges": {"id", "source_raw_id"},
+    "media": set(),
+    "custody_log": {"id"},
+    "web_snapshots": {"id"},
+}
+
+
+def _table_set(conn: sqlite3.Connection, table: str, exclude: set[str]) -> set[tuple]:
+    cols = [r[1] for r in conn.execute(f"PRAGMA table_info({table})") if r[1] not in exclude]
+    sql = f"SELECT {', '.join(cols)} FROM {table}"
+    return {tuple(row) for row in conn.execute(sql)}
+
+
+def assert_round_trip(
+    db1: Path, db2: Path, *, skip_tables: frozenset[str] = frozenset()
+) -> None:
+    c1, c2 = sqlite3.connect(db1), sqlite3.connect(db2)
+    try:
+        for table, exclude in ROUND_TRIP_EXCLUDE.items():
+            if table in skip_tables:
+                continue
+            s1, s2 = _table_set(c1, table, exclude), _table_set(c2, table, exclude)
+            assert s1 == s2, (
+                f"{table} diverged:\n only in source: {sorted(s1 - s2)[:5]}\n"
+                f" only in reprojected: {sorted(s2 - s1)[:5]}"
+            )
+    finally:
+        c1.close()
+        c2.close()
+
+
+def test_round_trip_identity(tmp_path, monkeypatch):
+    """Spec §7: collect -> reproject -> projections identical, timestamps
+    included. Runs with the REAL clock (no freezing) — timestamp equality is
+    exactly what the observed-at seam exists to guarantee."""
+    db1 = asyncio.run(run_full_collect(tmp_path))
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    assert_round_trip(db1, tmp_path / "default" / "paperboy.reprojected.sqlite")
+
+
+def test_reproject_is_incapable_of_network_or_keychain(tmp_path, monkeypatch):
+    asyncio.run(run_full_collect(tmp_path))
+
+    def _forbidden(*a, **k):
+        raise AssertionError("reproject touched a forbidden constructor")
+
+    import keyring
+
+    import paperboy.gateway as gw
+    import paperboy.web.client as wc
+
+    monkeypatch.setattr(gw.TelethonGateway, "__init__", _forbidden)
+    monkeypatch.setattr(wc.WebClient, "__init__", _forbidden)
+    monkeypatch.setattr(keyring, "get_password", _forbidden)
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+
+
+async def _collect_with_fixtures(
+    data_dir: Path, fixtures: dict, phases: list[str]
+) -> Path:
+    settings = load_settings("default", {"data_dir": data_dir})
+    db = data_dir / "default" / "paperboy.sqlite"
+    with Store.open(db) as store:
+        await collect_channel(
+            FakeGateway(fixtures), store, settings, parse_target("@durov"),
+            phases=phases, log=logging.getLogger("t"),
+        )
+    return db
+
+
+def test_reproject_corrects_old_code_projections(tmp_path, monkeypatch):
+    """A DB whose projections were written by OLD code (a reduced-flag
+    channel, a stored self peer, a lost edge) reprojects to the current
+    correct shape — raw is the system of record."""
+    fx = full_collect_fixtures()
+    # A richer channel than the shared parity fixture (which carries only
+    # `broadcast`), so "old code dropped flags" is a meaningful scenario.
+    fx["full_channel"] = {
+        **fx["full_channel"],
+        "full_chat": {
+            **fx["full_channel"]["full_chat"],
+            "can_view_participants": True, "antispam": True,
+        },
+        "chats": [{
+            **fx["full_channel"]["chats"][0],
+            "verified": True, "noforwards": True, "signatures": True,
+        }],
+    }
+    # channel+history+graph: graph is what turns msg 3's URL entity into a
+    # mention edge, giving the "lost edge" simulation below something real
+    # to restore.
+    db1 = asyncio.run(_collect_with_fixtures(tmp_path, fx, ["channel", "history", "graph"]))
+    conn = sqlite3.connect(db1)
+    good_flags = conn.execute("SELECT flags_json FROM channels").fetchone()[0]
+    assert len(json.loads(good_flags)) > 3
+    conn.execute("UPDATE channels SET flags_json = ?",
+                 (json.dumps({"broadcast": True}),))          # old 1-flag shape
+    conn.execute(
+        "INSERT INTO peers (uri, kind, id, is_min, first_seen, last_seen) "
+        "VALUES ('tg:user:1', 'user', 1, 0, 'x', 'x')")       # self row (pre-#12)
+    conn.execute("DELETE FROM edges")                         # lost projections
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    out = sqlite3.connect(tmp_path / "default" / "paperboy.reprojected.sqlite")
+    assert json.loads(out.execute("SELECT flags_json FROM channels").fetchone()[0]) \
+        == json.loads(good_flags)
+    assert out.execute("SELECT count(*) FROM peers WHERE uri='tg:user:1'").fetchone()[0] == 0
+    assert out.execute("SELECT count(*) FROM edges").fetchone()[0] > 0
+    out.close()
+
+
+def test_source_without_graph_reprojects_without_graph(tmp_path, monkeypatch):
+    # channel+history-only DB1 (no graph/web/media raws) -> DB2 must not grow
+    # mention edges the original never projected (plan D4.5).
+    db1 = asyncio.run(
+        _collect_with_fixtures(tmp_path, full_collect_fixtures(), ["channel", "history"])
+    )
+    src = ReplaySource.open(db1, tmp_path / "default" / "media")
+    assert detect_phases(src) == ["channel", "history"]
+    src.close()
+
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    assert_round_trip(db1, tmp_path / "default" / "paperboy.reprojected.sqlite")
+
+
+def _diff_page(pts: int, *, final: bool, mid: int) -> dict:
+    return {
+        "_": "updates.channelDifference", "final": final, "pts": pts,
+        "new_messages": [
+            {"_": "message", "id": mid, "message": f"c{mid}", "date": 1767322445}
+        ],
+        "other_updates": [],
+    }
+
+
+def test_partial_interrupted_source_reprojects_to_same_partial_state(tmp_path, monkeypatch):
+    # DB1 whose catch_up PhaseStopped mid-backlog: the channel_difference
+    # fixture is [non_final_page(pts 50), PhaseStop("flood")]. Reproject must
+    # land on the same partial projections — raw_records is excluded here:
+    # replay closes the log with one synthetic final empty diff the
+    # interrupted original never wrote (plan D4.4).
+    fx = full_collect_fixtures()
+    fx["channel_difference"] = [_diff_page(50, final=False, mid=99), PhaseStop("flood")]
+
+    async def _collect() -> Path:
+        settings = load_settings("default", {"data_dir": tmp_path})
+        db = tmp_path / "default" / "paperboy.sqlite"
+        with Store.open(db) as store:
+            results = await collect_channel(
+                FakeGateway(fx), store, settings, parse_target("@durov"),
+                phases=["channel", "history"], log=logging.getLogger("t"),
+            )
+        history = next(r for r in results if r.name == "history")
+        assert history.stopped == "phase_stop"
+        return db
+
+    db1 = asyncio.run(_collect())
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    assert_round_trip(
+        db1, tmp_path / "default" / "paperboy.reprojected.sqlite",
+        skip_tables=frozenset({"raw_records"}),
+    )
+
+
+def test_reproject_never_rewrites_media_files(tmp_path, monkeypatch):
+    asyncio.run(run_full_collect(tmp_path))
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+
+    def _no_write(self, data):
+        raise AssertionError(f"reproject wrote a media file: {self}")
+
+    monkeypatch.setattr(Path, "write_bytes", _no_write)
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -167,8 +167,16 @@ def test_one_bad_historical_target_does_not_abort_other_targets(tmp_path, monkey
 # D5 (plan): equality modulo autoincrement pks and source_raw_id, compared as
 # DISTINCT row sets — replay legitimately serves one observation through two
 # paths (getHistory + getChannelDifference), duplicating byte-identical rows.
+# `raw_records.run_id` (ADR-0005) is excluded too, same spirit as `id`: it is
+# a synthetic pass-grouping identifier, not observed content. A legacy
+# (pre-migration) source's rows carry NULL run_id but replay LABELS their
+# inferred segment `legacy-0001...` when writing the target, so literal
+# run_id equality would never hold for a real archive predating this column
+# even though the replay is faithful; for a stamped source the source's own
+# run_id is threaded straight through to the target, so excluding it here
+# loses no real signal either way.
 ROUND_TRIP_EXCLUDE = {
-    "raw_records": {"id"},
+    "raw_records": {"id", "run_id"},
     "channels": {"source_raw_id"},
     "channel_snapshots": {"id", "source_raw_id"},
     "peers": {"source_raw_id"},

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -30,7 +30,7 @@ runner = CliRunner()
 async def test_detect_phases_reflects_recorded_raw_kinds(tmp_path):
     db = await run_full_collect(tmp_path)
     src = ReplaySource.open(db, tmp_path / "default" / "media")
-    phases = detect_phases(src)
+    phases = detect_phases(src, src.runs()[0])
     assert phases[:2] == ["channel", "history"]
     assert "graph" in phases and "web" in phases and "media" in phases
 
@@ -47,7 +47,7 @@ async def test_detect_phases_minimal_source(tmp_path):
             log=logging.getLogger("t"),
         )
     src = ReplaySource.open(db, tmp_path / "default" / "media")
-    assert detect_phases(src) == ["channel", "history"]
+    assert detect_phases(src, src.runs()[0]) == ["channel", "history"]
 
 
 def test_cli_reproject_writes_fresh_db_and_prints_diff(tmp_path, monkeypatch):
@@ -76,10 +76,25 @@ def test_cli_reproject_refuses_existing_out(tmp_path, monkeypatch):
 
 
 def test_cli_reproject_empty_source_exits_1(tmp_path, monkeypatch):
+    # Zero raw_records at all -> zero runs -> the "empty log" message
+    # (ADR-0005): distinct from "has runs but none resolved anything",
+    # covered separately below.
     monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
     (tmp_path / "default").mkdir(parents=True)
     with Store.open(tmp_path / "default" / "paperboy.sqlite"):
         pass  # schema only, no raws
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 1
+    assert "raw log is empty" in result.output
+
+
+def test_cli_reproject_source_with_no_resolve_records_exits_1(tmp_path, monkeypatch):
+    # Raw records exist (so at least one run), but none of them is a
+    # ResolvedPeer — nothing for reproject to replay a target from.
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    (tmp_path / "default").mkdir(parents=True)
+    with Store.open(tmp_path / "default" / "paperboy.sqlite") as st:
+        st.add_raw("user", {"_": "user", "id": 1, "self": True}, "self", None)
     result = runner.invoke(app, ["reproject", "--profile", "default"])
     assert result.exit_code == 1
     assert "no resolve records" in result.output
@@ -137,12 +152,19 @@ def test_one_bad_historical_target_does_not_abort_other_targets(tmp_path, monkey
     # with a bare ValueError even on a live run; reproject's multi-target
     # loop must not let that discard every other target's already-committed
     # projections the way a single crashed `collect` run naturally would.
+    # Two proper historical runs (ADR-0005): self is written FIRST in each,
+    # matching the real collector's capture order (`channel.py` writes self
+    # before anything else) — the segmentation the source archive naturally
+    # has when built from two separate `collect` invocations.
     db = tmp_path / "default" / "paperboy.sqlite"
     with Store.open(db) as st:
         resolve = json.loads(Path("tests/fixtures/tl/resolve_durov.json").read_text())
         full_channel = json.loads(Path("tests/fixtures/tl/full_channel.json").read_text())
+        st.begin_run()
+        st.add_raw("user", {"_": "user", "id": 1, "self": True}, "self", None)
         st.add_raw(resolve.get("_"), resolve, "stranger", {"target": "@durov"})
         st.add_raw(full_channel.get("_"), full_channel, "stranger", {"channel_id": 5})
+        st.begin_run()
         st.add_raw("user", {"_": "user", "id": 1, "self": True}, "self", None)
         st.add_raw(
             "contacts.resolvedPeer",
@@ -310,7 +332,7 @@ def test_source_without_graph_reprojects_without_graph(tmp_path, monkeypatch):
         _collect_with_fixtures(tmp_path, full_collect_fixtures(), ["channel", "history"])
     )
     src = ReplaySource.open(db1, tmp_path / "default" / "media")
-    assert detect_phases(src) == ["channel", "history"]
+    assert detect_phases(src, src.runs()[0]) == ["channel", "history"]
     src.close()
 
     monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
@@ -403,10 +425,6 @@ def _second_run_fixtures(fx: dict) -> dict:
     return fx
 
 
-@pytest.mark.xfail(
-    reason="#33 / ADR-0005: multi-run replay lands in tasks R2-R5",
-    strict=True,
-)
 def test_two_run_round_trip_identity(tmp_path, monkeypatch):
     """ADR-0005 gate: a source built from TWO collect passes — the ordinary
     real-archive shape — must round-trip identically, time series included."""

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -434,3 +434,55 @@ def test_two_run_round_trip_identity(tmp_path, monkeypatch):
     result = runner.invoke(app, ["reproject", "--profile", "default"])
     assert result.exit_code == 0, result.output
     assert_round_trip(db1, tmp_path / "default" / "paperboy.reprojected.sqlite")
+
+
+def _seed_backward_backfill_source(db: Path, *, run1_ids: range, run2_ids: range) -> None:
+    """A hand-built raw log matching the real archive's shape (found running
+    the R6 smoke, ADR-0005): two collect passes against the SAME channel,
+    where the second extends a backward backfill FURTHER INTO THE PAST —
+    `run2_ids` entirely below `run1_ids`. This is the ordinary multi-session
+    shape a deep backward backfill takes; it never involves a stamped
+    `run_id`/legacy-marker ambiguity, so it isolates the OTHER bug this
+    revision found: `HistoryCollector`'s live-collection incremental-vs-full
+    state (`sync_state` scopes `history`/`history_sweep`) surviving across
+    REPLAYED runs. `iter_history`, scoped per run (ADR-0005), naturally
+    empties out at each run's OWN rowid boundary — `history.py` reads that
+    as "reached the real end of the channel's history" and marks the sweep
+    complete, which is only true for a LIVE gateway (Telegram's real history
+    can't retroactively grow older messages between sessions, so this
+    couldn't happen live) — leaking that flag into the next run wrongly
+    switches it to incremental-only (ids above the first run's high-water
+    mark), silently dropping every one of its own, all-older messages.
+    """
+    resolve = json.loads(Path("tests/fixtures/tl/resolve_durov.json").read_text())
+    full_channel = json.loads(Path("tests/fixtures/tl/full_channel.json").read_text())
+    with Store.open(db) as st:
+        for run_name, ids in (("run-1", run1_ids), ("run-2", run2_ids)):
+            st.begin_run(run_name)
+            st.add_raw("user", {"_": "user", "id": 1, "self": True}, "self", None)
+            st.add_raw(resolve.get("_"), resolve, "stranger", {"target": "@durov"})
+            st.add_raw(full_channel.get("_"), full_channel, "stranger", {"channel_id": 5})
+            for i in ids:
+                st.add_raw(
+                    "message", {"_": "message", "id": i, "message": f"m{i}", "date": 1767322400},
+                    "stranger", {"channel_id": 5},
+                )
+
+
+def test_reproject_does_not_truncate_a_backward_multi_run_backfill(tmp_path, monkeypatch):
+    # Run 1: 150 messages (ids 851..1000, > one page of 100) so it naturally
+    # empties out at ITS OWN rowid boundary after 2 pages. Run 2: 150 OLDER
+    # messages (ids 701..850), also > one page — the bug's failure mode
+    # needs run 2 to span more than one page, or an early "caught up" break
+    # after page 1 would still have captured everything.
+    db = tmp_path / "default" / "paperboy.sqlite"
+    _seed_backward_backfill_source(db, run1_ids=range(851, 1001), run2_ids=range(701, 851))
+    source_ids = set(range(701, 1001))
+
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    out = sqlite3.connect(tmp_path / "default" / "paperboy.reprojected.sqlite")
+    reprojected_ids = {r[0] for r in out.execute("SELECT msg_id FROM messages")}
+    out.close()
+    assert reprojected_ids == source_ids

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -111,6 +111,38 @@ def test_cli_reproject_custom_out_path(tmp_path, monkeypatch):
     assert not (tmp_path / "default" / "paperboy.reprojected.sqlite").exists()
 
 
+def test_one_bad_historical_target_does_not_abort_other_targets(tmp_path, monkeypatch):
+    # A source archive can carry more than one resolved target across its
+    # history (successive `collect` runs against different inputs, found
+    # exercising this against a real archive — DoD smoke, see the feature
+    # doc). One later turning out not to be a channel (an accidental collect
+    # against a user, say) crashes `channel.collect`'s `_resolved_channel_id`
+    # with a bare ValueError even on a live run; reproject's multi-target
+    # loop must not let that discard every other target's already-committed
+    # projections the way a single crashed `collect` run naturally would.
+    db = tmp_path / "default" / "paperboy.sqlite"
+    with Store.open(db) as st:
+        resolve = json.loads(Path("tests/fixtures/tl/resolve_durov.json").read_text())
+        full_channel = json.loads(Path("tests/fixtures/tl/full_channel.json").read_text())
+        st.add_raw(resolve.get("_"), resolve, "stranger", {"target": "@durov"})
+        st.add_raw(full_channel.get("_"), full_channel, "stranger", {"channel_id": 5})
+        st.add_raw("user", {"_": "user", "id": 1, "self": True}, "self", None)
+        st.add_raw(
+            "contacts.resolvedPeer",
+            {"_": "contacts.resolvedPeer", "peer": {"_": "PeerUser", "user_id": 999},
+             "chats": [], "users": [{"_": "User", "id": 999}]},
+            "stranger", {"target": "@notachannel"},
+        )
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    out = sqlite3.connect(tmp_path / "default" / "paperboy.reprojected.sqlite")
+    # The good target's channel landed despite the bad target existing too.
+    assert out.execute("SELECT count(*) FROM channels WHERE id=5").fetchone()[0] == 1
+    out.close()
+    assert "notachannel" in result.output
+
+
 # ---------------------------------------------------------------------------
 # Task 7: the correctness battery — round-trip identity + guardrails (spec §7)
 # ---------------------------------------------------------------------------

--- a/tests/test_reproject_parity.py
+++ b/tests/test_reproject_parity.py
@@ -1,0 +1,177 @@
+"""Live-collect parity: a full frozen-clock collect must produce byte-identical
+projections before and after the observed-at seam (spec §5). Regenerate the
+golden with: UPDATE_GOLDEN=1 uv run pytest tests/test_reproject_parity.py -q
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+from paperboy.collectors.web import WebCollector
+from paperboy.config import load_settings
+from paperboy.recipes import collect_channel
+from paperboy.store.db import Store
+from paperboy.targets import parse_target
+from paperboy.web.client import WebClient
+from tests.fakes import FakeGateway
+
+FX = Path("tests/fixtures/tl")
+GOLDEN = Path("tests/fixtures/reproject/parity_golden.json")
+FROZEN_NOW = "2026-01-01T00:00:00+00:00"
+
+# Tables whose content the parity golden pins. Excludes operational /
+# bookkeeping tables (schema_migrations, flood_log) and the FTS shadow tables.
+PARITY_TABLES = (
+    "raw_records", "channels", "channel_snapshots", "peers", "messages",
+    "message_revisions", "message_metrics", "message_tombstones", "edges",
+    "media", "custody_log", "web_snapshots", "sync_state", "sync_ranges",
+    "run_events",
+)
+
+
+def freeze_clock(monkeypatch) -> None:
+    """Pin utc_now_iso in EVERY imported paperboy module. Modules import it
+    by name (`from paperboy.ids import utc_now_iso`), so patching the
+    definition alone would miss every importer's local reference."""
+    for name, mod in list(sys.modules.items()):
+        if name.startswith(("paperboy", "tests")) and hasattr(mod, "utc_now_iso"):
+            monkeypatch.setattr(mod, "utc_now_iso", lambda: FROZEN_NOW)
+
+
+def full_collect_fixtures() -> dict:
+    resolve = json.loads((FX / "resolve_durov.json").read_text())
+    full_channel = json.loads((FX / "full_channel.json").read_text())
+    return {
+        "resolve": resolve,
+        "full_channel": full_channel,
+        "self": {"_": "user", "id": 1, "self": True, "phone": "+15551234567"},
+        "history": [
+            {
+                "_": "message", "id": 3, "message": "see https://t.me/other_channel",
+                "date": 1767322500, "views": 10,
+                "entities": [{"_": "MessageEntityUrl", "offset": 4, "length": 24}],
+            },
+            {
+                "_": "message", "id": 2, "message": "", "date": 1767322445,
+                "media": {
+                    "_": "MessageMediaDocument",
+                    "document": {
+                        "_": "Document", "id": 9, "access_hash": 1,
+                        "mime_type": "text/plain",
+                        "attributes": [
+                            {"_": "DocumentAttributeFilename", "file_name": "a.txt"}
+                        ],
+                    },
+                },
+            },
+            {"_": "message", "id": 1, "message": "m1", "date": 1767322400},
+        ],
+        # One catch-up page carrying an edit of msg 1 — exercises the
+        # revisions path and (later) replay's nested-payload clock.
+        "channel_difference": {
+            "_": "updates.channelDifference", "final": True, "pts": 43,
+            "new_messages": [
+                {"_": "message", "id": 1, "message": "m1 edited",
+                 "date": 1767322400, "edit_date": 1767322600},
+            ],
+            "other_updates": [],
+        },
+        "get_messages": {},
+        "media": {2: b"file contents"},
+        "channel_recommendations": json.loads((FX / "recommendations.json").read_text()),
+        "sponsored_messages": json.loads((FX / "sponsored_messages.json").read_text()),
+        "chat_invite": {},
+    }
+
+
+_TME_HTML = """<html><body>
+<div class="tgme_widget_message" data-post="durov/1">
+  <div class="tgme_widget_message_text">m1</div>
+  <time datetime="2026-01-01T00:00:00+00:00"></time>
+</div>
+</body></html>"""
+
+
+def _web_transport() -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if url.startswith("https://t.me/s/durov?before="):
+            return httpx.Response(200, text="<html><body></body></html>")
+        if url.startswith("https://t.me/s/durov"):
+            return httpx.Response(200, text=_TME_HTML)
+        if url.startswith("https://web.archive.org/cdx/"):
+            return httpx.Response(200, text=json.dumps([
+                ["urlkey", "timestamp", "original", "mimetype", "statuscode",
+                 "digest", "length"],
+                ["me,t)/s/durov", "20260101000000", "https://t.me/s/durov",
+                 "text/html", "200", "DIGEST1", "1234"],
+            ]))
+        raise AssertionError(f"unexpected URL fetched: {url}")
+
+    return httpx.MockTransport(handler)
+
+
+async def run_full_collect(data_dir: Path) -> Path:
+    """Collect every phase into <data_dir>/default/paperboy.sqlite; returns the DB path."""
+    settings = load_settings("default", {"data_dir": data_dir})
+    db = data_dir / "default" / "paperboy.sqlite"
+    web = WebCollector(
+        client=WebClient(transport=_web_transport()),
+        min_interval=0.0, sleep=lambda s: None,
+    )
+    from paperboy.collectors.media import MediaCollector
+    from paperboy.recipes import _default_collectors
+    collectors = [
+        c for c in _default_collectors(include_media=False, include_web=False)
+    ] + [web, MediaCollector()]
+    with Store.open(db) as store:
+        await collect_channel(
+            FakeGateway(full_collect_fixtures()), store, settings,
+            parse_target("@durov"),
+            phases=["channel", "history", "discussion", "graph", "web", "media"],
+            log=logging.getLogger("parity"), collectors=collectors,
+        )
+    return db
+
+
+def dump_db(conn, data_dir: Path, tables=PARITY_TABLES) -> dict[str, list]:
+    """Canonical dump: per table, sorted rows as column->value dicts, with the
+    machine-specific data_dir prefix normalized out of path-bearing values."""
+    prefix = str(data_dir)
+    out: dict[str, list] = {}
+    for table in tables:
+        cols = [r[1] for r in conn.execute(f"PRAGMA table_info({table})")]
+        rows = []
+        for row in conn.execute(f"SELECT * FROM {table}"):
+            d = {
+                c: (v.replace(prefix, "<DATA_DIR>") if isinstance(v, str) else v)
+                for c, v in zip(cols, row, strict=True)
+            }
+            rows.append(d)
+        out[table] = sorted(rows, key=lambda d: json.dumps(d, sort_keys=True, default=str))
+    return out
+
+
+@pytest.mark.asyncio
+async def test_full_collect_matches_golden(tmp_path, monkeypatch):
+    freeze_clock(monkeypatch)
+    db = await run_full_collect(tmp_path)
+    with Store.open(db) as store:
+        dumped = dump_db(store.conn, tmp_path)
+    if os.environ.get("UPDATE_GOLDEN"):
+        GOLDEN.parent.mkdir(parents=True, exist_ok=True)
+        # One-shot test-fixture regeneration, not runtime code — a
+        # trio.Path/anyio.Path dependency for this would buy nothing.
+        GOLDEN.write_text(  # noqa: ASYNC240
+            json.dumps(dumped, indent=1, sort_keys=True, default=str)
+        )
+        pytest.skip("golden regenerated")
+    golden = json.loads(GOLDEN.read_text())  # noqa: ASYNC240 - see above
+    assert dumped == golden

--- a/tests/test_reproject_parity.py
+++ b/tests/test_reproject_parity.py
@@ -156,17 +156,32 @@ async def run_full_collect(
 
 def dump_db(conn, data_dir: Path, tables=PARITY_TABLES) -> dict[str, list]:
     """Canonical dump: per table, sorted rows as column->value dicts, with the
-    machine-specific data_dir prefix normalized out of path-bearing values."""
+    machine-specific data_dir prefix normalized out of path-bearing values.
+
+    `raw_records.run_id` (ADR-0005) is a random uuid4 hex per process, so it
+    is normalized to `run-0001`, `run-0002`, ... in order of first appearance
+    (by raw rowid) — otherwise the golden would be non-reproducible.
+    """
     prefix = str(data_dir)
+    run_ids: dict[str, str] = {}
+
+    def _norm_run_id(v: str | None) -> str | None:
+        if v is None:
+            return None
+        return run_ids.setdefault(v, f"run-{len(run_ids) + 1:04d}")
+
     out: dict[str, list] = {}
     for table in tables:
         cols = [r[1] for r in conn.execute(f"PRAGMA table_info({table})")]
         rows = []
-        for row in conn.execute(f"SELECT * FROM {table}"):
+        query = f"SELECT * FROM {table}" + (" ORDER BY id" if table == "raw_records" else "")
+        for row in conn.execute(query):
             d = {
                 c: (v.replace(prefix, "<DATA_DIR>") if isinstance(v, str) else v)
                 for c, v in zip(cols, row, strict=True)
             }
+            if table == "raw_records":
+                d["run_id"] = _norm_run_id(d["run_id"])
             rows.append(d)
         out[table] = sorted(rows, key=lambda d: json.dumps(d, sort_keys=True, default=str))
     return out

--- a/tests/test_reproject_parity.py
+++ b/tests/test_reproject_parity.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 import httpx
@@ -118,8 +119,17 @@ def _web_transport() -> httpx.MockTransport:
     return httpx.MockTransport(handler)
 
 
-async def run_full_collect(data_dir: Path) -> Path:
-    """Collect every phase into <data_dir>/default/paperboy.sqlite; returns the DB path."""
+async def run_full_collect(
+    data_dir: Path,
+    mutate_fixtures: Callable[[dict], dict] | None = None,
+) -> Path:
+    """Collect every phase into <data_dir>/default/paperboy.sqlite; returns the DB path.
+
+    `mutate_fixtures` (ADR-0005 / #33) lets a caller run a SECOND collect pass
+    against the same DB with varied FakeGateway fixtures — e.g. a later run
+    observing a new message — to exercise multi-run replay. The web transport
+    is unchanged; only the FakeGateway fixtures dict is mutated.
+    """
     settings = load_settings("default", {"data_dir": data_dir})
     db = data_dir / "default" / "paperboy.sqlite"
     web = WebCollector(
@@ -131,9 +141,12 @@ async def run_full_collect(data_dir: Path) -> Path:
     collectors = [
         c for c in _default_collectors(include_media=False, include_web=False)
     ] + [web, MediaCollector()]
+    fixtures = full_collect_fixtures()
+    if mutate_fixtures is not None:
+        fixtures = mutate_fixtures(fixtures)
     with Store.open(db) as store:
         await collect_channel(
-            FakeGateway(full_collect_fixtures()), store, settings,
+            FakeGateway(fixtures), store, settings,
             parse_target("@durov"),
             phases=["channel", "history", "discussion", "graph", "web", "media"],
             log=logging.getLogger("parity"), collectors=collectors,

--- a/tests/test_store_channels.py
+++ b/tests/test_store_channels.py
@@ -93,6 +93,28 @@ def test_upsert_channel_records_a_new_snapshot_each_call(tmp_path):
         assert [s["participants_count"] for s in snaps] == [100, 150]  # history preserved
 
 
+def test_out_of_order_observation_keeps_newest_state(tmp_path):
+    # ADR-0005 §6: same order-independence contract as peers — an older
+    # observation arriving after a newer one must not clobber current state,
+    # but the observation window (first_seen/last_seen, via channel_snapshots
+    # remaining an unconditional append) still reflects the true range.
+    with Store.open(tmp_path / "p.sqlite") as st:
+        chan = {"_": "channel", "id": 5, "title": "Durov", "broadcast": True}
+        full_new = {"_": "channelFull", "id": 5, "participants_count": 200}
+        r_new = st.add_raw("channelFull", full_new, "stranger", None)
+        upsert_channel(st, full_new, chan, r_new, "2026-02-01T00:00:00+00:00")
+        full_old = {"_": "channelFull", "id": 5, "participants_count": 100}
+        r_old = st.add_raw("channelFull", full_old, "stranger", None)
+        # The OLDER observation arrives second (out of order):
+        upsert_channel(st, full_old, chan, r_old, "2026-01-01T00:00:00+00:00")
+        row = st.conn.execute(
+            "select participants_count, first_seen, last_seen from channels where id=5"
+        ).fetchone()
+        assert row["participants_count"] == 200  # stale data must not clobber
+        assert row["first_seen"] == "2026-01-01T00:00:00+00:00"
+        assert row["last_seen"] == "2026-02-01T00:00:00+00:00"
+
+
 def test_linked_chat_id_preserved_when_present(tmp_path):
     with Store.open(tmp_path / "p.sqlite") as st:
         chan = {"_": "channel", "id": 5, "title": "Durov", "broadcast": True}

--- a/tests/test_store_peers.py
+++ b/tests/test_store_peers.py
@@ -84,6 +84,34 @@ def test_out_of_order_observation_keeps_seen_window_and_newest_state(tmp_path):
         assert row["username"] == "new_name"   # stale data must not clobber
 
 
+def test_min_observation_older_than_first_seen_still_widens_the_window(tmp_path):
+    # adversarial-reviewer, round 2: the min-over-an-existing-non-min-row
+    # branch widened only `last_seen` (MAX), never `first_seen` (MIN) — a
+    # regression against this module's own documented invariant
+    # ("first_seen/last_seen themselves always widen to the true min/max
+    # window regardless of arrival order"). A min observation OLDER than the
+    # stored full row's first_seen must still pull first_seen backward, the
+    # same way the full-upsert branch already does (`test_out_of_order_
+    # observation_keeps_seen_window_and_newest_state` above covers that
+    # branch; this covers the min branch, which took a different code path
+    # untouched by that test).
+    with Store.open(tmp_path / "p.sqlite") as st:
+        full = {"_": "user", "id": 9, "access_hash": 111, "username": "real"}
+        r1 = st.add_raw("user", full, "member", None)
+        upsert_peer(st, full, r1, "2026-01-02T00:00:00+00:00", seen_in_chat=None, seen_in_msg=None)
+        mn = {"_": "user", "id": 9, "min": True}
+        r2 = st.add_raw("user", mn, "stranger", None)
+        # The min observation is OLDER than the stored row's first_seen —
+        # replay can serve records out of `observed_at` order (ADR-0005 §6).
+        upsert_peer(st, mn, r2, "2026-01-01T00:00:00+00:00", seen_in_chat=7, seen_in_msg=1)
+        row = st.conn.execute(
+            "select first_seen, last_seen, username from peers where uri='tg:user:9'"
+        ).fetchone()
+        assert row["first_seen"] == "2026-01-01T00:00:00+00:00"  # widened backward
+        assert row["last_seen"] == "2026-01-02T00:00:00+00:00"  # unaffected
+        assert row["username"] == "real"  # stale min observation didn't clobber state
+
+
 def test_join_to_send_flag_is_persisted(tmp_path):
     """`join_to_send` is the passivity guardrail the `discussion` collector's
     preflight relies on to decide whether reading a linked group requires

--- a/tests/test_store_peers.py
+++ b/tests/test_store_peers.py
@@ -60,6 +60,30 @@ def test_channel_typed_peer_stores_title(tmp_path):
         assert row["title"] == "Durov"
 
 
+def test_out_of_order_observation_keeps_seen_window_and_newest_state(tmp_path):
+    # ADR-0005 §6: replay serves records in RECORDED order, not necessarily
+    # observed_at order across runs — an older observation can arrive at
+    # upsert_peer AFTER a newer one already landed. first_seen/last_seen must
+    # widen to the true window regardless of arrival order, and stale data
+    # must never clobber a newer value.
+    with Store.open(tmp_path / "p.sqlite") as store:
+        raw_new = store.add_raw("User", {"_": "user", "id": 9}, "stranger", None)
+        raw_old = store.add_raw("User", {"_": "user", "id": 9}, "stranger", None)
+        upsert_peer(store, {"_": "user", "id": 9, "username": "new_name"},
+                    raw_new, "2026-02-01T00:00:00+00:00",
+                    seen_in_chat=None, seen_in_msg=None)
+        # The OLDER observation arrives second (out of order):
+        upsert_peer(store, {"_": "user", "id": 9, "username": "old_name"},
+                    raw_old, "2026-01-01T00:00:00+00:00",
+                    seen_in_chat=None, seen_in_msg=None)
+        row = store.conn.execute(
+            "SELECT username, first_seen, last_seen FROM peers"
+        ).fetchone()
+        assert row["first_seen"] == "2026-01-01T00:00:00+00:00"
+        assert row["last_seen"] == "2026-02-01T00:00:00+00:00"
+        assert row["username"] == "new_name"   # stale data must not clobber
+
+
 def test_join_to_send_flag_is_persisted(tmp_path):
     """`join_to_send` is the passivity guardrail the `discussion` collector's
     preflight relies on to decide whether reading a linked group requires

--- a/tests/test_store_peers.py
+++ b/tests/test_store_peers.py
@@ -1,4 +1,7 @@
+import itertools
 import json
+
+import pytest
 
 from paperboy.store.db import Store
 from paperboy.store.peers import upsert_peer
@@ -137,3 +140,160 @@ def test_join_to_send_flag_is_persisted(tmp_path):
         row = st.conn.execute("select flags_json from peers where uri=?", (uri,)).fetchone()
         flags = json.loads(row["flags_json"]) if row["flags_json"] else {}
         assert flags.get("join_to_send") is True
+
+
+# --- ADR-0005 §6 (amended, round-2 finding A): the composed richness ∘
+# recency lattice, table-tested cell by cell. --------------------------------
+
+_T_STORED = "2026-01-05T00:00:00+00:00"
+_T_OLDER = "2026-01-01T00:00:00+00:00"   # < _T_STORED
+_T_NEWER = "2026-01-10T00:00:00+00:00"   # > _T_STORED
+
+_STORED_FULL = {"_": "user", "id": 9, "access_hash": 111, "username": "stored_full",
+                "first_name": "StoredFull"}
+_STORED_MIN = {"_": "user", "id": 9, "min": True, "first_name": "StoredMin"}
+_INCOMING_FULL = {"_": "user", "id": 9, "access_hash": 222, "username": "incoming_full",
+                   "first_name": "IncomingFull"}
+_INCOMING_MIN = {"_": "user", "id": 9, "min": True, "first_name": "IncomingMin"}
+
+_STORED_PROV = (100, 200)      # seen_in_chat, seen_in_msg for the stored observation
+_INCOMING_PROV = (300, 400)    # seen_in_chat, seen_in_msg for the incoming observation
+
+
+def _seed(store, stored_obj, stored_prov):
+    r = store.add_raw("user", stored_obj, "member", None, observed_at=_T_STORED)
+    upsert_peer(store, stored_obj, r, _T_STORED,
+                seen_in_chat=stored_prov[0], seen_in_msg=stored_prov[1])
+    return r
+
+
+# Each case: (stored_kind, incoming_kind, incoming_stamp,
+#             identity_from, provenance_from, source_raw_from,
+#             expected_first_seen, expected_last_seen)
+# "identity_from"/"provenance_from"/"source_raw_from" are "stored" or
+# "incoming" -- which observation's values must appear in the final row.
+_LATTICE_CASES = [
+    # full <- full: recency for everything.
+    ("full", "full", "older", "stored", "stored", "stored", _T_OLDER, _T_STORED),
+    ("full", "full", "newer", "incoming", "incoming", "incoming", _T_STORED, _T_NEWER),
+    # full <- min: richness -- identity NEVER moves; provenance (+source_raw_id) on recency.
+    ("full", "min", "older", "stored", "stored", "stored", _T_OLDER, _T_STORED),
+    ("full", "min", "newer", "stored", "incoming", "incoming", _T_STORED, _T_NEWER),
+    # min <- full: richness -- identity (+source_raw_id) ALWAYS moves; provenance on recency.
+    ("min", "full", "older", "incoming", "stored", "incoming", _T_OLDER, _T_STORED),
+    ("min", "full", "newer", "incoming", "incoming", "incoming", _T_STORED, _T_NEWER),
+    # min <- min: recency for everything.
+    ("min", "min", "older", "stored", "stored", "stored", _T_OLDER, _T_STORED),
+    ("min", "min", "newer", "incoming", "incoming", "incoming", _T_STORED, _T_NEWER),
+]
+
+
+@pytest.mark.parametrize(
+    "stored_kind, incoming_kind, incoming_stamp, identity_from, provenance_from, "
+    "source_raw_from, expected_first_seen, expected_last_seen",
+    _LATTICE_CASES,
+    ids=[f"{c[0]}_stored-{c[1]}_incoming-{c[2]}" for c in _LATTICE_CASES],
+)
+def test_upsert_peer_composed_lattice(
+    tmp_path, stored_kind, incoming_kind, incoming_stamp, identity_from,
+    provenance_from, source_raw_from, expected_first_seen, expected_last_seen,
+):
+    """ADR-0005 §6 (amended): the eight (stored richness x incoming richness x
+    incoming recency) cells of the composed lattice. Round 2 shipped a
+    recency-only rule that silently dropped `peers.py`'s pre-existing richness
+    invariant; two cells broke as a result -- both are covered here
+    (`min_stored-full_incoming-older` is the one the round-2 escalation
+    named explicitly: a full incoming observation with an OLDER stamp than a
+    stored `min` row must still win, because a `min` row never had
+    trustworthy profile data to begin with)."""
+    stored_obj = _STORED_FULL if stored_kind == "full" else _STORED_MIN
+    incoming_obj = _INCOMING_FULL if incoming_kind == "full" else _INCOMING_MIN
+    incoming_t = _T_OLDER if incoming_stamp == "older" else _T_NEWER
+
+    with Store.open(tmp_path / "p.sqlite") as store:
+        stored_raw = _seed(store, stored_obj, _STORED_PROV)
+        incoming_raw = store.add_raw("user", incoming_obj, "stranger", None,
+                                      observed_at=incoming_t)
+        upsert_peer(store, incoming_obj, incoming_raw, incoming_t,
+                    seen_in_chat=_INCOMING_PROV[0], seen_in_msg=_INCOMING_PROV[1])
+
+        row = store.conn.execute(
+            "SELECT username, is_min, seen_in_chat, seen_in_msg, source_raw_id, "
+            "first_seen, last_seen FROM peers WHERE uri='tg:user:9'"
+        ).fetchone()
+
+    want_identity = stored_obj if identity_from == "stored" else incoming_obj
+    assert row["username"] == want_identity.get("username")
+    assert row["is_min"] == int(bool(want_identity.get("min")))
+
+    want_prov = _STORED_PROV if provenance_from == "stored" else _INCOMING_PROV
+    assert (row["seen_in_chat"], row["seen_in_msg"]) == want_prov
+
+    want_raw = stored_raw if source_raw_from == "stored" else incoming_raw
+    assert row["source_raw_id"] == want_raw
+
+    assert row["first_seen"] == expected_first_seen
+    assert row["last_seen"] == expected_last_seen
+
+
+def test_upsert_peer_lattice_is_order_independent_for_a_replay_sequence(tmp_path):
+    """The ordering-property gate the #33 round-2 escalation demanded: a
+    class of test that can fail on a future ordering defect without a
+    reviewer having to invent a fresh probe for it (rather than one more
+    fixed-order example, which round 2's own gap showed is easy to write
+    around by accident).
+
+    Three observations of the same peer -- full@t1 (oldest), min@t2, full@t3
+    (newest) -- applied in every one of the six possible arrival orders must
+    converge on the identical final row: replay does not guarantee
+    observed_at-order delivery within upsert_peer (ADR-0005 §6's own
+    `test_out_of_order_observation_keeps_seen_window_and_newest_state` above
+    already pins that for a single full<-full pair), so the merge must be
+    genuinely order-independent, not just correct for the one arrival order a
+    live collect happens to produce.
+
+    Scope note: this triple is chosen so `min`'s own stamp never exceeds
+    BOTH full stamps. When it does (a `min` observation strictly newer than
+    every `full` observation of the same peer, arriving between two `full`
+    observations in processing order), the composed lattice as specified by
+    ADR-0005 §6 is provably NOT order-independent -- richness correctly
+    promotes whichever `full` observation is current at the moment the
+    later, "poisoned" `last_seen` benchmark was set, and *which* `full` that
+    is depends on arrival order, not just timestamps (`peers.last_seen` is
+    one shared column standing in for two different benchmarks: "freshest
+    observation of any kind" and "freshest full/identity observation").
+    Filed as #38 (real-world reachable via replay's payload-keyed,
+    non-chronological delivery -- see `ReplayClock`'s docstring) rather than
+    fixed here: round 3 was authorized narrow, and closing it needs a real
+    design change (a richness-scoped timestamp benchmark distinct from
+    `last_seen`), not a guard tweak.
+    """
+    t1 = "2026-01-01T00:00:00+00:00"
+    t2 = "2026-01-02T00:00:00+00:00"
+    t3 = "2026-01-03T00:00:00+00:00"
+    observations = {
+        "full1": ({"_": "user", "id": 9, "access_hash": 1, "username": "u1"}, t1, (10, 20)),
+        "min2": ({"_": "user", "id": 9, "min": True}, t2, (30, 40)),
+        "full3": ({"_": "user", "id": 9, "access_hash": 3, "username": "u3"}, t3, (50, 60)),
+    }
+    results = []
+    for order in itertools.permutations(observations):
+        with Store.open(tmp_path / f"p_{'_'.join(order)}.sqlite") as store:
+            for label in order:
+                obj, t, (sc, sm) = observations[label]
+                raw_id = store.add_raw("user", obj, "stranger", None, observed_at=t)
+                upsert_peer(store, obj, raw_id, t, seen_in_chat=sc, seen_in_msg=sm)
+            row = store.conn.execute(
+                "SELECT username, access_hash, is_min, seen_in_chat, seen_in_msg, "
+                "first_seen, last_seen FROM peers"
+            ).fetchone()
+            results.append(dict(row))
+
+    assert all(r == results[0] for r in results), results
+    # Matches the lattice's expected outcome: the newest AND full observation
+    # wins outright, with its own provenance and the fully-widened window.
+    assert results[0] == {
+        "username": "u3", "access_hash": 3, "is_min": 0,
+        "seen_in_chat": 50, "seen_in_msg": 60,
+        "first_seen": t1, "last_seen": t3,
+    }

--- a/tests/test_store_peers.py
+++ b/tests/test_store_peers.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 
-from paperboy.store.db import Store
+from paperboy.store.db import Store, dumps
 from paperboy.store.peers import upsert_peer
 
 
@@ -253,20 +253,27 @@ def test_upsert_peer_lattice_is_order_independent_for_a_replay_sequence(tmp_path
     live collect happens to produce.
 
     Scope note: this triple is chosen so `min`'s own stamp never exceeds
-    BOTH full stamps. When it does (a `min` observation strictly newer than
-    every `full` observation of the same peer, arriving between two `full`
-    observations in processing order), the composed lattice as specified by
-    ADR-0005 §6 is provably NOT order-independent -- richness correctly
-    promotes whichever `full` observation is current at the moment the
-    later, "poisoned" `last_seen` benchmark was set, and *which* `full` that
-    is depends on arrival order, not just timestamps (`peers.last_seen` is
-    one shared column standing in for two different benchmarks: "freshest
-    observation of any kind" and "freshest full/identity observation").
-    Filed as #38 (real-world reachable via replay's payload-keyed,
-    non-chronological delivery -- see `ReplayClock`'s docstring) rather than
-    fixed here: round 3 was authorized narrow, and closing it needs a real
-    design change (a richness-scoped timestamp benchmark distinct from
-    `last_seen`), not a guard tweak.
+    the NEWEST full stamp. When it does, the composed lattice as specified
+    by ADR-0005 §6 is provably NOT order-independent, in two filed
+    families: sandwiched between two `full` observations, *identity*
+    columns diverge by arrival order (#38 -- richness promotes whichever
+    `full` is current when the later, "poisoned" `last_seen` benchmark was
+    set; `peers.last_seen` is one shared column standing in for two
+    different benchmarks); and with >=1 `full`, the `source_raw_id`
+    raw-evidence lineage pointer diverges while identity converges (#39 --
+    the early branch's provenance rule and the main upsert's richness rule
+    each move that one dual-role column). Both are real-world reachable via
+    replay's payload-keyed, non-chronological delivery (see `ReplayClock`'s
+    docstring) and filed rather than fixed here: round 3 was authorized
+    narrow, and closing them needs a real design change (a richness-scoped
+    timestamp benchmark distinct from `last_seen`, plus a decision on
+    `source_raw_id`'s dual role), not a guard tweak.
+
+    The comparison resolves `source_raw_id` to the raw record's
+    payload_json (`source_payload` below) rather than comparing the rowid
+    itself, which is not comparable across the per-permutation stores --
+    so raw-evidence lineage IS covered by this gate for every
+    configuration outside the two filed families.
     """
     t1 = "2026-01-01T00:00:00+00:00"
     t2 = "2026-01-02T00:00:00+00:00"
@@ -285,15 +292,19 @@ def test_upsert_peer_lattice_is_order_independent_for_a_replay_sequence(tmp_path
                 upsert_peer(store, obj, raw_id, t, seen_in_chat=sc, seen_in_msg=sm)
             row = store.conn.execute(
                 "SELECT username, access_hash, is_min, seen_in_chat, seen_in_msg, "
-                "first_seen, last_seen FROM peers"
+                "first_seen, last_seen, "
+                "(SELECT payload_json FROM raw_records WHERE id = peers.source_raw_id) "
+                "AS source_payload FROM peers"
             ).fetchone()
             results.append(dict(row))
 
     assert all(r == results[0] for r in results), results
     # Matches the lattice's expected outcome: the newest AND full observation
-    # wins outright, with its own provenance and the fully-widened window.
+    # wins outright, with its own provenance, its own raw record as the
+    # evidence lineage, and the fully-widened window.
     assert results[0] == {
         "username": "u3", "access_hash": 3, "is_min": 0,
         "seen_in_chat": 50, "seen_in_msg": 60,
         "first_seen": t1, "last_seen": t3,
+        "source_payload": dumps(observations["full3"][0]),
     }


### PR DESCRIPTION
Closes #33. Fixes #34, #35.

`paperboy reproject` rebuilds every normalized projection from `raw_records` into a fresh SQLite DB by replaying the raw log through the **real collectors** — offline, zero network, zero credentials, original observation timestamps preserved. The payoff on the real `default` archive: corrected 48-flag channels, a self-free `peers` table, idempotent edges, the `MessageEmpty` guard — applied to everything already captured, including since-deleted content that now exists only in raw, with no Telegram contact.

**Spec:** `docs/superpowers/specs/2026-08-25-reproject-design.md` (+ §10/§11 implementation revisions)
**Plan:** `docs/superpowers/plans/2026-08-26-reproject.md` (tasks 1–8, revisions R and R2)
**ADR:** `docs/adr/0005-run-structure.md` (accepted, §6 amended)
**Feature doc + full DoD smoke transcripts:** `docs/features/reproject.md`

## How it works (one paragraph)

`RawReplayGateway`/`RawReplayWebClient` implement the existing `Gateway`/`WebGetter` seams backed by a source DB's `raw_records`, so `recipes.collect_channel` runs **unchanged** against them into a fresh target store — the reprojection is the same code path as a live collect. A `Clock` seam (`LiveClock`/`ReplayClock`, payload-keyed) threads each raw record's original `observed_at` into every projection site, making the projection a pure function of the raw log; the round-trip identity test (collect → reproject → byte-equal projections, timestamps included) is the correctness contract.

## The three-round story (full diagnoses on #33)

- **Round 1** implemented the spec as approved and was rejected by the adversarial review panel — correctly: the spec's premise ("projections rebuildable from raw") is **false for multi-run archives**, because the raw log recorded no run structure. Escalated; user approved **ADR-0005**: `raw_records.run_id` (migration `0003_run_id.sql`), replay once per historical run, legacy rows segmented read-only at the opening-cluster marker, order-independent upserts.
- **Round 2** implemented ADR-0005 and was rejected on two localized findings: the ADR §6 upsert rule as originally written was recency-only and dropped `peers.py`'s pre-existing richness invariant (a genuine spec defect — §6 now carries the full composed lattice), and the feature doc's shape made stale-behavior claims the default. Round 2 also found and fixed three real legacy-segmentation bugs and verified the design digit-for-digit against the real archive.
- **Round 3** (finished inline after the workflow was stopped): the composed richness∘recency `upsert_peer` fix with an 8-case lattice table test and a 6-permutation order-invariance property gate; the doc restructured to single-source-of-truth (docstrings canonical, smoke narratives frozen); the ghost-profile CLI fix; the completed 5-mutation battery; and a final single-agent adversarial review, whose one finding (a second, unfiled order-dependence family) was resolved by filing #39 and correcting every residual-scoping statement.

## DoD evidence

- **Gates:** 408 passed, `ruff` clean, `pyright` clean (all runs with `TMPDIR=/Volumes/Storage/tmp` — the root volume ran out of space mid-round-2 and corrupts default-tmp sqlite runs).
- **Round-trip identity:** single-run and **two-run** sources round-trip exactly (`test_round_trip_identity`, `test_two_run_round_trip_identity` — the latter written red-first as the convergence gate round 1 lacked).
- **Guardrails asserted by test:** zero network (`TelethonGateway`/`WebClient` constructors monkeypatched to raise), zero keychain (`keyring.get_password` raises), no media re-writes (`Path.write_bytes` raises), source opened `mode=ro`.
- **Real-archive smoke** (source md5 `ea97fc2b8ab297c77c2a816e3d3363cf`, byte-unchanged, verified three times): 7 legacy runs segmented; time series exact (`channel_snapshots` 6→6, `web_snapshots` 362→362, `message_metrics` 4020→4020); `messages`/`revisions` 5496→5496, tombstones 258→258; flags corrected 10→48; self peer rows 0. Full transcripts in the feature doc.
- **Mutation battery:** all five round-2 regression tests proven live signal (each killed by its reverting mutation; table in the feature doc). Reviewer independently spot-checked two rows plus the CLI guard.

## Judgment calls to review at Gate B

1. **Spec §3 deviations D4.1–D4.7** (documented in spec §10): non-tombstoning `ReplayUnknownMessage` placeholder (never fabricate deletion evidence), sponsored-envelope reconstruction, synthetic no-op `join_channel` under forced `allow_join=True`, synthetic final empty diff, raw-kind phase detection, namespace-tolerant kind matching, per-target error isolation.
2. **D3 live-behavior change:** derived edges (mentions, thread edges, replier backfill) and duplicate-custody rows now stamp the underlying observation's capture time, not scan time — required for projections to be a pure function of raw.
3. **ADR-0005 §6 as amended:** the composed richness∘recency peer-merge lattice (the original recency-only sentence shipped round 2's regression; the amendment is the fix).
4. **D5 equality contract:** distinct-row sets modulo autoincrement ids and `source_raw_id` (content round-trips via the `raw_records` comparison).

## Known residuals (all filed, none silent)

- #36 — a historical run whose media phase downloaded nothing new leaves no raw trace; its duplicate-custody rows aren't replayed (`custody_log` 607→599 on the real archive; conservative phase detection by design).
- #37 — replayed backfill can absorb catch-up-captured messages, inflating `sync_state`/`sync_ranges` bookkeeping only (outside the equality contract; matters only if a reprojected DB is then live-collected against).
- #38 / #39 — two order-dependence families in the peer merge when a `min` observation is stamped newer than the newest `full` (identity divergence in the sandwich; `source_raw_id` lineage divergence with ≥1 full). Closing them needs a richness-scoped timestamp benchmark — a follow-up design change.
- Two `media` files (451→449) are genuinely missing from the profile's on-disk store; replay correctly reports them unavailable rather than fabricating bytes.

## Review verdicts

- Round-2 panel: design confirmed sound; both blocking findings resolved in round 3.
- Round-3 adversarial reviewer: initial REJECT (the #39 scoping finding), retry **PASS** — verdict quoted in the final review comment on #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
