### PR TITLE
feat(person-layer): leg 3 — the participants collector (#41)

### DIFF
--- a/src/paperboy/collectors/channel.py
+++ b/src/paperboy/collectors/channel.py
@@ -32,13 +32,16 @@ def _redact_self(user: dict) -> dict:
     return {k: v for k, v in user.items() if k not in _SELF_CREDENTIAL_FIELDS}
 
 
-def _pick_channel(chats: list[dict], channel_id: int) -> dict:
+def pick_channel(chats: list[dict], channel_id: int) -> dict:
     """The channel-typed chat in `chats` whose id is `channel_id`.
 
     Never pick by vector position: a linked discussion megagroup serialises as
     `Channel` too, and Telegram promises no ordering — a group listed first
     would silently misattribute the entire collect (issue #23). The
     authoritative id comes from `ResolvedPeer.peer` / `full_chat.id`.
+
+    Public (Task 8): `participants` needs it too for the linked group's own
+    preflight `ChatFull`.
     """
     for chat in chats:
         # Telethon's to_dict() uses the PascalCase class name ("Channel",
@@ -48,6 +51,9 @@ def _pick_channel(chats: list[dict], channel_id: int) -> dict:
     raise ValueError(
         f"no channel-typed chat with id {channel_id} in the response's chats vector"
     )
+
+
+_pick_channel = pick_channel  # back-compat alias
 
 
 def _resolved_channel_id(resolved: dict) -> int:
@@ -98,7 +104,7 @@ class ChannelCollector:
             resolved.get("_", "ResolvedPeer"), resolved, ctx.tier, {"target": ctx.target.raw},
             observed_at=t_resolved,
         )
-        chan = _pick_channel(resolved.get("chats", []), _resolved_channel_id(resolved))
+        chan = pick_channel(resolved.get("chats", []), _resolved_channel_id(resolved))
         input_channel = {"channel_id": chan["id"], "access_hash": chan["access_hash"]}
 
         full = await ctx.gateway.get_full_channel(input_channel)
@@ -121,7 +127,7 @@ class ChannelCollector:
         # Prefer the richer `chat` object returned alongside getFullChannel
         # (may carry admin_rights/creator not present on the resolve() one).
         full_chats = full.get("chats", [])
-        chan_for_channel = _pick_channel(full_chats, full_chat["id"]) if full_chats else chan
+        chan_for_channel = pick_channel(full_chats, full_chat["id"]) if full_chats else chan
 
         channel_id = chan_for_channel["id"]
         channel_uri_ = upsert_channel(

--- a/src/paperboy/collectors/discussion.py
+++ b/src/paperboy/collectors/discussion.py
@@ -77,7 +77,7 @@ async def join_or_skip(
     return None
 
 
-def linked_group(ctx: CollectContext) -> tuple[int, dict, bool] | str:
+def linked_group(ctx: CollectContext, phase: str = "discussion") -> tuple[int, dict, bool] | str:
     """`(group_id, input_channel, needs_join)`, or a `stopped` reason string.
 
     `needs_join` is True when the group sets `join_to_send` — reading it then
@@ -88,6 +88,14 @@ def linked_group(ctx: CollectContext) -> tuple[int, dict, bool] | str:
     The reasons are deliberately lexically disjoint — no reason contains
     another's distinguishing word — because tests assert on them, and an
     overlapping pair lets a test pass on the wrong branch.
+
+    `phase` names the caller (`self.name`) in the "no access hash known"
+    reason, mirroring `join_or_skip`'s own `phase` parameter and for the same
+    reason: that reason is a `stopped`/warning message the OPERATOR reads, so
+    it must name the phase that is actually running, not hard-code
+    "discussion" for every caller (round-3 review). "no linked discussion
+    group" stays phase-neutral — a channel either has one or it does not,
+    regardless of which phase asked.
 
     Extracted (Task 8) so `participants` can share it.
     """
@@ -107,7 +115,7 @@ def linked_group(ctx: CollectContext) -> tuple[int, dict, bool] | str:
     if peer is None or not peer["access_hash"]:
         # A stored `0` is not a usable hash — it yields CHANNEL_INVALID
         # against live Telegram, a phase error rather than a clean skip.
-        return f"discussion group {group_id}: no access hash known"
+        return f"{phase} group {group_id}: no access hash known"
 
     flags = json.loads(peer["flags_json"]) if peer["flags_json"] else {}
     # Reading is open to anyone *unless* `join_to_send` is set. Honouring it
@@ -142,7 +150,7 @@ class DiscussionCollector:
             ctx.store, ctx.channel_id, ctx.tier
         )
 
-        target = linked_group(ctx)
+        target = linked_group(ctx, self.name)
         if isinstance(target, str):
             return CollectResult(name=self.name, counts=counts, stopped=target)
         group_id, input_channel, needs_join = target
@@ -188,7 +196,7 @@ class DiscussionCollector:
     def _linked_group(self, ctx: CollectContext) -> tuple[int, dict, bool] | str:
         """Delegate to the module-level `linked_group` (shared with
         `participants`, Task 8)."""
-        return linked_group(ctx)
+        return linked_group(ctx, self.name)
 
     def _write_thread_edges(
         self, ctx: CollectContext, group_id: int, counts: dict[str, int]

--- a/src/paperboy/collectors/discussion.py
+++ b/src/paperboy/collectors/discussion.py
@@ -50,11 +50,14 @@ async def join_or_skip(
     is a clean skip, distinguishable from "join_to_send set, --join not given".
 
     Extracted (Task 8) so `participants` can share it: `phase` names the
-    caller (`self.name`) in the `run_events` row and the log line.
+    caller (`self.name`) in the `run_events` row, the log line, AND the
+    returned reason string — a reason is a `stopped`/warning message the
+    OPERATOR reads, so it must name the phase that is actually running, not
+    hard-code "discussion" for every caller.
     """
     if not ctx.settings.allow_join:
         return (
-            f"discussion group {group_id}: join_to_send is set; "
+            f"{phase} group {group_id}: join_to_send is set; "
             "re-run with --join to join and read it"
         )
     try:
@@ -63,7 +66,7 @@ async def join_or_skip(
         ctx.log.warning(
             "%s: --join join of group %s was refused: %s", phase, group_id, exc
         )
-        return f"discussion group {group_id}: --join was given but joining failed"
+        return f"{phase} group {group_id}: --join was given but joining failed"
     record_run_event(
         ctx.store, ctx.channel_id, phase, "join",
         {"group_id": group_id, "method": "channels.joinChannel", "active": True},

--- a/src/paperboy/collectors/discussion.py
+++ b/src/paperboy/collectors/discussion.py
@@ -36,6 +36,85 @@ _COMMENTED_ON = "commented_on"
 _REPLIED_TO = "replied_to"
 
 
+async def join_or_skip(
+    ctx: CollectContext, phase: str, group_id: int, input_channel: dict
+) -> str | None:
+    """Join a `join_to_send` group under `--join`, or return a skip reason.
+
+    Joining is the one WRITE paperboy makes and the single documented
+    exception to read-only (spec §2, issue #20): it happens ONLY under an
+    explicit `--join`, is routed through the budget/guardrail module (so
+    `PEER_FLOOD` is a `HardStop` that ends the run and is deliberately NOT
+    caught here), and is recorded in `run_events` as an active, non-passive
+    act. A refused join (e.g. an approval-gated group -> `INVITE_REQUEST_SENT`)
+    is a clean skip, distinguishable from "join_to_send set, --join not given".
+
+    Extracted (Task 8) so `participants` can share it: `phase` names the
+    caller (`self.name`) in the `run_events` row and the log line.
+    """
+    if not ctx.settings.allow_join:
+        return (
+            f"discussion group {group_id}: join_to_send is set; "
+            "re-run with --join to join and read it"
+        )
+    try:
+        await ctx.gateway.join_channel(input_channel)
+    except SkipAndRecord as exc:
+        ctx.log.warning(
+            "%s: --join join of group %s was refused: %s", phase, group_id, exc
+        )
+        return f"discussion group {group_id}: --join was given but joining failed"
+    record_run_event(
+        ctx.store, ctx.channel_id, phase, "join",
+        {"group_id": group_id, "method": "channels.joinChannel", "active": True},
+    )
+    ctx.log.warning(
+        "%s: JOINED group %s via --join — an active, non-passive act", phase, group_id
+    )
+    return None
+
+
+def linked_group(ctx: CollectContext) -> tuple[int, dict, bool] | str:
+    """`(group_id, input_channel, needs_join)`, or a `stopped` reason string.
+
+    `needs_join` is True when the group sets `join_to_send` — reading it then
+    requires membership, and the caller will join under `--join` or skip.
+    Every failure here is a clean skip, never an exception: a channel with no
+    discussion group, or one whose access hash is unknown, is normal.
+
+    The reasons are deliberately lexically disjoint — no reason contains
+    another's distinguishing word — because tests assert on them, and an
+    overlapping pair lets a test pass on the wrong branch.
+
+    Extracted (Task 8) so `participants` can share it.
+    """
+    row = ctx.store.conn.execute(
+        "SELECT linked_chat_id FROM channels WHERE id=?", (ctx.channel_id,)
+    ).fetchone()
+    group_id = row["linked_chat_id"] if row else None
+    if not group_id:
+        # `0` is as meaningful as NULL here and must not be treated as a
+        # channel id — falsy, not `is None`.
+        return "no linked discussion group"
+
+    peer = ctx.store.conn.execute(
+        "SELECT access_hash, flags_json FROM peers WHERE uri=?",
+        (channel_uri(group_id),),
+    ).fetchone()
+    if peer is None or not peer["access_hash"]:
+        # A stored `0` is not a usable hash — it yields CHANNEL_INVALID
+        # against live Telegram, a phase error rather than a clean skip.
+        return f"discussion group {group_id}: no access hash known"
+
+    flags = json.loads(peer["flags_json"]) if peer["flags_json"] else {}
+    # Reading is open to anyone *unless* `join_to_send` is set. Honouring it
+    # is what keeps collection passive; `--join` (issue #20) is the explicit
+    # escape hatch, applied by `join_or_skip`.
+    needs_join = bool(flags.get("join_to_send"))
+    input_channel = {"channel_id": group_id, "access_hash": peer["access_hash"]}
+    return group_id, input_channel, needs_join
+
+
 class DiscussionCollector:
     name = "discussion"
 
@@ -60,13 +139,13 @@ class DiscussionCollector:
             ctx.store, ctx.channel_id, ctx.tier
         )
 
-        target = self._linked_group(ctx)
+        target = linked_group(ctx)
         if isinstance(target, str):
             return CollectResult(name=self.name, counts=counts, stopped=target)
         group_id, input_channel, needs_join = target
 
         if needs_join:
-            skip = await self._join_or_skip(ctx, group_id, input_channel)
+            skip = await join_or_skip(ctx, self.name, group_id, input_channel)
             if skip is not None:
                 return CollectResult(name=self.name, counts=counts, stopped=skip)
 
@@ -99,74 +178,14 @@ class DiscussionCollector:
     async def _join_or_skip(
         self, ctx: CollectContext, group_id: int, input_channel: dict
     ) -> str | None:
-        """Join a `join_to_send` group under `--join`, or return a skip reason.
-
-        Joining is the one WRITE paperboy makes and the single documented
-        exception to read-only (spec §2, issue #20): it happens ONLY under an
-        explicit `--join`, is routed through the budget/guardrail module (so
-        `PEER_FLOOD` is a `HardStop` that ends the run and is deliberately NOT
-        caught here), and is recorded in `run_events` as an active, non-passive
-        act. A refused join (e.g. an approval-gated group -> `INVITE_REQUEST_SENT`)
-        is a clean skip, distinguishable from "join_to_send set, --join not given".
-        """
-        if not ctx.settings.allow_join:
-            return (
-                f"discussion group {group_id}: join_to_send is set; "
-                "re-run with --join to join and read it"
-            )
-        try:
-            await ctx.gateway.join_channel(input_channel)
-        except SkipAndRecord as exc:
-            ctx.log.warning(
-                "discussion: --join join of group %s was refused: %s", group_id, exc
-            )
-            return f"discussion group {group_id}: --join was given but joining failed"
-        record_run_event(
-            ctx.store, ctx.channel_id, self.name, "join",
-            {"group_id": group_id, "method": "channels.joinChannel", "active": True},
-        )
-        ctx.log.warning(
-            "discussion: JOINED group %s via --join — an active, non-passive act", group_id
-        )
-        return None
+        """Delegate to the module-level `join_or_skip` (shared with
+        `participants`, Task 8)."""
+        return await join_or_skip(ctx, self.name, group_id, input_channel)
 
     def _linked_group(self, ctx: CollectContext) -> tuple[int, dict, bool] | str:
-        """`(group_id, input_channel, needs_join)`, or a `stopped` reason string.
-
-        `needs_join` is True when the group sets `join_to_send` — reading it then
-        requires membership, and `collect` will join under `--join` or skip.
-        Every failure here is a clean skip, never an exception: a channel with no
-        discussion group, or one whose access hash is unknown, is normal.
-
-        The reasons are deliberately lexically disjoint — no reason contains
-        another's distinguishing word — because tests assert on them, and an
-        overlapping pair lets a test pass on the wrong branch.
-        """
-        row = ctx.store.conn.execute(
-            "SELECT linked_chat_id FROM channels WHERE id=?", (ctx.channel_id,)
-        ).fetchone()
-        group_id = row["linked_chat_id"] if row else None
-        if not group_id:
-            # `0` is as meaningful as NULL here and must not be treated as a
-            # channel id — falsy, not `is None`.
-            return "no linked discussion group"
-
-        peer = ctx.store.conn.execute(
-            "SELECT access_hash, flags_json FROM peers WHERE uri=?",
-            (channel_uri(group_id),),
-        ).fetchone()
-        if peer is None or not peer["access_hash"]:
-            # A stored `0` is not a usable hash — it yields CHANNEL_INVALID
-            # against live Telegram, a phase error rather than a clean skip.
-            return f"discussion group {group_id}: no access hash known"
-
-        flags = json.loads(peer["flags_json"]) if peer["flags_json"] else {}
-        # Reading is open to anyone *unless* `join_to_send` is set. Honouring it
-        # is what keeps collection passive; `--join` (issue #20) is the explicit
-        # escape hatch, applied by `_join_or_skip`.
-        needs_join = bool(flags.get("join_to_send"))
-        input_channel = {"channel_id": group_id, "access_hash": peer["access_hash"]}
-        return group_id, input_channel, needs_join
+        """Delegate to the module-level `linked_group` (shared with
+        `participants`, Task 8)."""
+        return linked_group(ctx)
 
     def _write_thread_edges(
         self, ctx: CollectContext, group_id: int, counts: dict[str, int]

--- a/src/paperboy/collectors/participants.py
+++ b/src/paperboy/collectors/participants.py
@@ -1,0 +1,462 @@
+"""The `participants` collector: roster discovery for the person layer
+(spec §6) — within Telegram's hard walls, passive by default.
+
+For a BROADCAST channel a non-admin can enumerate nothing about subscribers
+(research §1.3, settled live: `CHAT_ADMIN_REQUIRED` for every filter), and
+joining buys nothing. That wall is a first-class stored outcome — a
+`RosterWalled` raw record + a `participant_snapshots` accounting row, with
+ZERO enumeration RPC against the channel — never a silent zero. The people
+live in the linked discussion supergroup, whose public roster IS enumerable
+un-joined (spec §13, live probe): `channels.getParticipants(Recent)` is paged
+to the server's depth and `enumerated / true_count` is recorded every run
+(spec §6.3 — 200 is a page size, not a total; the real ceiling is Telegram's
+and a shortfall is labelled, with the `--join` escalation named, §6.4).
+
+Unioned with zero new RPC: join/leave service messages already in the
+captured history (`store.participants.project_join_service_messages`) and
+the `recent_reactions` sample inside stored messages
+(`store.reactions.backfill_recent_reactions`). Bounded RPC vectors (Task 9):
+the `channels.getParticipant` oracle for known users a partial roster
+missed, and `messages.getMessageReactionsList` on reacted group messages.
+
+Guardrails: the per-phase session-age gate (spec §6.1) refuses enumeration
+on a young session unless `--unsafe`; `--join` joins only a group we have
+not joined, through the shared audited `join_or_skip`; admin-only
+sub-methods (boosts, invite importers, admin log) are never attempted.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from paperboy.budget import PhaseStop, SkipAndRecord
+from paperboy.collectors.base import CollectContext, CollectResult
+from paperboy.collectors.channel import pick_channel
+from paperboy.collectors.discussion import join_or_skip, linked_group
+from paperboy.collectors.posture import record_privacy_posture
+from paperboy.doctor import session_age_days
+from paperboy.gateway import FILTER_ADMINS, FILTER_BOTS, FILTER_RECENT
+from paperboy.ids import namespaced_kind
+from paperboy.store.channels import channel_flags, upsert_channel
+from paperboy.store.events import record_run_event
+from paperboy.store.message_peers import backfill_message_referenced_peers
+from paperboy.store.participants import (
+    add_participant_snapshot,
+    add_roster_snapshot,
+    membership_edges,
+    project_join_service_messages,
+    upsert_participant,
+)
+from paperboy.store.peers import upsert_full_peer, upsert_peer
+from paperboy.store.reactions import backfill_recent_reactions
+from paperboy.store.users import add_user_snapshot, target_user_facts, upsert_user
+from paperboy.targets import Target
+
+_PAGE_SIZE = 200  # Telegram's page size, not a total cap (spec §6.3)
+METHOD_GET_PARTICIPANTS = "channels.getParticipants"
+# Admin-only sub-methods: detected via rights and SKIPPED, never attempted (spec §6.5).
+_ADMIN_ONLY_METHODS = (
+    "channels.getAdminLog", "premium.getBoostsList", "messages.getChatInviteImporters",
+    "channels.getParticipants(channelParticipantsKicked/Banned)",
+)
+
+JOIN_SHORTFALL_WARNING = (
+    "participants: enumerated {enumerated} of {total} members of group {group_id}; the full "
+    "roster requires membership — re-run with --join to join and enumerate (an active, "
+    "audited write)"
+)
+
+
+@dataclass
+class _Roster:
+    """One enumerable group: the linked discussion group, or the target itself
+    when it is a supergroup. `stamp`/`source_raw_id` are the ChatFull
+    observation that established the flags — every zero-RPC row derived
+    from this roster is stamped from them, never from "now" (plan D5)."""
+
+    group_id: int
+    input_channel: dict
+    flags: dict
+    true_count: int | None
+    stamp: str
+    source_raw_id: int | None
+    chan: dict | None  # the group's `Channel` object (its `left` flag drives --join)
+
+
+class ParticipantsCollector:
+    name = "participants"
+
+    def applies_to(self, target: Target) -> bool:
+        return target.is_channel_like
+
+    async def collect(self, ctx: CollectContext) -> CollectResult:
+        if ctx.channel_id is None or ctx.input_channel is None:
+            raise PhaseStop(
+                "participants skipped: channel context not established "
+                "(channel phase did not complete)"
+            )
+        counts = {
+            "rosters": 0, "walled": 0, "enumerated": 0, "true_count": 0, "participants": 0,
+            "users": 0, "edges": 0, "oracle": 0, "backfilled_peers": 0, "service_joins": 0,
+            "service_leaves": 0, "reactors": 0, "reaction_lists": 0, "skipped": 0,
+        }
+        chan = ctx.store.conn.execute(
+            "SELECT kind, participants_count, flags_json, last_seen, source_raw_id "
+            "FROM channels WHERE id=?",
+            (ctx.channel_id,),
+        ).fetchone()
+        if chan is None:
+            raise PhaseStop(
+                "participants skipped: no channels row (channel phase did not complete)"
+            )
+        run_stamp: str = chan["last_seen"]
+        target_is_group = chan["kind"] != "broadcast"
+
+        if not target_is_group:
+            # §6.2: the broadcast channel's OWN subscriber roster is never
+            # enumerable — skip IT (recorded, zero RPC), not the collector.
+            self._record_walled(
+                ctx, ctx.channel_id, "broadcast_channel: subscriber roster is never enumerable "
+                "below admin (CHAT_ADMIN_REQUIRED for every filter)",
+                chan["participants_count"], run_stamp, counts,
+            )
+        linked = linked_group(ctx)
+        if isinstance(linked, str):
+            if not target_is_group:
+                # No comment section => no person vector at all (§2): the one
+                # case that is a FULL phase skip.
+                return CollectResult(
+                    name=self.name, counts=counts,
+                    stopped=f"{linked} — no person vector (a broadcast channel's subscribers "
+                            "are never enumerable)",
+                )
+            ctx.log.info("participants: %s", linked)
+
+        # Zero-RPC vectors first — they read only the store, so they run even
+        # when the session gate below refuses enumeration.
+        group_ids = ([ctx.channel_id] if target_is_group else []) + (
+            [] if isinstance(linked, str) else [linked[0]]
+        )
+        for group_id in group_ids:
+            self._zero_rpc_vectors(ctx, group_id, counts)
+
+        # The gate comes BEFORE the first RPC against any group (spec §6.1) —
+        # including the linked group's preflight getFullChannel.
+        gate = await self._session_gate(ctx)
+        if gate is not None:
+            ctx.log.warning(gate)
+            record_run_event(
+                ctx.store, ctx.channel_id, self.name, "warning",
+                {"code": "session_age_gate", "message": gate},
+            )
+            return CollectResult(name=self.name, counts=counts, stopped=gate)
+        # The roster's free `users` vectors carry `userStatus*`, so the account's
+        # own posture is recorded here too (once per run — a no-op if `profiles`
+        # already did it this run; spec §4.3).
+        await record_privacy_posture(ctx, self.name)
+
+        rosters: list[_Roster] = []
+        if target_is_group:
+            rosters.append(_Roster(
+                ctx.channel_id, ctx.input_channel, json.loads(chan["flags_json"] or "{}"),
+                chan["participants_count"], run_stamp, chan["source_raw_id"], None,
+            ))
+        if not isinstance(linked, str):
+            group_id, input_channel, _needs_join = linked
+            roster = await self._preflight_group(ctx, group_id, input_channel, run_stamp, counts)
+            if roster is not None:
+                rosters.append(roster)
+
+        stopped: list[str] = []
+        for roster in rosters:
+            reason = await self._enumerate(ctx, roster, counts)
+            if reason:
+                stopped.append(reason)
+        return CollectResult(name=self.name, counts=counts, stopped="; ".join(stopped) or None)
+
+    # ---- preflight + gate --------------------------------------------------------
+
+    async def _preflight_group(
+        self, ctx: CollectContext, group_id: int, input_channel: dict, run_stamp: str,
+        counts: dict[str, int],
+    ) -> _Roster | None:
+        """§6.1: `can_view_participants` / `participants_hidden` live on the
+        GROUP's channelFull, which no phase has fetched before. Also projects
+        the group into `channels` (+ snapshot) and its vectors into peers."""
+        try:
+            full = await ctx.gateway.get_full_channel(input_channel)
+        except SkipAndRecord as exc:
+            self._record_walled(ctx, group_id, f"preflight: {exc}", None, run_stamp, counts)
+            return None
+        observed_at = ctx.clock.for_payload(full)
+        # A SECOND `ChatFull` in the same pass. `ReplaySource.runs()` treats
+        # `chatfull` rows as opening-cluster markers only for LEGACY (NULL
+        # run_id) rows; every record this collector writes is stamped, so this
+        # never splits a run — keep that invariant if that branch ever changes.
+        raw_id = ctx.store.add_raw(
+            full.get("_", "ChatFull"), full, ctx.tier, {"channel_id": group_id},
+            observed_at=observed_at,
+        )
+        full_chat = full.get("full_chat") or {}
+        if full_chat.get("id") != group_id:
+            ctx.log.warning(
+                "participants: getFullChannel for group %s answered for %s — not enumerating",
+                group_id, full_chat.get("id"),
+            )
+            counts["skipped"] += 1
+            return None
+        chats = full.get("chats") or []
+        try:
+            chan = pick_channel(chats, group_id) if chats else None
+        except ValueError:
+            chan = None
+        if chan is not None:
+            upsert_channel(ctx.store, full_chat, chan, raw_id, observed_at)
+        if not (chan or {}).get("admin_rights") and not (chan or {}).get("creator"):
+            # Spec §6.5: admin-only sub-methods (boosts, invite importers, admin
+            # log, kicked/banned) are detected via rights and SKIPPED, never
+            # attempted — recorded so their absence is a stored decision.
+            record_run_event(
+                ctx.store, ctx.channel_id, self.name, "admin_only_skipped",
+                {"group_id": group_id, "methods": list(_ADMIN_ONLY_METHODS),
+                 "reason": "no admin_rights on the group"},
+            )
+        for obj in chats:
+            upsert_peer(ctx.store, obj, raw_id, observed_at, seen_in_chat=None, seen_in_msg=None)
+        self._project_users_vector(ctx, full, raw_id, observed_at, counts)
+        return _Roster(
+            group_id, input_channel, channel_flags(full_chat, chan or {}),
+            full_chat.get("participants_count"), observed_at, raw_id, chan,
+        )
+
+    async def _session_gate(self, ctx: CollectContext) -> str | None:
+        """Spec §6.1 MUST: no participant sweep on a session younger than
+        `min_session_age_days` without `--unsafe` — enforced per phase here,
+        not only run-level by `doctor`."""
+        if ctx.settings.unsafe:
+            return None
+        try:
+            authorizations = await ctx.gateway.get_authorizations()
+        except SkipAndRecord as exc:
+            return (
+                f"participants: roster enumeration refused — session age unknown ({exc}); "
+                "pass --unsafe to enumerate anyway"
+            )
+        age = session_age_days(authorizations)
+        minimum = ctx.settings.min_session_age_days
+        if age is None or age < minimum:
+            shown = "unknown" if age is None else f"{age:.1f} days"
+            return (
+                f"participants: roster enumeration refused — session age {shown} is below "
+                f"min_session_age_days={minimum}; pass --unsafe to enumerate anyway"
+            )
+        return None
+
+    # ---- zero-RPC vectors -----------------------------------------------------------
+
+    def _zero_rpc_vectors(self, ctx: CollectContext, group_id: int, counts: dict[str, int]) -> None:
+        """Everything derivable from the store alone: #11's message-referenced
+        peers (so forward origins/mentions become oracle candidates too),
+        join/leave service messages, and the `recent_reactions` sample."""
+        counts["backfilled_peers"] += backfill_message_referenced_peers(ctx.store, group_id)
+        service = project_join_service_messages(ctx.store, group_id, ctx.tier)
+        counts["service_joins"] += service["joins"]
+        counts["service_leaves"] += service["leaves"]
+        counts["edges"] += service["edges"]
+        counts["reactors"] += backfill_recent_reactions(ctx.store, group_id, ctx.tier)
+
+    def _record_walled(
+        self, ctx: CollectContext, group_id: int, reason: str, true_count: int | None,
+        observed_at: str, counts: dict[str, int], *, enumerated: int = 0,
+    ) -> None:
+        """A walled roster is a stored observation (§6.2): a synthetic raw
+        record (so a reproject detects and reproduces it) + the accounting
+        row + an audit event. Stamped from the observation that established
+        the wall, never from the wall clock (plan D5)."""
+        payload = {
+            "_": "RosterWalled", "group_id": group_id, "reason": reason,
+            "participants_count": true_count, "enumerated": enumerated,
+        }
+        raw_id = ctx.store.add_raw(
+            "RosterWalled", payload, ctx.tier, {"channel_id": group_id}, observed_at=observed_at
+        )
+        add_roster_snapshot(
+            ctx.store, group_id, observed_at, enumerated=enumerated, true_count=true_count,
+            reason=reason, source_raw_id=raw_id,
+        )
+        record_run_event(
+            ctx.store, ctx.channel_id, self.name, "roster_walled",
+            {"group_id": group_id, "reason": reason, "participants_count": true_count},
+        )
+        counts["walled"] += 1
+
+    # ---- enumeration ----------------------------------------------------------------
+
+    async def _enumerate(
+        self, ctx: CollectContext, roster: _Roster, counts: dict[str, int]
+    ) -> str | None:
+        """Page `Recent` (plus `Admins`/`Bots` once joined), record
+        `enumerated / true_count`, then run the bounded vectors. Returns the
+        §6.4 shortfall warning when the roster came back walled or partial
+        and we are not a member — the phase's `stopped` reason."""
+        group_id = roster.group_id
+        counts["rosters"] += 1
+        joined = await self._maybe_join(ctx, roster)
+        enumerated: set[str] = set()
+        last_stamp, last_raw = roster.stamp, roster.source_raw_id
+        true_count = roster.true_count
+        walled: str | None = None
+        filters = [FILTER_RECENT] + ([FILTER_ADMINS, FILTER_BOTS] if joined else [])
+        for filter_ in filters:
+            try:
+                count, last_stamp, last_raw = await self._page(
+                    ctx, roster, filter_, enumerated, counts, last_stamp, last_raw
+                )
+            except SkipAndRecord as exc:
+                if filter_ is FILTER_RECENT:
+                    walled = str(exc)
+                else:
+                    ctx.log.warning(
+                        "participants: %s skipped for group %s: %s", filter_["_"], group_id, exc
+                    )
+                    counts["skipped"] += 1
+                continue
+            if count is not None and filter_ is FILTER_RECENT:
+                true_count = count  # an Admins/Bots page's `count` is only its own filter's
+        if walled is not None:
+            self._record_walled(
+                ctx, group_id, walled, true_count, last_stamp, counts, enumerated=len(enumerated)
+            )
+        else:
+            add_roster_snapshot(
+                ctx.store, group_id, last_stamp, enumerated=len(enumerated),
+                true_count=true_count, reason=None, source_raw_id=last_raw,
+            )
+        record_run_event(
+            ctx.store, ctx.channel_id, self.name, "roster",
+            {"group_id": group_id, "enumerated": len(enumerated), "true_count": true_count,
+             "walled": walled, "joined": joined},
+        )
+        counts["enumerated"] += len(enumerated)
+        counts["true_count"] += true_count or 0
+
+        partial = walled is not None or (true_count is not None and len(enumerated) < true_count)
+        if partial:
+            await self._oracle(ctx, roster, enumerated, counts)
+        await self._reactions(ctx, roster, counts)
+        if not partial or joined:
+            return None
+        warning = JOIN_SHORTFALL_WARNING.format(
+            enumerated=len(enumerated), total=true_count if true_count is not None else "?",
+            group_id=group_id,
+        )
+        ctx.log.warning(warning)
+        record_run_event(
+            ctx.store, ctx.channel_id, self.name, "warning",
+            {"code": "roster_partial", "group_id": group_id, "enumerated": len(enumerated),
+             "true_count": true_count, "walled": walled, "hint": "--join"},
+        )
+        return warning
+
+    async def _maybe_join(self, ctx: CollectContext, roster: _Roster) -> bool:
+        """Under `--join`, join a group we are not a member of (`Channel.left`
+        true, or membership unknown) through the shared audited path; a
+        refused join falls back to the un-joined branch. Never without the
+        flag (plan D11)."""
+        if not ctx.settings.allow_join:
+            return False
+        if roster.chan is not None and roster.chan.get("left") is False:
+            return True  # already a member: nothing to write
+        skip = await join_or_skip(ctx, self.name, roster.group_id, roster.input_channel)
+        if skip is not None:
+            ctx.log.warning("participants: %s", skip)
+            return False
+        return True
+
+    async def _page(
+        self, ctx: CollectContext, roster: _Roster, filter_: dict, enumerated: set[str],
+        counts: dict[str, int], last_stamp: str, last_raw: int | None,
+    ) -> tuple[int | None, str, int | None]:
+        """Page one filter until the server stops adding members: an empty
+        or short page, or a page that adds nothing new (a capped server
+        repeats itself). Returns `(count, stamp, raw_id)` of the last page."""
+        offset = 0
+        count: int | None = None
+        while True:
+            page = await ctx.gateway.get_participants(
+                roster.input_channel, filter_, offset, _PAGE_SIZE, 0
+            )
+            last_stamp = ctx.clock.for_payload(page)
+            last_raw = ctx.store.add_raw(
+                namespaced_kind("channels", page, "ChannelParticipants"), page, ctx.tier,
+                {"channel_id": roster.group_id, "filter": filter_["_"], "offset": offset},
+                observed_at=last_stamp,
+            )
+            if (page.get("_") or "").lower().endswith("notmodified"):
+                break
+            if page.get("count") is not None:
+                count = page["count"]
+            new = self._project_page(
+                ctx, roster.group_id, page, last_raw, last_stamp, enumerated, counts
+            )
+            got = len(page.get("participants") or [])
+            if got == 0 or new == 0 or got < _PAGE_SIZE:
+                break
+            offset += got
+        return count, last_stamp, last_raw
+
+    def _project_page(
+        self, ctx: CollectContext, group_id: int, page: dict, raw_id: int, stamp: str,
+        enumerated: set[str], counts: dict[str, int],
+    ) -> int:
+        """Spec §6.5 for one page: participants rows + snapshots, member_of/
+        admin_of edges, and the free full `User` objects. Returns how many
+        participants were NEW to this run's enumerated set."""
+        self._project_users_vector(ctx, page, raw_id, stamp, counts)
+        for chat in page.get("chats") or []:
+            upsert_peer(ctx.store, chat, raw_id, stamp, seen_in_chat=None, seen_in_msg=None)
+        new = 0
+        for participant in page.get("participants") or []:
+            facts = upsert_participant(ctx.store, group_id, participant, raw_id, stamp)
+            if facts is None:
+                continue
+            counts["participants"] += 1
+            if facts.uri not in enumerated:
+                enumerated.add(facts.uri)
+                new += 1
+            add_participant_snapshot(ctx.store, group_id, facts, stamp, raw_id)
+            counts["edges"] += membership_edges(
+                ctx.store, group_id, facts, stamp, ctx.tier, raw_id,
+                {"source": "roster", "status": facts.status},
+            )
+        return new
+
+    def _project_users_vector(
+        self, ctx: CollectContext, envelope: dict, raw_id: int, stamp: str, counts: dict[str, int]
+    ) -> None:
+        """Roster RPCs enrich DURING discovery (spec §3): every full `User` in
+        the response's `users` vector lands in `users` (+ snapshot) and
+        `peers` (provenance preserved) for free."""
+        for user in envelope.get("users") or []:
+            if (user.get("_") or "").lower() != "user":
+                continue
+            upsert_full_peer(ctx.store, user, raw_id, stamp)
+            uri = upsert_user(ctx.store, user, raw_id, stamp, ctx.tier)
+            if uri is None:
+                continue
+            counts["users"] += 1
+            add_user_snapshot(
+                ctx.store, uri, stamp, ctx.tier, METHOD_GET_PARTICIPANTS,
+                {"user": target_user_facts(user)}, raw_id,
+            )
+
+    async def _oracle(
+        self, ctx: CollectContext, roster: _Roster, enumerated: set[str], counts: dict[str, int]
+    ) -> None:
+        return None  # Task 9
+
+    async def _reactions(
+        self, ctx: CollectContext, roster: _Roster, counts: dict[str, int]
+    ) -> None:
+        return None  # Task 9

--- a/src/paperboy/collectors/participants.py
+++ b/src/paperboy/collectors/participants.py
@@ -47,6 +47,7 @@ from paperboy.store.participants import (
     add_participant_snapshot,
     add_roster_snapshot,
     membership_edges,
+    participant_row,
     project_join_service_messages,
     upsert_participant,
     write_participant,
@@ -58,14 +59,21 @@ from paperboy.store.reactions import (
     fetched_reaction_lists,
     reacted_message_ids,
 )
+from paperboy.store.sync import is_self
 from paperboy.store.users import add_user_snapshot, target_user_facts, upsert_user
 from paperboy.targets import Target
 
 _PAGE_SIZE = 200  # Telegram's page size, not a total cap (spec §6.3)
 _REACTIONS_PAGE = 100
+# Hard per-message cap on `messages.getMessageReactionsList` pages: unlike
+# `_page` (three independent stop conditions), a `next_offset` that never
+# falls falsy has nothing else bounding it — a server that repeats a
+# non-empty offset would otherwise spin forever, growing the DB unbounded.
+_REACTIONS_MAX_PAGES = 50
 METHOD_GET_PARTICIPANTS = "channels.getParticipants"
 METHOD_GET_PARTICIPANT = "channels.getParticipant"
 METHOD_REACTIONS = "messages.getMessageReactionsList"
+METHOD_GET_FULL_CHANNEL = "channels.getFullChannel"
 # Admin-only sub-methods: detected via rights and SKIPPED, never attempted (spec §6.5).
 _ADMIN_ONLY_METHODS = (
     "channels.getAdminLog", "premium.getBoostsList", "messages.getChatInviteImporters",
@@ -78,17 +86,40 @@ JOIN_SHORTFALL_WARNING = (
     "audited write)"
 )
 
+_REASON_BROADCAST = (
+    "broadcast_channel: subscriber roster is never enumerable below admin "
+    "(CHAT_ADMIN_REQUIRED for every filter)"
+)
+_REASON_HIDDEN = "participants_hidden: roster not viewable"
+
+
+def _roster_wall_reason(flags: dict) -> str | None:
+    """spec §6.1/§6.2: a roster that is structurally never enumerable below
+    admin — a BROADCAST peer's subscriber list (`channelFull.linked_chat_id`
+    is bidirectional: a group's own link points back at its broadcast, not
+    only the broadcast->group direction — research
+    sources/mtproto-channel-messages.md:154), or a group whose owner has
+    hidden participants (`participants_hidden` / `can_view_participants`) —
+    walls with ZERO enumeration RPC. Shared by the target's own roster and
+    the linked group's preflight so both paths agree on one check."""
+    if flags.get("broadcast") and not flags.get("megagroup"):
+        return _REASON_BROADCAST
+    if flags.get("participants_hidden") or flags.get("can_view_participants") is False:
+        return _REASON_HIDDEN
+    return None
+
 
 @dataclass
 class _Roster:
     """One enumerable group: the linked discussion group, or the target itself
-    when it is a supergroup. `stamp`/`source_raw_id` are the ChatFull
-    observation that established the flags — every zero-RPC row derived
-    from this roster is stamped from them, never from "now" (plan D5)."""
+    when it is a supergroup — never a broadcast peer or a hidden roster, both
+    walled by `_roster_wall_reason` before construction. `stamp`/
+    `source_raw_id` are the ChatFull observation that established the flags —
+    every zero-RPC row derived from this roster is stamped from them, never
+    from "now" (plan D5)."""
 
     group_id: int
     input_channel: dict
-    flags: dict
     true_count: int | None
     stamp: str
     source_raw_id: int | None
@@ -128,9 +159,8 @@ class ParticipantsCollector:
             # §6.2: the broadcast channel's OWN subscriber roster is never
             # enumerable — skip IT (recorded, zero RPC), not the collector.
             self._record_walled(
-                ctx, ctx.channel_id, "broadcast_channel: subscriber roster is never enumerable "
-                "below admin (CHAT_ADMIN_REQUIRED for every filter)",
-                chan["participants_count"], run_stamp, counts,
+                ctx, ctx.channel_id, _REASON_BROADCAST, chan["participants_count"], run_stamp,
+                counts,
             )
         linked = linked_group(ctx)
         if isinstance(linked, str):
@@ -145,11 +175,14 @@ class ParticipantsCollector:
             ctx.log.info("participants: %s", linked)
 
         # Zero-RPC vectors first — they read only the store, so they run even
-        # when the session gate below refuses enumeration.
-        group_ids = ([ctx.channel_id] if target_is_group else []) + (
-            [] if isinstance(linked, str) else [linked[0]]
-        )
-        for group_id in group_ids:
+        # when the session gate below refuses enumeration. The TARGET's own
+        # id is swept unconditionally (its posts still carry a free
+        # `recent_reactions` sample even when the target is a broadcast whose
+        # subscriber roster and RPC-based reaction-list vector are both
+        # walled) — only the RPC-based roster/oracle/reaction vectors below
+        # stay GROUP-only.
+        zero_rpc_ids = [ctx.channel_id] + ([] if isinstance(linked, str) else [linked[0]])
+        for group_id in zero_rpc_ids:
             self._zero_rpc_vectors(ctx, group_id, counts)
 
         # The gate comes BEFORE the first RPC against any group (spec §6.1) —
@@ -168,18 +201,45 @@ class ParticipantsCollector:
         await record_privacy_posture(ctx, self.name)
 
         rosters: list[_Roster] = []
-        if target_is_group:
-            rosters.append(_Roster(
-                ctx.channel_id, ctx.input_channel, json.loads(chan["flags_json"] or "{}"),
-                chan["participants_count"], run_stamp, chan["source_raw_id"], None,
-            ))
-        if not isinstance(linked, str):
-            group_id, input_channel, _needs_join = linked
-            roster = await self._preflight_group(ctx, group_id, input_channel, run_stamp, counts)
-            if roster is not None:
-                rosters.append(roster)
-
         stopped: list[str] = []
+        if target_is_group:
+            target_flags = json.loads(chan["flags_json"] or "{}")
+            target_wall = _roster_wall_reason(target_flags)
+            if target_wall is not None:
+                # §6.1/§6.2: a megagroup TARGET can be just as structurally
+                # walled (hidden participants) as a broadcast — recorded with
+                # zero enumeration RPC exactly like the linked group's own
+                # preflight wall, rather than discovering it the expensive
+                # way via a `CHAT_ADMIN_REQUIRED` on the first page.
+                self._record_walled(
+                    ctx, ctx.channel_id, target_wall, chan["participants_count"], run_stamp,
+                    counts,
+                )
+            else:
+                rosters.append(_Roster(
+                    ctx.channel_id, ctx.input_channel,
+                    chan["participants_count"], run_stamp, chan["source_raw_id"], None,
+                ))
+        if not isinstance(linked, str):
+            group_id, input_channel, needs_join = linked
+            proceed = True
+            if needs_join:
+                # `join_to_send` is honoured the same way `discussion` treats
+                # it for the SAME group (its docstring: reading it then
+                # requires membership) — a roster read is not exempt from
+                # that just because it is not a message read.
+                skip = await join_or_skip(ctx, self.name, group_id, input_channel)
+                if skip is not None:
+                    ctx.log.warning("participants: %s", skip)
+                    stopped.append(skip)
+                    proceed = False
+            if proceed:
+                roster = await self._preflight_group(
+                    ctx, group_id, input_channel, run_stamp, counts,
+                )
+                if roster is not None:
+                    rosters.append(roster)
+
         for roster in rosters:
             reason = await self._enumerate(ctx, roster, counts)
             if reason:
@@ -193,8 +253,12 @@ class ParticipantsCollector:
         counts: dict[str, int],
     ) -> _Roster | None:
         """§6.1: `can_view_participants` / `participants_hidden` live on the
-        GROUP's channelFull, which no phase has fetched before. Also projects
-        the group into `channels` (+ snapshot) and its vectors into peers."""
+        GROUP's channelFull, which no phase has fetched before — a hidden
+        roster, or a peer that turns out to be a BROADCAST (`linked_chat_id`
+        is bidirectional: a discussion group's own link points back at its
+        broadcast), walls with zero further RPC via `_roster_wall_reason`.
+        Also projects the group into `channels` (+ snapshot) and its vectors
+        into peers."""
         try:
             full = await ctx.gateway.get_full_channel(input_channel)
         except SkipAndRecord as exc:
@@ -235,10 +299,19 @@ class ParticipantsCollector:
             )
         for obj in chats:
             upsert_peer(ctx.store, obj, raw_id, observed_at, seen_in_chat=None, seen_in_msg=None)
-        self._project_users_vector(ctx, full, raw_id, observed_at, counts)
+        self._project_users_vector(
+            ctx, full, raw_id, observed_at, counts, METHOD_GET_FULL_CHANNEL,
+        )
+        flags = channel_flags(full_chat, chan or {})
+        wall = _roster_wall_reason(flags)
+        if wall is not None:
+            self._record_walled(
+                ctx, group_id, wall, full_chat.get("participants_count"), observed_at, counts,
+            )
+            return None
         return _Roster(
-            group_id, input_channel, channel_flags(full_chat, chan or {}),
-            full_chat.get("participants_count"), observed_at, raw_id, chan,
+            group_id, input_channel, full_chat.get("participants_count"), observed_at, raw_id,
+            chan,
         )
 
     async def _session_gate(self, ctx: CollectContext) -> str | None:
@@ -315,13 +388,14 @@ class ParticipantsCollector:
         counts["rosters"] += 1
         joined = await self._maybe_join(ctx, roster)
         enumerated: set[str] = set()
+        self_seen = False
         last_stamp, last_raw = roster.stamp, roster.source_raw_id
         true_count = roster.true_count
         walled: str | None = None
         filters = [FILTER_RECENT] + ([FILTER_ADMINS, FILTER_BOTS] if joined else [])
         for filter_ in filters:
             try:
-                count, last_stamp, last_raw = await self._page(
+                count, last_stamp, last_raw, page_self_seen = await self._page(
                     ctx, roster, filter_, enumerated, counts, last_stamp, last_raw
                 )
             except SkipAndRecord as exc:
@@ -333,45 +407,61 @@ class ParticipantsCollector:
                     )
                     counts["skipped"] += 1
                 continue
+            self_seen = self_seen or page_self_seen
             if count is not None and filter_ is FILTER_RECENT:
                 true_count = count  # an Admins/Bots page's `count` is only its own filter's
+        # `roster_enumerated`: what THIS run's roster PAGES alone found —
+        # captured now, before the oracle mutates `enumerated` below, and
+        # used for every roster-page-scoped consumer (the walled/snapshot
+        # row, the `roster` event, the shortfall predicate, its warning text
+        # and its event) so all of them agree on one number (round-2 review:
+        # the predicate and the rendered warning previously read the set at
+        # two different points and could disagree). Self is never written to
+        # `participants` (issue #12) so `write_participant` drops it from
+        # `enumerated`, but Telegram's own `true_count` DOES include self
+        # when self is a member — added back in here, or a completely
+        # enumerated roster reports a permanent phantom shortfall of
+        # exactly 1 on every run after any --join.
+        roster_enumerated = len(enumerated) + (1 if self_seen else 0)
         if walled is not None:
             self._record_walled(
-                ctx, group_id, walled, true_count, last_stamp, counts, enumerated=len(enumerated)
+                ctx, group_id, walled, true_count, last_stamp, counts,
+                enumerated=roster_enumerated,
             )
         else:
             add_roster_snapshot(
-                ctx.store, group_id, last_stamp, enumerated=len(enumerated),
+                ctx.store, group_id, last_stamp, enumerated=roster_enumerated,
                 true_count=true_count, reason=None, source_raw_id=last_raw,
             )
         record_run_event(
             ctx.store, ctx.channel_id, self.name, "roster",
-            {"group_id": group_id, "enumerated": len(enumerated), "true_count": true_count,
+            {"group_id": group_id, "enumerated": roster_enumerated, "true_count": true_count,
              "walled": walled, "joined": joined},
         )
         counts["true_count"] += true_count or 0
 
-        partial = walled is not None or (true_count is not None and len(enumerated) < true_count)
+        partial = (
+            walled is not None or (true_count is not None and roster_enumerated < true_count)
+        )
         if partial:
             await self._oracle(ctx, roster, enumerated, counts)
         await self._reactions(ctx, roster, counts)
-        # AFTER the oracle: a positive oracle answer adds the SAME kind of
-        # confirmed-member row (`participants`, `member_of`) as a roster
-        # page, so it must count toward `enumerated` too -- otherwise this
-        # count and the shortfall warning below (which reads the same
-        # mutated `enumerated` set) would disagree about how many members
-        # this run actually confirmed.
+        # A positive oracle answer adds the SAME kind of confirmed-member row
+        # (`participants`, `member_of`) as a roster page, so it counts
+        # toward the RUN's total too — deliberately NOT toward
+        # `roster_enumerated` above, which stays roster-page-only (spec
+        # §6.3: an accounting row for the roster RPC alone).
         counts["enumerated"] += len(enumerated)
         if not partial or joined:
             return None
         warning = JOIN_SHORTFALL_WARNING.format(
-            enumerated=len(enumerated), total=true_count if true_count is not None else "?",
+            enumerated=roster_enumerated, total=true_count if true_count is not None else "?",
             group_id=group_id,
         )
         ctx.log.warning(warning)
         record_run_event(
             ctx.store, ctx.channel_id, self.name, "warning",
-            {"code": "roster_partial", "group_id": group_id, "enumerated": len(enumerated),
+            {"code": "roster_partial", "group_id": group_id, "enumerated": roster_enumerated,
              "true_count": true_count, "walled": walled, "hint": "--join"},
         )
         return warning
@@ -394,12 +484,15 @@ class ParticipantsCollector:
     async def _page(
         self, ctx: CollectContext, roster: _Roster, filter_: dict, enumerated: set[str],
         counts: dict[str, int], last_stamp: str, last_raw: int | None,
-    ) -> tuple[int | None, str, int | None]:
+    ) -> tuple[int | None, str, int | None, bool]:
         """Page one filter until the server stops adding members: an empty
         or short page, or a page that adds nothing new (a capped server
-        repeats itself). Returns `(count, stamp, raw_id)` of the last page."""
+        repeats itself). Returns `(count, stamp, raw_id, self_seen)` — the
+        last page's, except `self_seen`, which is True if ANY page across
+        this filter carried the collecting account as a participant."""
         offset = 0
         count: int | None = None
+        self_seen = False
         while True:
             page = await ctx.gateway.get_participants(
                 roster.input_channel, filter_, offset, _PAGE_SIZE, 0
@@ -414,29 +507,41 @@ class ParticipantsCollector:
                 break
             if page.get("count") is not None:
                 count = page["count"]
-            new = self._project_page(
+            new, page_self_seen = self._project_page(
                 ctx, roster.group_id, page, last_raw, last_stamp, enumerated, counts
             )
+            self_seen = self_seen or page_self_seen
             got = len(page.get("participants") or [])
             if got == 0 or new == 0 or got < _PAGE_SIZE:
                 break
             offset += got
-        return count, last_stamp, last_raw
+        return count, last_stamp, last_raw, self_seen
 
     def _project_page(
         self, ctx: CollectContext, group_id: int, page: dict, raw_id: int, stamp: str,
         enumerated: set[str], counts: dict[str, int],
-    ) -> int:
+    ) -> tuple[int, bool]:
         """Spec §6.5 for one page: participants rows + snapshots, member_of/
-        admin_of edges, and the free full `User` objects. Returns how many
-        participants were NEW to this run's enumerated set."""
-        self._project_users_vector(ctx, page, raw_id, stamp, counts)
+        admin_of edges, and the free full `User` objects. Returns
+        `(new, self_seen)`: how many participants were NEW to this run's
+        `enumerated` set, and whether the collecting account itself appeared
+        as a participant on this page — `write_participant` refuses to store
+        self (issue #12), so that fact would otherwise vanish rather than
+        being reported back to the caller, which needs it to reconcile
+        against Telegram's own `count` (spec-6.4 boundary; round-2 review)."""
+        self._project_users_vector(ctx, page, raw_id, stamp, counts, METHOD_GET_PARTICIPANTS)
         for chat in page.get("chats") or []:
             upsert_peer(ctx.store, chat, raw_id, stamp, seen_in_chat=None, seen_in_msg=None)
         new = 0
+        self_seen = False
         for participant in page.get("participants") or []:
-            facts = upsert_participant(ctx.store, group_id, participant, raw_id, stamp)
+            facts = participant_row(participant)
             if facts is None:
+                continue  # unknown constructor — never guessed at
+            if is_self(ctx.store, facts.uri):
+                self_seen = True
+                continue
+            if write_participant(ctx.store, group_id, facts, raw_id, stamp) is None:
                 continue
             counts["participants"] += 1
             if facts.uri not in enumerated:
@@ -447,14 +552,20 @@ class ParticipantsCollector:
                 ctx.store, group_id, facts, stamp, ctx.tier, raw_id,
                 {"source": "roster", "status": facts.status},
             )
-        return new
+        return new, self_seen
 
     def _project_users_vector(
-        self, ctx: CollectContext, envelope: dict, raw_id: int, stamp: str, counts: dict[str, int]
+        self, ctx: CollectContext, envelope: dict, raw_id: int, stamp: str, counts: dict[str, int],
+        method: str,
     ) -> None:
         """Roster RPCs enrich DURING discovery (spec §3): every full `User` in
         the response's `users` vector lands in `users` (+ snapshot) and
-        `peers` (provenance preserved) for free."""
+        `peers` (provenance preserved) for free. `method` is the RPC that
+        produced `envelope` — `user_snapshots.method` is both provenance and
+        the dedupe partition (`add_user_snapshot` keys on `(uri, method)`),
+        so each of the four call sites (the group preflight, roster pages,
+        the oracle, reaction lists) must pass its own, not share one
+        hard-coded value."""
         for user in envelope.get("users") or []:
             if (user.get("_") or "").lower() != "user":
                 continue
@@ -464,8 +575,7 @@ class ParticipantsCollector:
                 continue
             counts["users"] += 1
             add_user_snapshot(
-                ctx.store, uri, stamp, ctx.tier, METHOD_GET_PARTICIPANTS,
-                {"user": target_user_facts(user)}, raw_id,
+                ctx.store, uri, stamp, ctx.tier, method, {"user": target_user_facts(user)}, raw_id,
             )
 
     async def _oracle(
@@ -494,11 +604,23 @@ class ParticipantsCollector:
             """,
             (group_id, group_id, group_id),
         ).fetchall()
-        candidates = [r["uri"] for r in rows if r["uri"] not in enumerated][:budget]
-        for uri in candidates:
+        # Resolve to an `input_user_ref` and drop the budget onto THAT
+        # filtered list, not the raw uri list: slicing first (as before)
+        # let an unresolvable candidate occupy a budget slot forever — the
+        # same `ORDER BY uri` query re-selects it in the same position every
+        # run, and the oracle never reaches anyone past it.
+        candidates: list[tuple[str, dict]] = []
+        for r in rows:
+            uri = r["uri"]
+            if uri in enumerated:
+                continue
             ref = input_user_ref(ctx.store, uri)
             if ref is None:
                 continue
+            candidates.append((uri, ref))
+            if len(candidates) >= budget:
+                break
+        for uri, ref in candidates:
             try:
                 answer = await ctx.gateway.get_participant(roster.input_channel, ref)
             except SkipAndRecord as exc:
@@ -524,7 +646,7 @@ class ParticipantsCollector:
                 namespaced_kind("channels", answer, "ChannelParticipant"), answer, ctx.tier,
                 {"channel_id": group_id, "user_id": ref["user_id"]}, observed_at=stamp,
             )
-            self._project_users_vector(ctx, answer, raw_id, stamp, counts)
+            self._project_users_vector(ctx, answer, raw_id, stamp, counts, METHOD_GET_PARTICIPANT)
             facts = upsert_participant(
                 ctx.store, group_id, answer.get("participant") or {}, raw_id, stamp
             )
@@ -555,7 +677,7 @@ class ParticipantsCollector:
         candidates = [m for m in reacted_message_ids(ctx.store, group_id) if m not in done][:budget]
         for msg_id in candidates:
             offset: str | None = None
-            while True:
+            for _ in range(_REACTIONS_MAX_PAGES):
                 try:
                     result = await ctx.gateway.get_message_reactions_list(
                         roster.input_channel, msg_id, offset=offset, limit=_REACTIONS_PAGE
@@ -573,14 +695,28 @@ class ParticipantsCollector:
                     observed_at=stamp,
                 )
                 counts["reaction_lists"] += 1
-                self._project_users_vector(ctx, result, raw_id, stamp, counts)
+                self._project_users_vector(ctx, result, raw_id, stamp, counts, METHOD_REACTIONS)
                 for reaction in result.get("reactions") or []:
                     subject = peer_ref_uri(reaction.get("peer_id"))
                     stub = peer_stub(reaction.get("peer_id"))
                     if subject is None or stub is None:
                         continue
+                    # Fill-only provenance, mirroring the zero-RPC vector's
+                    # own rule (store/reactions.py): a reaction is not a
+                    # documented `inputPeerFromMessage` context (research
+                    # §8.7 lists author, forward header and mention), so it
+                    # must never replace stronger provenance a message
+                    # authorship already recorded for this same peer.
+                    known = ctx.store.conn.execute(
+                        "SELECT seen_in_chat, seen_in_msg FROM peers WHERE uri=?", (subject,)
+                    ).fetchone()
+                    known_chat = known["seen_in_chat"] if known is not None else None
+                    known_msg = known["seen_in_msg"] if known is not None else None
+                    fill = known_chat is None or known_msg is None
                     if upsert_peer(
-                        ctx.store, stub, raw_id, stamp, seen_in_chat=group_id, seen_in_msg=msg_id
+                        ctx.store, stub, raw_id, stamp,
+                        seen_in_chat=group_id if fill else known_chat,
+                        seen_in_msg=msg_id if fill else known_msg,
                     ) is None:
                         continue  # the collecting account reacted (#12)
                     if add_edge_once(
@@ -593,3 +729,9 @@ class ParticipantsCollector:
                 offset = result.get("next_offset")
                 if not offset:
                     break
+            else:
+                ctx.log.warning(
+                    "participants: reaction list for group %s message %s exceeded %d pages "
+                    "without ending — stopping this message",
+                    group_id, msg_id, _REACTIONS_MAX_PAGES,
+                )

--- a/src/paperboy/collectors/participants.py
+++ b/src/paperboy/collectors/participants.py
@@ -123,7 +123,11 @@ class _Roster:
     true_count: int | None
     stamp: str
     source_raw_id: int | None
-    chan: dict | None  # the group's `Channel` object (its `left` flag drives --join)
+    # The group's stored boolean flags (`store.channels.channel_flags`): for
+    # the linked group, from this run's preflight `ChatFull`; for a megagroup
+    # TARGET, from the `channel` phase's own row. `left` is what `--join`
+    # reads — `False` means we are already a member and nothing is written.
+    flags: dict
 
 
 class ParticipantsCollector:
@@ -154,6 +158,8 @@ class ParticipantsCollector:
             )
         run_stamp: str = chan["last_seen"]
         target_is_group = chan["kind"] != "broadcast"
+        target_flags: dict = {}
+        target_wall: str | None = None
 
         if not target_is_group:
             # §6.2: the broadcast channel's OWN subscriber roster is never
@@ -162,28 +168,46 @@ class ParticipantsCollector:
                 ctx, ctx.channel_id, _REASON_BROADCAST, chan["participants_count"], run_stamp,
                 counts,
             )
-        linked = linked_group(ctx)
-        if isinstance(linked, str):
-            if not target_is_group:
-                # No comment section => no person vector at all (§2): the one
-                # case that is a FULL phase skip.
-                return CollectResult(
-                    name=self.name, counts=counts,
-                    stopped=f"{linked} — no person vector (a broadcast channel's subscribers "
-                            "are never enumerable)",
+        else:
+            # §6.1: a megagroup TARGET can be just as structurally walled
+            # (hidden participants) as a broadcast peer — evaluated here,
+            # zero-RPC and on the SAME side of the session gate as the
+            # broadcast check above, rather than after it. Both are zero-RPC
+            # facts derived from already-stored flags, so a gate-refused run
+            # must record either one identically — previously the megagroup
+            # check ran only after the gate, so a hidden megagroup target
+            # stored no `RosterWalled` row on a gate-refused run while a
+            # broadcast target did (round-3 review).
+            target_flags = json.loads(chan["flags_json"] or "{}")
+            target_wall = _roster_wall_reason(target_flags)
+            if target_wall is not None:
+                self._record_walled(
+                    ctx, ctx.channel_id, target_wall, chan["participants_count"], run_stamp,
+                    counts,
                 )
-            ctx.log.info("participants: %s", linked)
+        linked = linked_group(ctx, self.name)
 
         # Zero-RPC vectors first — they read only the store, so they run even
-        # when the session gate below refuses enumeration. The TARGET's own
-        # id is swept unconditionally (its posts still carry a free
-        # `recent_reactions` sample even when the target is a broadcast whose
-        # subscriber roster and RPC-based reaction-list vector are both
-        # walled) — only the RPC-based roster/oracle/reaction vectors below
-        # stay GROUP-only.
+        # when the phase stops right below (a broadcast with no linked
+        # discussion group still carries a free `recent_reactions` sample on
+        # its own posts) or when the session gate further down refuses
+        # enumeration. The TARGET's own id is swept unconditionally — only
+        # the RPC-based roster/oracle/reaction vectors stay GROUP-only.
         zero_rpc_ids = [ctx.channel_id] + ([] if isinstance(linked, str) else [linked[0]])
         for group_id in zero_rpc_ids:
             self._zero_rpc_vectors(ctx, group_id, counts)
+
+        if isinstance(linked, str):
+            if not target_is_group:
+                # No comment section => no enumerable roster (§2): the one
+                # case that is a FULL phase skip — but the zero-RPC sweep
+                # above has already run, so the free vectors are not lost.
+                return CollectResult(
+                    name=self.name, counts=counts,
+                    stopped=f"{linked} — no enumerable roster (a broadcast channel's "
+                            "subscribers are never enumerable); zero-RPC vectors still swept",
+                )
+            ctx.log.info("participants: %s", linked)
 
         # The gate comes BEFORE the first RPC against any group (spec §6.1) —
         # including the linked group's preflight getFullChannel.
@@ -202,24 +226,17 @@ class ParticipantsCollector:
 
         rosters: list[_Roster] = []
         stopped: list[str] = []
-        if target_is_group:
-            target_flags = json.loads(chan["flags_json"] or "{}")
-            target_wall = _roster_wall_reason(target_flags)
-            if target_wall is not None:
-                # §6.1/§6.2: a megagroup TARGET can be just as structurally
-                # walled (hidden participants) as a broadcast — recorded with
-                # zero enumeration RPC exactly like the linked group's own
-                # preflight wall, rather than discovering it the expensive
-                # way via a `CHAT_ADMIN_REQUIRED` on the first page.
-                self._record_walled(
-                    ctx, ctx.channel_id, target_wall, chan["participants_count"], run_stamp,
-                    counts,
-                )
-            else:
-                rosters.append(_Roster(
-                    ctx.channel_id, ctx.input_channel,
-                    chan["participants_count"], run_stamp, chan["source_raw_id"], None,
-                ))
+        if target_is_group and target_wall is None:
+            # `target_flags` already carries whatever `left` the `channel`
+            # phase observed — pass it through so `_maybe_join` can see
+            # known membership for the TARGET exactly as it does for the
+            # linked group, instead of re-joining a group we already know
+            # we are in on every run (round-3 review). The wall itself (if
+            # any) was already recorded above, before the session gate.
+            rosters.append(_Roster(
+                ctx.channel_id, ctx.input_channel,
+                chan["participants_count"], run_stamp, chan["source_raw_id"], target_flags,
+            ))
         if not isinstance(linked, str):
             group_id, input_channel, needs_join = linked
             proceed = True
@@ -240,8 +257,19 @@ class ParticipantsCollector:
                 if roster is not None:
                     rosters.append(roster)
 
+        # `participant_oracle_budget`/`participant_reactions_budget` are
+        # documented as per-RUN caps (config.py, plan D8), not per-roster —
+        # a target with a linked group produces TWO rosters, so a budget read
+        # fresh inside `_oracle`/`_reactions` for each one could spend up to
+        # 2x the documented ceiling. One dict, decremented as each roster
+        # spends it, keeps the whole run under the documented cap
+        # (round-3 review).
+        budgets = {
+            "oracle": ctx.settings.participant_oracle_budget,
+            "reactions": ctx.settings.participant_reactions_budget,
+        }
         for roster in rosters:
-            reason = await self._enumerate(ctx, roster, counts)
+            reason = await self._enumerate(ctx, roster, counts, budgets)
             if reason:
                 stopped.append(reason)
         return CollectResult(name=self.name, counts=counts, stopped="; ".join(stopped) or None)
@@ -302,7 +330,22 @@ class ParticipantsCollector:
         self._project_users_vector(
             ctx, full, raw_id, observed_at, counts, METHOD_GET_FULL_CHANNEL,
         )
-        flags = channel_flags(full_chat, chan or {})
+        if chan is None:
+            # `broadcast`/`megagroup` live on the `Channel` object, not on
+            # `ChannelFull` — with no Channel to read, `_roster_wall_reason`
+            # cannot see them, so falling through with an incomplete flag set
+            # (the old `chan or {}`) could enumerate a BROADCAST it just
+            # never recognised as one. That breaks this module's headline
+            # zero-enumeration-RPC guarantee, so treat it as an audited
+            # preflight failure instead — the same way an unreadable
+            # preflight is recorded above — rather than a silent fall-through
+            # (round-3 review).
+            self._record_walled(
+                ctx, group_id, "preflight: no Channel object in the chats vector",
+                full_chat.get("participants_count"), observed_at, counts,
+            )
+            return None
+        flags = channel_flags(full_chat, chan)
         wall = _roster_wall_reason(flags)
         if wall is not None:
             self._record_walled(
@@ -311,7 +354,7 @@ class ParticipantsCollector:
             return None
         return _Roster(
             group_id, input_channel, full_chat.get("participants_count"), observed_at, raw_id,
-            chan,
+            flags,
         )
 
     async def _session_gate(self, ctx: CollectContext) -> str | None:
@@ -378,12 +421,14 @@ class ParticipantsCollector:
     # ---- enumeration ----------------------------------------------------------------
 
     async def _enumerate(
-        self, ctx: CollectContext, roster: _Roster, counts: dict[str, int]
+        self, ctx: CollectContext, roster: _Roster, counts: dict[str, int], budgets: dict[str, int]
     ) -> str | None:
         """Page `Recent` (plus `Admins`/`Bots` once joined), record
         `enumerated / true_count`, then run the bounded vectors. Returns the
         §6.4 shortfall warning when the roster came back walled or partial
-        and we are not a member — the phase's `stopped` reason."""
+        and we are not a member — the phase's `stopped` reason. `budgets` is
+        the RUN-level oracle/reactions spend, shared and decremented across
+        every roster `_enumerate` is called for."""
         group_id = roster.group_id
         counts["rosters"] += 1
         joined = await self._maybe_join(ctx, roster)
@@ -444,8 +489,8 @@ class ParticipantsCollector:
             walled is not None or (true_count is not None and roster_enumerated < true_count)
         )
         if partial:
-            await self._oracle(ctx, roster, enumerated, counts)
-        await self._reactions(ctx, roster, counts)
+            await self._oracle(ctx, roster, enumerated, counts, budgets)
+        await self._reactions(ctx, roster, counts, budgets)
         # A positive oracle answer adds the SAME kind of confirmed-member row
         # (`participants`, `member_of`) as a roster page, so it counts
         # toward the RUN's total too — deliberately NOT toward
@@ -473,8 +518,8 @@ class ParticipantsCollector:
         flag (plan D11)."""
         if not ctx.settings.allow_join:
             return False
-        if roster.chan is not None and roster.chan.get("left") is False:
-            return True  # already a member: nothing to write
+        if roster.flags.get("left") is False:
+            return True  # already a member (per the stored flags): nothing to write
         skip = await join_or_skip(ctx, self.name, roster.group_id, roster.input_channel)
         if skip is not None:
             ctx.log.warning("participants: %s", skip)
@@ -579,15 +624,18 @@ class ParticipantsCollector:
             )
 
     async def _oracle(
-        self, ctx: CollectContext, roster: _Roster, enumerated: set[str], counts: dict[str, int]
+        self, ctx: CollectContext, roster: _Roster, enumerated: set[str], counts: dict[str, int],
+        budgets: dict[str, int],
     ) -> None:
         """`channels.getParticipant` for users REFERENCED in the group (message
         authors, provenance) that a partial/walled roster did not cover and
         that have no answer yet — bounded by `participant_oracle_budget`
-        (plan D9), never one call per known commenter. Confirmed un-joined /
-        non-admin on the group (spec §13); a `USER_NOT_PARTICIPANT` answer is a
-        definitive negative and is stored as such."""
-        budget = ctx.settings.participant_oracle_budget
+        (plan D9), never one call per known commenter, and shared across every
+        roster in `budgets["oracle"]` so a target+linked-group run cannot
+        spend the RUN-level cap twice over (round-3 review). Confirmed
+        un-joined / non-admin on the group (spec §13); a `USER_NOT_PARTICIPANT`
+        answer is a definitive negative and is stored as such."""
+        budget = budgets["oracle"]
         if budget <= 0:
             return
         group_id = roster.group_id
@@ -621,6 +669,7 @@ class ParticipantsCollector:
             if len(candidates) >= budget:
                 break
         for uri, ref in candidates:
+            budgets["oracle"] -= 1
             try:
                 answer = await ctx.gateway.get_participant(roster.input_channel, ref)
             except SkipAndRecord as exc:
@@ -661,21 +710,25 @@ class ParticipantsCollector:
             )
 
     async def _reactions(
-        self, ctx: CollectContext, roster: _Roster, counts: dict[str, int]
+        self, ctx: CollectContext, roster: _Roster, counts: dict[str, int], budgets: dict[str, int]
     ) -> None:
         """`messages.getMessageReactionsList` on reacted GROUP messages —
         newest first, bounded by `participant_reactions_budget`, resumable
         (the done-set is derived from the raw log). Reactors get a
         `reacted_to` edge, a `users` row (the response's `users` vector) and
         a `peers` row with the message as provenance. The first wall
-        (`BROADCAST_FORBIDDEN` / `CHAT_ADMIN_REQUIRED`) ends the vector."""
-        budget = ctx.settings.participant_reactions_budget
+        (`BROADCAST_FORBIDDEN` / `CHAT_ADMIN_REQUIRED`) ends the vector.
+        Shared across every roster in `budgets["reactions"]` so a
+        target+linked-group run cannot spend the RUN-level cap twice over
+        (round-3 review)."""
+        budget = budgets["reactions"]
         if budget <= 0:
             return
         group_id = roster.group_id
         done = fetched_reaction_lists(ctx.store, group_id)
         candidates = [m for m in reacted_message_ids(ctx.store, group_id) if m not in done][:budget]
         for msg_id in candidates:
+            budgets["reactions"] -= 1
             offset: str | None = None
             for _ in range(_REACTIONS_MAX_PAGES):
                 try:
@@ -730,8 +783,21 @@ class ParticipantsCollector:
                 if not offset:
                     break
             else:
+                # A truncated reactor list is a partial observation, exactly
+                # the case `add_roster_snapshot` exists to make un-silent for
+                # rosters — record it the same way here, and count it as a
+                # skip, or the shortfall is invisible in the store AND (via
+                # `fetched_reaction_lists`, keyed on message id alone)
+                # permanently un-revisited on every future run (round-3
+                # review).
                 ctx.log.warning(
                     "participants: reaction list for group %s message %s exceeded %d pages "
                     "without ending — stopping this message",
                     group_id, msg_id, _REACTIONS_MAX_PAGES,
                 )
+                record_run_event(
+                    ctx.store, ctx.channel_id, self.name, "warning",
+                    {"code": "reaction_list_truncated", "group_id": group_id, "msg_id": msg_id,
+                     "pages": _REACTIONS_MAX_PAGES},
+                )
+                counts["skipped"] += 1

--- a/src/paperboy/collectors/participants.py
+++ b/src/paperboy/collectors/participants.py
@@ -349,13 +349,19 @@ class ParticipantsCollector:
             {"group_id": group_id, "enumerated": len(enumerated), "true_count": true_count,
              "walled": walled, "joined": joined},
         )
-        counts["enumerated"] += len(enumerated)
         counts["true_count"] += true_count or 0
 
         partial = walled is not None or (true_count is not None and len(enumerated) < true_count)
         if partial:
             await self._oracle(ctx, roster, enumerated, counts)
         await self._reactions(ctx, roster, counts)
+        # AFTER the oracle: a positive oracle answer adds the SAME kind of
+        # confirmed-member row (`participants`, `member_of`) as a roster
+        # page, so it must count toward `enumerated` too -- otherwise this
+        # count and the shortfall warning below (which reads the same
+        # mutated `enumerated` set) would disagree about how many members
+        # this run actually confirmed.
+        counts["enumerated"] += len(enumerated)
         if not partial or joined:
             return None
         warning = JOIN_SHORTFALL_WARNING.format(

--- a/src/paperboy/collectors/participants.py
+++ b/src/paperboy/collectors/participants.py
@@ -37,24 +37,35 @@ from paperboy.collectors.discussion import join_or_skip, linked_group
 from paperboy.collectors.posture import record_privacy_posture
 from paperboy.doctor import session_age_days
 from paperboy.gateway import FILTER_ADMINS, FILTER_BOTS, FILTER_RECENT
-from paperboy.ids import namespaced_kind
+from paperboy.ids import iso_or_none, msg_uri, namespaced_kind, peer_ref_uri, peer_stub
 from paperboy.store.channels import channel_flags, upsert_channel
+from paperboy.store.edges import add_edge_once
 from paperboy.store.events import record_run_event
 from paperboy.store.message_peers import backfill_message_referenced_peers
 from paperboy.store.participants import (
+    ParticipantFacts,
     add_participant_snapshot,
     add_roster_snapshot,
     membership_edges,
     project_join_service_messages,
     upsert_participant,
+    write_participant,
 )
-from paperboy.store.peers import upsert_full_peer, upsert_peer
-from paperboy.store.reactions import backfill_recent_reactions
+from paperboy.store.peers import input_user_ref, upsert_full_peer, upsert_peer
+from paperboy.store.reactions import (
+    REACTED_TO,
+    backfill_recent_reactions,
+    fetched_reaction_lists,
+    reacted_message_ids,
+)
 from paperboy.store.users import add_user_snapshot, target_user_facts, upsert_user
 from paperboy.targets import Target
 
 _PAGE_SIZE = 200  # Telegram's page size, not a total cap (spec §6.3)
+_REACTIONS_PAGE = 100
 METHOD_GET_PARTICIPANTS = "channels.getParticipants"
+METHOD_GET_PARTICIPANT = "channels.getParticipant"
+METHOD_REACTIONS = "messages.getMessageReactionsList"
 # Admin-only sub-methods: detected via rights and SKIPPED, never attempted (spec §6.5).
 _ADMIN_ONLY_METHODS = (
     "channels.getAdminLog", "premium.getBoostsList", "messages.getChatInviteImporters",
@@ -454,9 +465,125 @@ class ParticipantsCollector:
     async def _oracle(
         self, ctx: CollectContext, roster: _Roster, enumerated: set[str], counts: dict[str, int]
     ) -> None:
-        return None  # Task 9
+        """`channels.getParticipant` for users REFERENCED in the group (message
+        authors, provenance) that a partial/walled roster did not cover and
+        that have no answer yet — bounded by `participant_oracle_budget`
+        (plan D9), never one call per known commenter. Confirmed un-joined /
+        non-admin on the group (spec §13); a `USER_NOT_PARTICIPANT` answer is a
+        definitive negative and is stored as such."""
+        budget = ctx.settings.participant_oracle_budget
+        if budget <= 0:
+            return
+        group_id = roster.group_id
+        rows = ctx.store.conn.execute(
+            """
+            SELECT DISTINCT uri FROM (
+                SELECT from_uri AS uri FROM messages
+                WHERE channel_id = ? AND from_uri LIKE 'tg:user:%'
+                UNION
+                SELECT uri FROM peers WHERE kind = 'user' AND seen_in_chat = ?
+            )
+            WHERE uri NOT IN (SELECT uri FROM participants WHERE group_id = ?)
+            ORDER BY uri
+            """,
+            (group_id, group_id, group_id),
+        ).fetchall()
+        candidates = [r["uri"] for r in rows if r["uri"] not in enumerated][:budget]
+        for uri in candidates:
+            ref = input_user_ref(ctx.store, uri)
+            if ref is None:
+                continue
+            try:
+                answer = await ctx.gateway.get_participant(roster.input_channel, ref)
+            except SkipAndRecord as exc:
+                # CHAT_ADMIN_REQUIRED here is the wall itself, not a per-user
+                # condition — stop asking this group.
+                ctx.log.warning("participants: oracle walled on group %s: %s", group_id, exc)
+                counts["skipped"] += 1
+                return
+            counts["oracle"] += 1
+            if answer is None:
+                payload = {"_": "UserNotParticipant", "user_id": ref["user_id"]}
+                stamp = ctx.clock.for_payload(payload)
+                raw_id = ctx.store.add_raw(
+                    "UserNotParticipant", payload, ctx.tier,
+                    {"channel_id": group_id, "user_id": ref["user_id"]}, observed_at=stamp,
+                )
+                facts = ParticipantFacts(uri, "left", None, None, None, None)
+                if write_participant(ctx.store, group_id, facts, raw_id, stamp):
+                    add_participant_snapshot(ctx.store, group_id, facts, stamp, raw_id)
+                continue
+            stamp = ctx.clock.for_payload(answer)
+            raw_id = ctx.store.add_raw(
+                namespaced_kind("channels", answer, "ChannelParticipant"), answer, ctx.tier,
+                {"channel_id": group_id, "user_id": ref["user_id"]}, observed_at=stamp,
+            )
+            self._project_users_vector(ctx, answer, raw_id, stamp, counts)
+            facts = upsert_participant(
+                ctx.store, group_id, answer.get("participant") or {}, raw_id, stamp
+            )
+            if facts is None:
+                continue
+            counts["participants"] += 1
+            enumerated.add(facts.uri)
+            add_participant_snapshot(ctx.store, group_id, facts, stamp, raw_id)
+            counts["edges"] += membership_edges(
+                ctx.store, group_id, facts, stamp, ctx.tier, raw_id,
+                {"source": "oracle", "status": facts.status},
+            )
 
     async def _reactions(
         self, ctx: CollectContext, roster: _Roster, counts: dict[str, int]
     ) -> None:
-        return None  # Task 9
+        """`messages.getMessageReactionsList` on reacted GROUP messages —
+        newest first, bounded by `participant_reactions_budget`, resumable
+        (the done-set is derived from the raw log). Reactors get a
+        `reacted_to` edge, a `users` row (the response's `users` vector) and
+        a `peers` row with the message as provenance. The first wall
+        (`BROADCAST_FORBIDDEN` / `CHAT_ADMIN_REQUIRED`) ends the vector."""
+        budget = ctx.settings.participant_reactions_budget
+        if budget <= 0:
+            return
+        group_id = roster.group_id
+        done = fetched_reaction_lists(ctx.store, group_id)
+        candidates = [m for m in reacted_message_ids(ctx.store, group_id) if m not in done][:budget]
+        for msg_id in candidates:
+            offset: str | None = None
+            while True:
+                try:
+                    result = await ctx.gateway.get_message_reactions_list(
+                        roster.input_channel, msg_id, offset=offset, limit=_REACTIONS_PAGE
+                    )
+                except SkipAndRecord as exc:
+                    ctx.log.warning(
+                        "participants: reaction lists skipped for group %s: %s", group_id, exc
+                    )
+                    counts["skipped"] += 1
+                    return
+                stamp = ctx.clock.for_payload(result)
+                raw_id = ctx.store.add_raw(
+                    namespaced_kind("messages", result, "MessageReactionsList"), result, ctx.tier,
+                    {"channel_id": group_id, "msg_id": msg_id, "offset": offset or ""},
+                    observed_at=stamp,
+                )
+                counts["reaction_lists"] += 1
+                self._project_users_vector(ctx, result, raw_id, stamp, counts)
+                for reaction in result.get("reactions") or []:
+                    subject = peer_ref_uri(reaction.get("peer_id"))
+                    stub = peer_stub(reaction.get("peer_id"))
+                    if subject is None or stub is None:
+                        continue
+                    if upsert_peer(
+                        ctx.store, stub, raw_id, stamp, seen_in_chat=group_id, seen_in_msg=msg_id
+                    ) is None:
+                        continue  # the collecting account reacted (#12)
+                    if add_edge_once(
+                        ctx.store, subject, REACTED_TO, msg_uri(group_id, msg_id), stamp, ctx.tier,
+                        raw_id,
+                        {"source": "reactions_list", "reaction": reaction.get("reaction"),
+                         "date": iso_or_none(reaction.get("date"))},
+                    ):
+                        counts["edges"] += 1
+                offset = result.get("next_offset")
+                if not offset:
+                    break

--- a/src/paperboy/collectors/participants.py
+++ b/src/paperboy/collectors/participants.py
@@ -37,7 +37,7 @@ from paperboy.collectors.discussion import join_or_skip, linked_group
 from paperboy.collectors.posture import record_privacy_posture
 from paperboy.doctor import session_age_days
 from paperboy.gateway import FILTER_ADMINS, FILTER_BOTS, FILTER_RECENT
-from paperboy.ids import iso_or_none, msg_uri, namespaced_kind, peer_ref_uri, peer_stub
+from paperboy.ids import channel_uri, iso_or_none, msg_uri, namespaced_kind, peer_ref_uri, peer_stub
 from paperboy.store.channels import channel_flags, upsert_channel
 from paperboy.store.edges import add_edge_once
 from paperboy.store.events import record_run_event
@@ -58,6 +58,7 @@ from paperboy.store.reactions import (
     backfill_recent_reactions,
     fetched_reaction_lists,
     reacted_message_ids,
+    reaction_resume_offsets,
 )
 from paperboy.store.sync import is_self
 from paperboy.store.users import add_user_snapshot, target_user_facts, upsert_user
@@ -93,19 +94,25 @@ _REASON_BROADCAST = (
 _REASON_HIDDEN = "participants_hidden: roster not viewable"
 
 
-def _roster_wall_reason(flags: dict) -> str | None:
-    """spec §6.1/§6.2: a roster that is structurally never enumerable below
-    admin — a BROADCAST peer's subscriber list (`channelFull.linked_chat_id`
-    is bidirectional: a group's own link points back at its broadcast, not
-    only the broadcast->group direction — research
-    sources/mtproto-channel-messages.md:154), or a group whose owner has
-    hidden participants (`participants_hidden` / `can_view_participants`) —
-    walls with ZERO enumeration RPC. Shared by the target's own roster and
-    the linked group's preflight so both paths agree on one check."""
+def _roster_wall_reason(flags: dict) -> tuple[str, bool] | None:
+    """spec §6.1/§6.2: a roster whose BULK enumeration is walled below admin,
+    as `(reason, terminal)`. `terminal=True` for a BROADCAST peer's
+    subscriber list (`channelFull.linked_chat_id` is bidirectional: a group's
+    own link points back at its broadcast — research
+    sources/mtproto-channel-messages.md:154): the per-user oracle is
+    `CHAT_ADMIN_REQUIRED` there too (spec §13), so there is nothing left to
+    do and no `_Roster` is built. `terminal=False` for a group whose owner
+    hid participants (`participants_hidden` / `can_view_participants` false):
+    ONLY the bulk `getParticipants` sweep is walled — the `getParticipant`
+    oracle and the reaction-list vector are exactly the designated fallback
+    for a hidden-member group (spec §5/§6.2, plan D9, research §1.8), so a
+    `_Roster` IS built (carrying `bulk_walled`) and `_enumerate` runs those
+    vectors without paging. Shared by the target's own roster and the linked
+    group's preflight so both paths agree on one check."""
     if flags.get("broadcast") and not flags.get("megagroup"):
-        return _REASON_BROADCAST
+        return (_REASON_BROADCAST, True)
     if flags.get("participants_hidden") or flags.get("can_view_participants") is False:
-        return _REASON_HIDDEN
+        return (_REASON_HIDDEN, False)
     return None
 
 
@@ -128,6 +135,12 @@ class _Roster:
     # TARGET, from the `channel` phase's own row. `left` is what `--join`
     # reads — `False` means we are already a member and nothing is written.
     flags: dict
+    # Set once `collect` has already joined this group this run (the
+    # `join_to_send` branch): `_maybe_join` must not join it a SECOND time.
+    prejoined: bool = False
+    # The bulk `getParticipants` wall reason for a hidden-member group, if
+    # any: `_enumerate` skips paging and runs the oracle/reaction fallback.
+    bulk_walled: str | None = None
 
 
 class ParticipantsCollector:
@@ -159,7 +172,7 @@ class ParticipantsCollector:
         run_stamp: str = chan["last_seen"]
         target_is_group = chan["kind"] != "broadcast"
         target_flags: dict = {}
-        target_wall: str | None = None
+        target_wall: tuple[str, bool] | None = None
 
         if not target_is_group:
             # §6.2: the broadcast channel's OWN subscriber roster is never
@@ -182,7 +195,7 @@ class ParticipantsCollector:
             target_wall = _roster_wall_reason(target_flags)
             if target_wall is not None:
                 self._record_walled(
-                    ctx, ctx.channel_id, target_wall, chan["participants_count"], run_stamp,
+                    ctx, ctx.channel_id, target_wall[0], chan["participants_count"], run_stamp,
                     counts,
                 )
         linked = linked_group(ctx, self.name)
@@ -231,28 +244,57 @@ class ParticipantsCollector:
             # phase observed — pass it through so `_maybe_join` can see
             # known membership for the TARGET exactly as it does for the
             # linked group, instead of re-joining a group we already know
-            # we are in on every run (round-3 review). The wall itself (if
-            # any) was already recorded above, before the session gate.
+            # we are in on every run (round-3 review).
             rosters.append(_Roster(
                 ctx.channel_id, ctx.input_channel,
                 chan["participants_count"], run_stamp, chan["source_raw_id"], target_flags,
             ))
+        elif target_is_group and target_wall is not None and not target_wall[1]:
+            # A HIDDEN megagroup target: bulk enumeration is walled (recorded
+            # above, before the gate) but the oracle + reaction-list vectors
+            # are the designated fallback — build a roster so `_enumerate`
+            # runs them without paging (round-4 review).
+            rosters.append(_Roster(
+                ctx.channel_id, ctx.input_channel,
+                chan["participants_count"], run_stamp, chan["source_raw_id"], target_flags,
+                bulk_walled=target_wall[0],
+            ))
         if not isinstance(linked, str):
             group_id, input_channel, needs_join = linked
             proceed = True
+            prejoined = False
             if needs_join:
                 # `join_to_send` is honoured the same way `discussion` treats
-                # it for the SAME group (its docstring: reading it then
-                # requires membership) — a roster read is not exempt from
-                # that just because it is not a message read.
-                skip = await join_or_skip(ctx, self.name, group_id, input_channel)
-                if skip is not None:
-                    ctx.log.warning("participants: %s", skip)
-                    stopped.append(skip)
-                    proceed = False
+                # it (reading it then requires membership) — but ONLY when we
+                # are not already a member and the peer is a group, not a
+                # broadcast. This is the same membership check `_maybe_join`
+                # makes for the roster path; without it, this second join
+                # site re-joined an already-member group with an active,
+                # audited `channels.joinChannel` on every run (round-4
+                # review). Membership is read from `channels.flags_json`,
+                # written by a PRIOR run's preflight — unknown on the first
+                # run, so we join once, then never again.
+                stored = self._stored_group_flags(ctx, group_id)
+                if stored.get("broadcast") and not stored.get("megagroup"):
+                    # A `join_to_send` flag on a BROADCAST linked peer: never
+                    # join it — the preflight below walls it (terminal) with
+                    # zero further RPC.
+                    ctx.log.info(
+                        "participants: linked peer %s is a broadcast — not joining", group_id
+                    )
+                elif self._already_member(ctx, group_id):
+                    prejoined = True  # a prior run's preflight recorded left=false
+                else:
+                    skip = await join_or_skip(ctx, self.name, group_id, input_channel)
+                    if skip is not None:
+                        ctx.log.warning("participants: %s", skip)
+                        stopped.append(skip)
+                        proceed = False
+                    else:
+                        prejoined = True
             if proceed:
                 roster = await self._preflight_group(
-                    ctx, group_id, input_channel, run_stamp, counts,
+                    ctx, group_id, input_channel, run_stamp, counts, prejoined=prejoined,
                 )
                 if roster is not None:
                     rosters.append(roster)
@@ -276,9 +318,31 @@ class ParticipantsCollector:
 
     # ---- preflight + gate --------------------------------------------------------
 
+    @staticmethod
+    def _stored_group_flags(ctx: CollectContext, group_id: int) -> dict:
+        """The linked group's stored boolean flags from `peers` (the `channel`
+        phase's row) — used BEFORE preflight to refuse joining a broadcast
+        peer. `left` is not among `peers._FLAG_KEYS`, so membership is read
+        from `channels` (`_already_member`), not here."""
+        row = ctx.store.conn.execute(
+            "SELECT flags_json FROM peers WHERE uri=?", (channel_uri(group_id),)
+        ).fetchone()
+        return json.loads(row["flags_json"]) if row and row["flags_json"] else {}
+
+    @staticmethod
+    def _already_member(ctx: CollectContext, group_id: int) -> bool:
+        """True when a PRIOR run's preflight recorded this group in `channels`
+        with `left=false`. Unknown (absent) on the first run, so the first
+        `--join`/`join_to_send` join happens once and no run repeats it."""
+        row = ctx.store.conn.execute(
+            "SELECT flags_json FROM channels WHERE id=?", (group_id,)
+        ).fetchone()
+        flags = json.loads(row["flags_json"]) if row and row["flags_json"] else {}
+        return flags.get("left") is False
+
     async def _preflight_group(
         self, ctx: CollectContext, group_id: int, input_channel: dict, run_stamp: str,
-        counts: dict[str, int],
+        counts: dict[str, int], *, prejoined: bool = False,
     ) -> _Roster | None:
         """§6.1: `can_view_participants` / `participants_hidden` live on the
         GROUP's channelFull, which no phase has fetched before — a hidden
@@ -308,6 +372,10 @@ class ParticipantsCollector:
                 group_id, full_chat.get("id"),
             )
             counts["skipped"] += 1
+            record_run_event(
+                ctx.store, ctx.channel_id, self.name, "preflight_mismatch",
+                {"group_id": group_id, "answered_id": full_chat.get("id")},
+            )
             return None
         chats = full.get("chats") or []
         try:
@@ -348,13 +416,21 @@ class ParticipantsCollector:
         flags = channel_flags(full_chat, chan)
         wall = _roster_wall_reason(flags)
         if wall is not None:
+            reason, terminal = wall
             self._record_walled(
-                ctx, group_id, wall, full_chat.get("participants_count"), observed_at, counts,
+                ctx, group_id, reason, full_chat.get("participants_count"), observed_at, counts,
             )
-            return None
+            if terminal:
+                return None  # a broadcast peer: the oracle is walled too
+            # A hidden-member group: bulk paging is walled, but the oracle +
+            # reaction-list fallback still run — carry the wall to `_enumerate`.
+            return _Roster(
+                group_id, input_channel, full_chat.get("participants_count"), observed_at,
+                raw_id, flags, prejoined=prejoined, bulk_walled=reason,
+            )
         return _Roster(
             group_id, input_channel, full_chat.get("participants_count"), observed_at, raw_id,
-            flags,
+            flags, prejoined=prejoined,
         )
 
     async def _session_gate(self, ctx: CollectContext) -> str | None:
@@ -431,6 +507,16 @@ class ParticipantsCollector:
         every roster `_enumerate` is called for."""
         group_id = roster.group_id
         counts["rosters"] += 1
+        if roster.bulk_walled is not None:
+            # Bulk enumeration is walled (participants_hidden) and already
+            # recorded at preflight/collect — do NOT re-record it. The oracle
+            # and the reaction-list vector are the designated fallback for a
+            # hidden-member group (spec §5/§6.2, plan D9): run them, page
+            # nothing. `--join` cannot un-hide members for a non-admin, so
+            # there is no shortfall escalation to emit.
+            await self._oracle(ctx, roster, set(), counts, budgets)
+            await self._reactions(ctx, roster, counts, budgets)
+            return None
         joined = await self._maybe_join(ctx, roster)
         enumerated: set[str] = set()
         self_seen = False
@@ -497,7 +583,13 @@ class ParticipantsCollector:
         # `roster_enumerated` above, which stays roster-page-only (spec
         # §6.3: an accounting row for the roster RPC alone).
         counts["enumerated"] += len(enumerated)
-        if not partial or joined:
+        # `joined` is True only under `--join`; a member reached without the
+        # flag (`flags.left is False`, or a `prejoined` join_to_send join)
+        # is equally past the point of a `--join` suggestion. Suppress the
+        # escalation for any member — the `add_roster_snapshot` shortfall row
+        # above still records the gap (round-4 review).
+        member = joined or roster.prejoined or roster.flags.get("left") is False
+        if not partial or member:
             return None
         warning = JOIN_SHORTFALL_WARNING.format(
             enumerated=roster_enumerated, total=true_count if true_count is not None else "?",
@@ -516,6 +608,8 @@ class ParticipantsCollector:
         true, or membership unknown) through the shared audited path; a
         refused join falls back to the un-joined branch. Never without the
         flag (plan D11)."""
+        if roster.prejoined:
+            return True  # `collect` already joined this group this run
         if not ctx.settings.allow_join:
             return False
         if roster.flags.get("left") is False:
@@ -674,9 +768,14 @@ class ParticipantsCollector:
                 answer = await ctx.gateway.get_participant(roster.input_channel, ref)
             except SkipAndRecord as exc:
                 # CHAT_ADMIN_REQUIRED here is the wall itself, not a per-user
-                # condition — stop asking this group.
+                # condition — stop asking this group, and record it (every
+                # other wall in this module is a stored fact, round-4 review).
                 ctx.log.warning("participants: oracle walled on group %s: %s", group_id, exc)
                 counts["skipped"] += 1
+                record_run_event(
+                    ctx.store, ctx.channel_id, self.name, "oracle_walled",
+                    {"group_id": group_id, "reason": str(exc)},
+                )
                 return
             counts["oracle"] += 1
             if answer is None:
@@ -726,10 +825,15 @@ class ParticipantsCollector:
             return
         group_id = roster.group_id
         done = fetched_reaction_lists(ctx.store, group_id)
+        resume = reaction_resume_offsets(ctx.store, group_id)
         candidates = [m for m in reacted_message_ids(ctx.store, group_id) if m not in done][:budget]
         for msg_id in candidates:
             budgets["reactions"] -= 1
-            offset: str | None = None
+            # Resume from the last recorded page of a list truncated by the
+            # page cap, rather than restarting at page 1 — so a >cap-reactor
+            # list CONVERGES over runs instead of re-walking the same head
+            # forever (round-4 review). A fresh message has no resume offset.
+            offset: str | None = resume.get(msg_id)
             for _ in range(_REACTIONS_MAX_PAGES):
                 try:
                     result = await ctx.gateway.get_message_reactions_list(
@@ -749,6 +853,15 @@ class ParticipantsCollector:
                 )
                 counts["reaction_lists"] += 1
                 self._project_users_vector(ctx, result, raw_id, stamp, counts, METHOD_REACTIONS)
+                # The reactor's rich `User` is in the response's own `users`
+                # vector (already projected by `_project_users_vector` above);
+                # index it so the provenance write below is never a bare,
+                # information-losing `min` stub that would NULL a `min` peer's
+                # identity under `upsert_peer`'s recency rule (round-4 review).
+                by_id = {
+                    u["id"]: u for u in (result.get("users") or []) + (result.get("chats") or [])
+                    if isinstance(u.get("id"), int)
+                }
                 for reaction in result.get("reactions") or []:
                     subject = peer_ref_uri(reaction.get("peer_id"))
                     stub = peer_stub(reaction.get("peer_id"))
@@ -757,21 +870,29 @@ class ParticipantsCollector:
                     # Fill-only provenance, mirroring the zero-RPC vector's
                     # own rule (store/reactions.py): a reaction is not a
                     # documented `inputPeerFromMessage` context (research
-                    # §8.7 lists author, forward header and mention), so it
-                    # must never replace stronger provenance a message
-                    # authorship already recorded for this same peer.
+                    # §8.7 lists author, forward header and mention). When a
+                    # peer already carries provenance, do NOT re-upsert it —
+                    # a re-write can only lose data — just guard `#12` and
+                    # emit the edge. When it does not, fill it from the
+                    # response's rich object (falling back to the stub only
+                    # if the reactor is in neither vector).
                     known = ctx.store.conn.execute(
                         "SELECT seen_in_chat, seen_in_msg FROM peers WHERE uri=?", (subject,)
                     ).fetchone()
-                    known_chat = known["seen_in_chat"] if known is not None else None
-                    known_msg = known["seen_in_msg"] if known is not None else None
-                    fill = known_chat is None or known_msg is None
-                    if upsert_peer(
-                        ctx.store, stub, raw_id, stamp,
-                        seen_in_chat=group_id if fill else known_chat,
-                        seen_in_msg=msg_id if fill else known_msg,
-                    ) is None:
-                        continue  # the collecting account reacted (#12)
+                    fill = (
+                        known is None
+                        or known["seen_in_chat"] is None
+                        or known["seen_in_msg"] is None
+                    )
+                    if fill:
+                        rich = by_id.get(stub["id"], stub)
+                        if upsert_peer(
+                            ctx.store, rich, raw_id, stamp,
+                            seen_in_chat=group_id, seen_in_msg=msg_id,
+                        ) is None:
+                            continue  # the collecting account reacted (#12)
+                    elif is_self(ctx.store, subject):
+                        continue
                     if add_edge_once(
                         ctx.store, subject, REACTED_TO, msg_uri(group_id, msg_id), stamp, ctx.tier,
                         raw_id,

--- a/src/paperboy/collectors/profiles.py
+++ b/src/paperboy/collectors/profiles.py
@@ -39,7 +39,7 @@ from paperboy.gateway import REPLAY_UNKNOWN_USER_KIND
 from paperboy.ids import channel_uri, namespaced_kind, user_uri
 from paperboy.store.events import record_run_event
 from paperboy.store.message_peers import backfill_message_referenced_peers
-from paperboy.store.peers import classify_peer, input_user_ref, upsert_peer
+from paperboy.store.peers import input_user_ref, upsert_full_peer
 from paperboy.store.sync import record_profile_attempt, set_state
 from paperboy.store.users import (
     add_user_snapshot,
@@ -266,7 +266,7 @@ class ProfilesCollector:
     ) -> str | None:
         """`users` + `user_snapshots` (+ the full object into `peers`, keeping
         the stub's provenance). `None` for the collecting account."""
-        self._upsert_peer_keeping_provenance(ctx, user, raw_id, observed_at)
+        upsert_full_peer(ctx.store, user, raw_id, observed_at)
         uri = upsert_user(ctx.store, user, raw_id, observed_at, ctx.tier, full_user=full_user)
         if uri is None:
             return None
@@ -276,33 +276,6 @@ class ProfilesCollector:
         if add_user_snapshot(ctx.store, uri, observed_at, ctx.tier, method, bundle, raw_id):
             counts["snapshots"] += 1
         return uri
-
-    @staticmethod
-    def _upsert_peer_keeping_provenance(
-        ctx: CollectContext, obj: dict, raw_id: int, observed_at: str
-    ) -> str | None:
-        """`upsert_peer` for a FULL object returned by a profile RPC. A full
-        observation carrying no provenance of its own would — correctly, by
-        the recency rule — overwrite the stub's `seen_in_chat`/`seen_in_msg`
-        with NULLs, losing the only path back to `inputUserFromMessage`. Pass
-        the stored provenance through instead.
-
-        The URI must be derived exactly the way `upsert_peer` itself derives
-        it — via `classify_peer` — not re-hand-rolled: a `Chat`/`ChatForbidden`/
-        `ChatEmpty` object (a legal member of `users.UserFull.chats`, a
-        `Vector<Chat>`) classifies as `chat`, not `channel`; a hand-rolled
-        `user_uri(...) if kind.startswith("user") else channel_uri(...)`
-        branch reads/writes the wrong peer row for one (round-2 review).
-        """
-        _, uri, _ = classify_peer(obj)
-        row = ctx.store.conn.execute(
-            "SELECT seen_in_chat, seen_in_msg FROM peers WHERE uri=?", (uri,)
-        ).fetchone()
-        return upsert_peer(
-            ctx.store, obj, raw_id, observed_at,
-            seen_in_chat=row["seen_in_chat"] if row else None,
-            seen_in_msg=row["seen_in_msg"] if row else None,
-        )
 
     def _record_summary(self, ctx: CollectContext, counts: dict[str, int], *, pass_: str) -> None:
         """The run's convergence summary (spec §7.1). The enrichment POSITION
@@ -472,7 +445,7 @@ class ProfilesCollector:
                         "SELECT 1 FROM peers WHERE uri=?", (channel_uri(chat["id"]),)
                     ).fetchone() is not None:
                         continue
-                    self._upsert_peer_keeping_provenance(ctx, chat, raw_id, observed_at)
+                    upsert_full_peer(ctx.store, chat, raw_id, observed_at)
                 if self._project_user(
                     ctx, user, raw_id, observed_at, METHOD_GET_FULL_USER, counts,
                     full_user=full_user,

--- a/src/paperboy/store/channels.py
+++ b/src/paperboy/store/channels.py
@@ -18,7 +18,7 @@ from paperboy.store.db import Store, dumps
 _FLAG_EXCLUDE = frozenset({"min"})
 
 
-def _channel_flags(full: dict, chan: dict) -> dict[str, bool]:
+def channel_flags(full: dict, chan: dict) -> dict[str, bool]:
     """Every boolean flag on the ChannelFull and Channel.
 
     Telegram's `flags.N?true` fields serialise as real booleans, so capturing
@@ -27,6 +27,9 @@ def _channel_flags(full: dict, chan: dict) -> dict[str, bool]:
     `join_to_send`/`join_request` the join decision rests on (issue #20). `chan`
     is applied last so the authoritative Channel wins any overlap with the
     ChannelFull.
+
+    Public (Task 8): `participants` needs it too, for the linked group's own
+    preflight `ChatFull`.
     """
     flags: dict[str, bool] = {}
     for obj in (full, chan):
@@ -34,6 +37,9 @@ def _channel_flags(full: dict, chan: dict) -> dict[str, bool]:
             if isinstance(v, bool) and k not in _FLAG_EXCLUDE:
                 flags[k] = v
     return flags
+
+
+_channel_flags = channel_flags  # back-compat alias
 
 
 def _channel_kind(chan: dict) -> str | None:
@@ -78,7 +84,7 @@ def upsert_channel(
     participants_count = full.get("participants_count")
     restriction = chan.get("restriction_reason")
     restriction_json = dumps(restriction) if restriction else None
-    flags = _channel_flags(full, chan)
+    flags = channel_flags(full, chan)
     flags_json = dumps(flags) if flags else None
 
     store.conn.execute(

--- a/src/paperboy/store/peers.py
+++ b/src/paperboy/store/peers.py
@@ -169,6 +169,32 @@ def upsert_peer(
     return uri
 
 
+def upsert_full_peer(store: Store, obj: dict, source_raw_id: int, observed_at: str) -> str | None:
+    """`upsert_peer` for a FULL object returned by a profile/roster RPC. A full
+    observation carrying no provenance of its own would — correctly, by the
+    recency rule — overwrite the stub's `seen_in_chat`/`seen_in_msg` with
+    NULLs, losing the only path back to `inputUserFromMessage`. Pass the
+    stored provenance through instead.
+
+    The URI must be derived exactly the way `upsert_peer` itself derives it —
+    via `classify_peer` — not re-hand-rolled: a `Chat`/`ChatForbidden`/
+    `ChatEmpty` object (a legal member of `users.UserFull.chats`, a
+    `Vector<Chat>`) classifies as `chat`, not `channel`; a hand-rolled
+    `user_uri(...) if kind.startswith("user") else channel_uri(...)` branch
+    reads/writes the wrong peer row for one (round-2 review; shared by
+    `profiles` and `participants`, Task 8).
+    """
+    _, uri, _ = classify_peer(obj)
+    row = store.conn.execute(
+        "SELECT seen_in_chat, seen_in_msg FROM peers WHERE uri=?", (uri,)
+    ).fetchone()
+    return upsert_peer(
+        store, obj, source_raw_id, observed_at,
+        seen_in_chat=row["seen_in_chat"] if row else None,
+        seen_in_msg=row["seen_in_msg"] if row else None,
+    )
+
+
 def input_user_ref(store: Store, uri: str) -> dict | None:
     """The store side of spec §5's `_input_user` builder: the dict the gateway
     turns into an `InputUser`/`InputPeerUser`.

--- a/src/paperboy/store/reactions.py
+++ b/src/paperboy/store/reactions.py
@@ -87,6 +87,29 @@ def reacted_message_ids(store: Store, channel_id: int) -> list[int]:
     return sorted(ids, reverse=True)
 
 
+def reaction_resume_offsets(store: Store, channel_id: int) -> dict[int, str]:
+    """For each message whose reactor list is NOT yet complete, the
+    `next_offset` of its most recently recorded page — the point a later run
+    should resume from instead of restarting at page 1. Lets a list truncated
+    by the per-message page cap CONVERGE across runs (each run advances a
+    further cap's worth of pages) rather than re-walking the same head
+    forever. A message with no recorded page, or whose latest page ended the
+    list (falsy `next_offset`), is absent from the map."""
+    rows = store.conn.execute(
+        "SELECT json_extract(context_json, '$.msg_id') AS m, payload_json FROM raw_records "
+        "WHERE lower(kind) LIKE '%messagereactionslist' "
+        "AND json_extract(context_json, '$.channel_id') = ? "
+        "ORDER BY id",
+        (channel_id,),
+    ).fetchall()
+    last: dict[int, str | None] = {}
+    for row in rows:
+        if row["m"] is None:
+            continue
+        last[int(row["m"])] = json.loads(row["payload_json"]).get("next_offset")
+    return {mid: off for mid, off in last.items() if off}
+
+
 def fetched_reaction_lists(store: Store, channel_id: int) -> set[int]:
     """Message ids whose full reactor list was already fetched — derived from
     the raw log so repeated runs converge instead of re-spending.

--- a/src/paperboy/store/reactions.py
+++ b/src/paperboy/store/reactions.py
@@ -88,12 +88,30 @@ def reacted_message_ids(store: Store, channel_id: int) -> list[int]:
 
 
 def fetched_reaction_lists(store: Store, channel_id: int) -> set[int]:
-    """Message ids whose full reactor list was already fetched (any run) —
-    derived from the raw log so repeated runs converge instead of re-spending."""
+    """Message ids whose full reactor list was already fetched — derived from
+    the raw log so repeated runs converge instead of re-spending.
+
+    A message counts as done only when its MOST RECENTLY recorded page ended
+    the list (a falsy `next_offset`). A message interrupted mid-list — a
+    `HardStop`, or the participants collector's hard per-message page cap —
+    is deliberately NOT done, so a later run revisits it instead of silently
+    treating a partial reactor list as complete forever (round-3 review). The
+    resumed fetch restarts from page 1 rather than the interrupted offset —
+    every write along the way is idempotent, so re-walking pages already
+    seen is wasted RPC, not a correctness risk."""
     rows = store.conn.execute(
-        "SELECT DISTINCT json_extract(context_json, '$.msg_id') AS m FROM raw_records "
+        "SELECT json_extract(context_json, '$.msg_id') AS m, payload_json FROM raw_records "
         "WHERE lower(kind) LIKE '%messagereactionslist' "
-        "AND json_extract(context_json, '$.channel_id') = ?",
+        "AND json_extract(context_json, '$.channel_id') = ? "
+        "ORDER BY id",
         (channel_id,),
     ).fetchall()
-    return {int(r["m"]) for r in rows if r["m"] is not None}
+    # Iterate in raw-log (insertion) order so the last assignment per msg_id
+    # wins — that is always this message's most recently recorded page.
+    last_offset: dict[int, str | None] = {}
+    for row in rows:
+        if row["m"] is None:
+            continue
+        payload = json.loads(row["payload_json"])
+        last_offset[int(row["m"])] = payload.get("next_offset")
+    return {mid for mid, offset in last_offset.items() if not offset}

--- a/tests/test_collector_participants.py
+++ b/tests/test_collector_participants.py
@@ -16,6 +16,7 @@ from paperboy.store.channels import upsert_channel
 from paperboy.store.db import Store
 from paperboy.store.messages import upsert_message
 from paperboy.store.peers import upsert_peer
+from paperboy.store.sync import set_state
 from paperboy.targets import parse_target
 from tests.fakes import FakeGateway
 
@@ -36,7 +37,10 @@ def _ctx(st, gw, settings=None, tier="stranger"):
     )
 
 
-def _seed_channel(st: Store, *, linked: int | None = GROUP_ID, kind: str = "broadcast") -> None:
+def _seed_channel(
+    st: Store, *, linked: int | None = GROUP_ID, kind: str = "broadcast",
+    linked_flags: dict | None = None,
+) -> None:
     raw_id = st.add_raw(
         "ChatFull", {"_": "ChatFull", "full_chat": {"id": CHANNEL_ID}}, "stranger",
         {"channel_id": CHANNEL_ID}, observed_at=T0,
@@ -49,11 +53,9 @@ def _seed_channel(st: Store, *, linked: int | None = GROUP_ID, kind: str = "broa
         chan, raw_id, T0,
     )
     if linked:
-        upsert_peer(
-            st,
-            {"_": "Channel", "id": linked, "access_hash": 4242, "title": "G", "megagroup": True},
-            raw_id, T0, seen_in_chat=None, seen_in_msg=None,
-        )
+        peer = {"_": "Channel", "id": linked, "access_hash": 4242, "title": "G", "megagroup": True}
+        peer.update(linked_flags or {})
+        upsert_peer(st, peer, raw_id, T0, seen_in_chat=None, seen_in_msg=None)
 
 
 def _group_full(count: int = 3, *, left: bool = True, hidden: bool = False, users=()) -> dict:
@@ -74,6 +76,10 @@ def _user(uid: int, **extra) -> dict:
 def _member(uid: int, **extra) -> dict:
     return {"_": "ChannelParticipant", "user_id": uid, "date": JOINED + uid, "rank": None,
             "subscription_until_date": None, **extra}
+
+
+def _self_participant(uid: int) -> dict:
+    return {"_": "ChannelParticipantSelf", "user_id": uid, "date": JOINED, "inviter_id": None}
 
 
 def _page(*participants: dict, count: int | None = None, users=None) -> dict:
@@ -382,6 +388,18 @@ def _seed_group_comment(
                 seen_in_chat=GROUP_ID, seen_in_msg=msg_id)
 
 
+def _seed_group_comment_no_peer(st: Store, msg_id: int, user_id: int) -> None:
+    """Like `_seed_group_comment`, but WITHOUT the peer stub — `from_uri`
+    still makes the author an oracle candidate (the query reads `messages`
+    directly), but with no `peers`/`users` row at all `input_user_ref` has
+    nothing to build a ref from: an unresolvable candidate."""
+    m = {"_": "Message", "id": msg_id, "message": "c", "date": 1767322445,
+         "from_id": {"_": "PeerUser", "user_id": user_id},
+         "peer_id": {"_": "PeerChannel", "channel_id": GROUP_ID}}
+    raw_id = st.add_raw("Message", m, "stranger", {"channel_id": GROUP_ID}, observed_at=T0)
+    upsert_message(st, GROUP_ID, m, raw_id, T0, "stranger")
+
+
 def _answer(uid: int) -> dict:
     return {
         "_": "ChannelParticipant", "participant": _member(uid), "chats": [],
@@ -463,10 +481,11 @@ async def test_oracle_wall_ends_the_oracle_loop_for_that_group(tmp_path):
 async def test_oracle_confirmed_members_count_toward_enumerated(tmp_path):
     """A positive oracle answer writes the SAME kind of confirmed-member row
     (`participants`, `member_of`) as a roster page, so it must count toward
-    the run's `enumerated` total too -- found running the Leg 3 DoD smoke:
-    the shortfall warning (built from the same, oracle-mutated `enumerated`
-    set) disagreed with `res.counts["enumerated"]`, which stopped counting
-    before the oracle ran."""
+    the run's `enumerated` total too -- found running the Leg 3 DoD smoke.
+    The shortfall warning stays scoped to the roster PAGE alone (spec §6.3;
+    round-2 review) -- it must not silently switch to the oracle-mutated
+    set, which would make it disagree with the `roster` event and the
+    `participant_snapshots` row for the very same run."""
     with Store.open(tmp_path / "p.sqlite") as st:
         _seed_channel(st)
         _seed_group_comment(st, 301, 21)
@@ -477,7 +496,48 @@ async def test_oracle_confirmed_members_count_toward_enumerated(tmp_path):
         res = await ParticipantsCollector().collect(_ctx(st, gw))
         assert res.counts["oracle"] == 1
         assert res.counts["enumerated"] == 2, "the roster's 1 + the oracle's confirmed 21"
-        assert res.stopped is not None and "2 of 3" in res.stopped
+        # the warning/roster accounting stays roster-page-only: 1 (not 2) of 3
+        assert res.stopped is not None and "1 of 3" in res.stopped
+        roster_event = json.loads(st.conn.execute(
+            "select detail_json from run_events where kind='roster'").fetchone()[0])
+        warning_event = json.loads(st.conn.execute(
+            "select detail_json from run_events where kind='warning'").fetchone()[0])
+        snapshot = st.conn.execute(
+            "select enumerated from participant_snapshots where group_id=? and uri is null",
+            (GROUP_ID,)).fetchone()
+        assert roster_event["enumerated"] == warning_event["enumerated"] == snapshot["enumerated"]
+
+
+@pytest.mark.asyncio
+async def test_oracle_completing_the_roster_never_claims_a_complete_roster_is_short(tmp_path):
+    """Boundary the previous fix (dd01185) missed by one case: when the
+    roster PAGE alone found 1 of a declared 2 and the oracle confirms the
+    other 1, the run's total IS complete (2 of 2) -- but the shortfall
+    warning must never say so while still telling the operator to spend the
+    tool's one documented write for a roster that is, by its own numbers,
+    already done. It reports the roster-page figure (1 of 2) instead, which
+    stays self-consistent with the `roster` event and the roster snapshot."""
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        _seed_group_comment(st, 301, 21)
+        gw = _gw(
+            [_page(_member(2), count=2)],
+            full_channel_by_id={GROUP_ID: _group_full(2)},
+            participant={GROUP_ID: {21: _answer(21)}},
+        )
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        assert res.counts["oracle"] == 1
+        assert res.counts["enumerated"] == 2  # the run DID find everyone, combined
+        assert res.stopped is not None
+        assert "2 of 2" not in res.stopped  # never claim complete while still warning
+        roster_event = json.loads(st.conn.execute(
+            "select detail_json from run_events where kind='roster'").fetchone()[0])
+        warning_event = json.loads(st.conn.execute(
+            "select detail_json from run_events where kind='warning'").fetchone()[0])
+        snapshot = st.conn.execute(
+            "select enumerated from participant_snapshots where group_id=? and uri is null",
+            (GROUP_ID,)).fetchone()
+        assert roster_event["enumerated"] == warning_event["enumerated"] == snapshot["enumerated"]
 
 
 @pytest.mark.asyncio
@@ -607,3 +667,312 @@ async def test_reaction_list_wall_is_a_recorded_skip(tmp_path):
         res = await ParticipantsCollector().collect(_ctx(st, gw))
         assert gw.reactions_calls == [(GROUP_ID, 402, None)]  # the wall ends the vector
         assert res.counts["skipped"] == 1 and res.stopped is None
+
+
+@pytest.mark.asyncio
+async def test_a_complete_roster_including_self_reports_no_shortfall(tmp_path):
+    """`true_count` (Telegram's own `channelParticipants.count`) includes the
+    collecting account when it is a member, but `write_participant` refuses
+    to store self (issue #12) so self can never land in `enumerated` the
+    same way. Left unreconciled, a completely enumerated roster with self as
+    one of its members reports a permanent phantom shortfall of exactly 1 on
+    every run — structural, not transient (correctness round-2 review)."""
+    with Store.open(tmp_path / "p.sqlite") as st:
+        set_state(st, "account", "self", {"uri": "tg:user:1", "id": 1})
+        _seed_channel(st)
+        page = _page(_member(2), _member(3), _self_participant(1), count=3)
+        gw = _gw([page], full_channel_by_id={GROUP_ID: _group_full(3)})
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        assert res.stopped is None
+        roster = st.conn.execute(
+            "select enumerated, true_count from participant_snapshots "
+            "where group_id=? and uri is null", (GROUP_ID,)).fetchone()
+        assert (roster["enumerated"], roster["true_count"]) == (3, 3)
+        assert st.conn.execute(
+            "select count(*) from participants where uri='tg:user:1'"
+        ).fetchone()[0] == 0  # self is still never a stored subject (#12)
+        assert st.conn.execute(
+            "select count(*) from users where uri='tg:user:1'"
+        ).fetchone()[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_linked_broadcast_peer_is_never_enumerated_or_joined(tmp_path):
+    """`channelFull.linked_chat_id` is bidirectional (research
+    sources/mtproto-channel-messages.md:154): from a discussion SUPERGROUP it
+    points back at its BROADCAST channel. That broadcast's subscriber roster
+    is never enumerable below admin regardless of which side of the link
+    discovered it — enumerating it, or joining it under --join, would
+    violate the module's own zero-enumeration-RPC promise for broadcasts."""
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st, linked=GROUP_ID, kind="megagroup")
+        broadcast_full = {
+            "_": "ChatFull",
+            "full_chat": {"_": "channelFull", "id": GROUP_ID, "participants_count": 50000,
+                          "pts": 1, "can_view_participants": True, "participants_hidden": False},
+            "chats": [{"_": "Channel", "id": GROUP_ID, "access_hash": 4242, "title": "B",
+                       "broadcast": True, "left": True}],
+            "users": [],
+        }
+        gw = _gw([_page(_member(2))], full_channel_by_id={GROUP_ID: broadcast_full})
+        res = await ParticipantsCollector().collect(_ctx(st, gw, _settings(allow_join=True)))
+        assert not any(c[0] == GROUP_ID for c in gw.participants_calls)
+        # the TARGET (a megagroup with unknown membership) is legitimately
+        # joined under --join (`_maybe_join`'s documented "membership
+        # unknown" branch) — what must NEVER happen is the LINKED BROADCAST
+        # being joined, so check the join audit trail by group, not the
+        # gateway's blanket join_channel call count.
+        joins = [
+            json.loads(r[0])["group_id"]
+            for r in st.conn.execute("select detail_json from run_events where kind='join'")
+        ]
+        assert GROUP_ID not in joins
+        walled = [json.loads(r[0]) for r in st.conn.execute(
+            "select payload_json from raw_records where kind='RosterWalled' order by id")]
+        assert any(w["group_id"] == GROUP_ID and "broadcast" in w["reason"] for w in walled)
+        assert res.counts["walled"] == 1
+
+
+@pytest.mark.asyncio
+async def test_hidden_linked_roster_is_walled_before_any_enumeration_rpc(tmp_path):
+    """spec §6.1: an owner-hidden roster (`participants_hidden` /
+    `can_view_participants`) is exactly as structural a wall as a broadcast
+    peer — walled with zero enumeration RPC, not discovered the expensive
+    way via a `CHAT_ADMIN_REQUIRED` on the first page."""
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        gw = _gw([_page(_member(2))], full_channel_by_id={GROUP_ID: _group_full(hidden=True)})
+        await ParticipantsCollector().collect(_ctx(st, gw))
+        assert gw.participants_calls == []
+        walled = [json.loads(r[0]) for r in st.conn.execute(
+            "select payload_json from raw_records where kind='RosterWalled' order by id")]
+        assert any(
+            w["group_id"] == GROUP_ID and "participants_hidden" in w["reason"] for w in walled
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_hidden_megagroup_target_is_walled_from_its_own_stored_flags(tmp_path):
+    """The same §6.1 wall applies to the TARGET's own roster when its stored
+    `channels.flags_json` (from an earlier `channel` phase observation)
+    already carries `participants_hidden` — zero enumeration RPC, exactly
+    like the linked group's own preflight wall (`_roster_wall_reason` is
+    shared by both paths)."""
+    with Store.open(tmp_path / "p.sqlite") as st:
+        raw_id = st.add_raw(
+            "ChatFull", {"_": "ChatFull", "full_chat": {"id": CHANNEL_ID}}, "stranger",
+            {"channel_id": CHANNEL_ID}, observed_at=T0,
+        )
+        chan = {"_": "Channel", "id": CHANNEL_ID, "access_hash": 9, "title": "C",
+                "username": "c", "megagroup": True}
+        upsert_channel(
+            st, {"_": "channelFull", "id": CHANNEL_ID, "pts": 1, "linked_chat_id": None,
+                 "participants_count": 10, "participants_hidden": True,
+                 "can_view_participants": False},
+            chan, raw_id, T0,
+        )
+        gw = FakeGateway({
+            "participants": {CHANNEL_ID: {"channelParticipantsRecent": [_page(_member(2))]}},
+        })
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        assert gw.participants_calls == []
+        walled = [json.loads(r[0]) for r in st.conn.execute(
+            "select payload_json from raw_records where kind='RosterWalled' order by id")]
+        assert any(
+            w["group_id"] == CHANNEL_ID and "participants_hidden" in w["reason"] for w in walled
+        )
+        assert res.stopped is None
+
+
+@pytest.mark.asyncio
+async def test_reaction_list_peer_write_is_fill_only_and_never_overwrites_authorship(tmp_path):
+    """A reaction is not a documented `inputPeerFromMessage` context (research
+    §8.7 lists author, forward header and mention) — a user's reaction to
+    someone else's message must never replace their authorship provenance,
+    mirroring `store.reactions.backfill_recent_reactions`'s own fill-only
+    rule for the zero-RPC vector (correctness round-2 review)."""
+    reacted = {
+        "_": "MessageReactions", "results": [{"_": "ReactionCount", "count": 1, "reaction": {}}],
+    }
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        _seed_group_comment(st, 301, 21)  # user 21 authored 301 -> provenance (77, 301)
+        _seed_group_comment(st, 401, 2, reactions=reacted)  # someone else's message, reacted
+        gw = _gw(
+            [_page(_member(2), count=1)],
+            reactions={GROUP_ID: {401: {
+                "_": "MessageReactionsList", "count": 1, "chats": [], "next_offset": None,
+                "users": [_user(21)],
+                "reactions": [
+                    {"_": "MessagePeerReaction", "peer_id": {"_": "PeerUser", "user_id": 21},
+                     "date": 1767322500, "reaction": {"_": "ReactionEmoji", "emoticon": "🔥"}},
+                ],
+            }}},
+        )
+        await ParticipantsCollector().collect(_ctx(st, gw))
+        peer = st.conn.execute(
+            "select seen_in_chat, seen_in_msg from peers where uri='tg:user:21'"
+        ).fetchone()
+        assert (peer["seen_in_chat"], peer["seen_in_msg"]) == (GROUP_ID, 301)
+        # the reaction is still recorded as an edge — only the provenance write is fill-only
+        assert ("tg:user:21", "reacted_to", "tg:msg:77/401") in {
+            (e[0], e[1], e[2])
+            for e in st.conn.execute("select subject_uri, predicate, object_uri from edges")
+        }
+
+
+@pytest.mark.asyncio
+async def test_reaction_list_peer_write_still_fills_provenance_for_a_new_peer(tmp_path):
+    """The fill-only guard must not regress the ordinary case: a reactor with
+    NO prior provenance still gets the reaction's `(chat, msg)` recorded."""
+    reacted = {
+        "_": "MessageReactions", "results": [{"_": "ReactionCount", "count": 1, "reaction": {}}],
+    }
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        _seed_group_comment(st, 401, 2, reactions=reacted)
+        gw = _gw(
+            [_page(_member(2), count=1)],
+            reactions={GROUP_ID: {401: {
+                "_": "MessageReactionsList", "count": 1, "chats": [], "next_offset": None,
+                "users": [_user(31)],
+                "reactions": [
+                    {"_": "MessagePeerReaction", "peer_id": {"_": "PeerUser", "user_id": 31},
+                     "date": 1767322500, "reaction": {"_": "ReactionEmoji", "emoticon": "🔥"}},
+                ],
+            }}},
+        )
+        await ParticipantsCollector().collect(_ctx(st, gw))
+        peer = st.conn.execute(
+            "select seen_in_chat, seen_in_msg from peers where uri='tg:user:31'"
+        ).fetchone()
+        assert (peer["seen_in_chat"], peer["seen_in_msg"]) == (GROUP_ID, 401)
+
+
+@pytest.mark.asyncio
+async def test_linked_group_honours_join_to_send_like_discussion_does(tmp_path):
+    """The linked group is shared with `discussion`, whose own docstring
+    states that reading it requires membership once `join_to_send` is set
+    (issue #20). A roster read is not exempt from that just because it is
+    not a message read — honour the same flag the same way, for the SAME
+    group, instead of silently reading it un-joined regardless."""
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st, linked_flags={"join_to_send": True})
+        gw = _gw([_page(_member(2))])
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        assert all(c[0] != GROUP_ID for c in gw.participants_calls)
+        assert gw.calls.count("get_full_channel") == 0
+        assert gw.calls.count("join_channel") == 0
+        assert res.stopped is not None and "join_to_send" in res.stopped
+        assert "participants group" in res.stopped  # named for THIS phase, not "discussion"
+
+    with Store.open(tmp_path / "q.sqlite") as st:
+        _seed_channel(st, linked_flags={"join_to_send": True})
+        gw = _gw(
+            [_page(_member(2), count=1)],
+            full_channel_by_id={GROUP_ID: _group_full(left=False)},
+        )
+        res = await ParticipantsCollector().collect(_ctx(st, gw, _settings(allow_join=True)))
+        assert gw.calls.count("join_channel") == 1  # joined once, via the needs_join gate
+        assert gw.calls.count("get_full_channel") == 1
+        assert gw.participants_calls[0] == (GROUP_ID, "channelParticipantsRecent", 0)
+        assert res.counts["rosters"] == 1
+        assert st.conn.execute(
+            "select count(*) from run_events where kind='join'"
+        ).fetchone()[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_broadcast_targets_own_recent_reactions_sample_is_swept(tmp_path):
+    """The zero-RPC `recent_reactions` sample on a BROADCAST's own posts is
+    free — it costs no RPC and is not the walled `getMessageReactionsList`
+    vector — so it must not be dropped just because the target itself is
+    never enumerated via `getParticipants` (correctness round-2 review)."""
+    reacted = {
+        "_": "MessageReactions", "results": [{"_": "ReactionCount", "count": 1, "reaction": {}}],
+        "recent_reactions": [
+            {"_": "MessagePeerReaction", "peer_id": {"_": "PeerUser", "user_id": 51},
+             "date": 1767322500, "reaction": {"_": "ReactionEmoji", "emoticon": "👍"}},
+        ],
+    }
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)  # target is a broadcast (default kind)
+        post = {"_": "Message", "id": 900, "message": "post", "date": 1767322000,
+                "peer_id": {"_": "PeerChannel", "channel_id": CHANNEL_ID}, "reactions": reacted}
+        raw_id = st.add_raw("Message", post, "stranger", {"channel_id": CHANNEL_ID}, observed_at=T0)
+        upsert_message(st, CHANNEL_ID, post, raw_id, T0, "stranger")
+        gw = _gw()
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        assert res.counts["reactors"] == 1
+        assert ("tg:user:51", "reacted_to", "tg:msg:5/900") in {
+            (e["subject_uri"], e["predicate"], e["object_uri"])
+            for e in st.conn.execute("select subject_uri, predicate, object_uri from edges")
+        }
+
+
+@pytest.mark.asyncio
+async def test_reaction_list_pagination_is_hard_capped_against_a_repeating_offset(tmp_path):
+    """Unlike `_page` (three independent stop conditions: empty page, short
+    page, no-new-members), a reaction list's only natural stop is a falsy
+    `next_offset` — a server that always returns one would otherwise spin
+    forever, growing the DB unbounded."""
+    reacted = {
+        "_": "MessageReactions", "results": [{"_": "ReactionCount", "count": 1, "reaction": {}}],
+    }
+    pages = [
+        {"_": "MessageReactionsList", "count": 0, "chats": [], "users": [],
+         "reactions": [], "next_offset": f"p{i}"}
+        for i in range(60)
+    ]
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        _seed_group_comment(st, 401, 2, reactions=reacted)
+        gw = _gw([_page(_member(2), count=1)], reactions={GROUP_ID: {401: pages}})
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        assert res.counts["reaction_lists"] == 50  # capped (`_REACTIONS_MAX_PAGES`), not 60
+        assert res.stopped is None
+
+
+@pytest.mark.asyncio
+async def test_oracle_budget_is_spent_on_resolvable_candidates_not_wasted_on_dead_ones(tmp_path):
+    """The budget slices AFTER filtering to resolvable `input_user_ref`s, not
+    before: an unresolvable candidate must never occupy a budget slot the
+    same `ORDER BY uri` query would otherwise hand to someone the oracle can
+    actually ask — and, unfixed, that starvation is PERMANENT (the dead
+    candidate sorts first on every future run too, since it never gets
+    written to `participants` either)."""
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        _seed_group_comment_no_peer(st, 300, 20)  # authored, but unresolvable: no peer row
+        _seed_group_comment(st, 301, 21)  # authored AND resolvable via inputUserFromMessage
+        gw = _gw(
+            [_page(_member(2), count=3)],
+            participant={GROUP_ID: {21: _answer(21)}},
+        )
+        res = await ParticipantsCollector().collect(
+            _ctx(st, gw, _settings(participant_oracle_budget=1))
+        )
+        assert gw.participant_calls == [(GROUP_ID, 21)]
+        assert res.counts["oracle"] == 1
+
+
+@pytest.mark.asyncio
+async def test_user_snapshot_method_matches_the_producing_rpc(tmp_path):
+    """`user_snapshots.method` is both provenance and the dedupe partition
+    (`add_user_snapshot` keys on `(uri, method)`) — each vector must record
+    the RPC that actually produced the observation, not share one
+    hard-coded value (correctness round-2 review)."""
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        _seed_group_comment(st, 301, 21)
+        gw = _gw(
+            [_page(_member(2), count=3)],
+            participant={GROUP_ID: {21: _answer(21)}},
+        )
+        await ParticipantsCollector().collect(_ctx(st, gw))
+        methods = {
+            r["uri"]: r["method"]
+            for r in st.conn.execute("select uri, method from user_snapshots")
+        }
+        assert methods["tg:user:2"] == "channels.getParticipants"
+        assert methods["tg:user:21"] == "channels.getParticipant"

--- a/tests/test_collector_participants.py
+++ b/tests/test_collector_participants.py
@@ -364,3 +364,225 @@ async def test_phase_stop_without_channel_context(tmp_path):
 def test_applies_to_channel_like_targets():
     assert ParticipantsCollector().applies_to(parse_target("@durov"))
     assert not ParticipantsCollector().applies_to(parse_target("+15551234567"))
+
+
+def _seed_group_comment(
+    st: Store, msg_id: int, user_id: int, *, reactions: dict | None = None
+) -> None:
+    m = {"_": "Message", "id": msg_id, "message": "c", "date": 1767322445,
+         "from_id": {"_": "PeerUser", "user_id": user_id},
+         "peer_id": {"_": "PeerChannel", "channel_id": GROUP_ID}}
+    if reactions is not None:
+        m["reactions"] = reactions
+    raw_id = st.add_raw("Message", m, "stranger", {"channel_id": GROUP_ID}, observed_at=T0)
+    upsert_message(st, GROUP_ID, m, raw_id, T0, "stranger")
+    # what `history._observe_message` does for an author: the min stub with provenance —
+    # without a `peers` row `input_user_ref` is None and the oracle has nothing to ask
+    upsert_peer(st, {"_": "User", "id": user_id, "min": True}, raw_id, T0,
+                seen_in_chat=GROUP_ID, seen_in_msg=msg_id)
+
+
+def _answer(uid: int) -> dict:
+    return {
+        "_": "ChannelParticipant", "participant": _member(uid), "chats": [],
+        "users": [_user(uid)],
+    }
+
+
+@pytest.mark.asyncio
+async def test_oracle_runs_only_on_a_partial_roster_and_is_bounded(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        for uid, mid in ((21, 301), (22, 302), (23, 303), (2, 304)):
+            _seed_group_comment(st, mid, uid)  # 2 is also in the roster; 21-23 are not
+        complete = _gw(
+            [_page(_member(2), count=1)],
+            participant={GROUP_ID: {21: _answer(21), 22: None, 23: _answer(23)}},
+        )
+        await ParticipantsCollector().collect(_ctx(st, complete))
+        assert complete.participant_calls == []  # complete roster: no oracle spend
+
+    with Store.open(tmp_path / "q.sqlite") as st:
+        _seed_channel(st)
+        for uid, mid in ((21, 301), (22, 302), (23, 303), (2, 304)):
+            _seed_group_comment(st, mid, uid)
+        partial = _gw(
+            [_page(_member(2), count=307)],
+            participant={GROUP_ID: {21: _answer(21), 22: None, 23: _answer(23)}},
+        )
+        res = await ParticipantsCollector().collect(
+            _ctx(st, partial, _settings(participant_oracle_budget=2))
+        )
+        assert partial.participant_calls == [(GROUP_ID, 21), (GROUP_ID, 22)]  # bounded, uri order
+        assert res.counts["oracle"] == 2
+        rows = {
+            r["uri"]: r["status"]
+            for r in st.conn.execute("select uri, status from participants")
+        }
+        assert rows["tg:user:21"] == "member" and rows["tg:user:22"] == "left"
+        assert "tg:user:23" not in rows
+        raw = [r["kind"] for r in st.conn.execute(
+            "select kind from raw_records where json_extract(context_json,'$.user_id') "
+            "in (21, 22) order by id")]
+        assert raw == ["channels.ChannelParticipant", "UserNotParticipant"]
+        edge = st.conn.execute(
+            "select evidence_json from edges where subject_uri='tg:user:21' "
+            "and predicate='member_of'").fetchone()
+        assert '"source": "oracle"' in edge["evidence_json"]
+        assert st.conn.execute(
+            "select count(*) from users where uri='tg:user:21'"
+        ).fetchone()[0] == 1
+
+        # a later run asks only about users still without an answer
+        again = _gw(
+            [_page(_member(2), count=307)],
+            participant={GROUP_ID: {21: _answer(21), 22: None, 23: _answer(23)}},
+        )
+        await ParticipantsCollector().collect(
+            _ctx(st, again, _settings(participant_oracle_budget=2))
+        )
+        assert again.participant_calls == [(GROUP_ID, 23)]
+
+
+@pytest.mark.asyncio
+async def test_oracle_wall_ends_the_oracle_loop_for_that_group(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        for uid, mid in ((21, 301), (22, 302)):
+            _seed_group_comment(st, mid, uid)
+        gw = _gw(
+            [_page(_member(2), count=307)],
+            participant={GROUP_ID: {21: SkipAndRecord("CHAT_ADMIN_REQUIRED"), 22: _answer(22)}},
+        )
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        assert gw.participant_calls == [(GROUP_ID, 21)]
+        assert res.counts["skipped"] == 1 and res.counts["oracle"] == 0
+
+
+@pytest.mark.asyncio
+async def test_join_flag_joins_a_left_group_then_pages_admins_and_bots(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        admins = {"_": "ChannelParticipants", "count": 1, "chats": [], "users": [_user(9)],
+                  "participants": [{"_": "ChannelParticipantCreator", "user_id": 9,
+                                    "admin_rights": {"_": "ChatAdminRights"}, "rank": "founder"}]}
+        bots = _page(_member(30), count=1, users=[_user(30, bot=True)])
+        gw = FakeGateway({
+            "full_channel_by_id": {GROUP_ID: _group_full(left=True)},
+            "participants": {GROUP_ID: {"channelParticipantsRecent": [_page(_member(2), count=3)],
+                                        "channelParticipantsAdmins": [admins],
+                                        "channelParticipantsBots": [bots]}},
+            "join": {"_": "Updates", "updates": []},
+        })
+        res = await ParticipantsCollector().collect(_ctx(st, gw, _settings(allow_join=True)))
+        assert gw.calls.count("join_channel") == 1
+        assert [c[1] for c in gw.participants_calls] == [
+            "channelParticipantsRecent", "channelParticipantsAdmins", "channelParticipantsBots",
+        ]
+        assert st.conn.execute(
+            "select status from participants where uri='tg:user:9'"
+        ).fetchone()[0] == "creator"
+        assert st.conn.execute(
+            "select count(*) from run_events where kind='join'"
+        ).fetchone()[0] == 1
+        assert res.stopped is None  # joined: the shortfall is not a --join warning any more
+
+    with Store.open(tmp_path / "q.sqlite") as st:
+        _seed_channel(st)
+        gw = FakeGateway({
+            "full_channel_by_id": {GROUP_ID: _group_full(left=False)},
+            "participants": {GROUP_ID: {"channelParticipantsRecent": [_page(_member(2), count=1)]}},
+        })
+        await ParticipantsCollector().collect(_ctx(st, gw, _settings(allow_join=True)))
+        assert gw.calls.count("join_channel") == 0  # already a member: never re-joined
+        assert [c[1] for c in gw.participants_calls][1:] == [
+            "channelParticipantsAdmins", "channelParticipantsBots",
+        ]
+
+
+@pytest.mark.asyncio
+async def test_join_never_fires_without_the_flag_and_a_refused_join_falls_back(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        gw = _gw([_page(_member(2), count=1)], join={"_": "Updates", "updates": []})
+        await ParticipantsCollector().collect(_ctx(st, gw))
+        assert "join_channel" not in gw.calls
+    with Store.open(tmp_path / "q.sqlite") as st:
+        _seed_channel(st)
+        gw = _gw([_page(_member(2), count=1)], join=SkipAndRecord("INVITE_REQUEST_SENT"))
+        res = await ParticipantsCollector().collect(_ctx(st, gw, _settings(allow_join=True)))
+        assert gw.calls.count("join_channel") == 1
+        assert [c[1] for c in gw.participants_calls] == ["channelParticipantsRecent"]  # un-joined
+        assert res.counts["enumerated"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reaction_lists_are_bounded_newest_first_and_resumable(tmp_path):
+    reacted = {
+        "_": "MessageReactions", "results": [{"_": "ReactionCount", "count": 2, "reaction": {}}],
+    }
+
+    def _list(*uids: int, next_offset=None) -> dict:
+        return {
+            "_": "MessageReactionsList", "count": len(uids), "chats": [],
+            "next_offset": next_offset,
+            "users": [_user(u) for u in uids],
+            "reactions": [
+                {"_": "MessagePeerReaction", "peer_id": {"_": "PeerUser", "user_id": u},
+                 "date": 1767322500, "reaction": {"_": "ReactionEmoji", "emoticon": "🔥"}}
+                for u in uids
+            ],
+        }
+
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        for mid in (401, 402, 403):
+            _seed_group_comment(st, mid, 2, reactions=reacted)
+        _seed_group_comment(st, 404, 2)  # no reactions: never asked
+        gw = _gw([_page(_member(2), count=1)], reactions={GROUP_ID: {
+            403: [_list(31, 32, next_offset="p2"), _list(33)], 402: _list(34), 401: _list(35),
+        }})
+        res = await ParticipantsCollector().collect(
+            _ctx(st, gw, _settings(participant_reactions_budget=2))
+        )
+        assert gw.reactions_calls == [
+            (GROUP_ID, 403, None), (GROUP_ID, 403, "p2"), (GROUP_ID, 402, None),
+        ]
+        assert res.counts["reaction_lists"] == 3
+        edges = {(e[0], e[2]) for e in st.conn.execute(
+            "select subject_uri, predicate, object_uri from edges where predicate='reacted_to'")}
+        assert edges == {
+            ("tg:user:31", "tg:msg:77/403"), ("tg:user:32", "tg:msg:77/403"),
+            ("tg:user:33", "tg:msg:77/403"), ("tg:user:34", "tg:msg:77/402"),
+        }
+        assert st.conn.execute(
+            "select count(*) from users where uri in ('tg:user:31','tg:user:34')"
+        ).fetchone()[0] == 2
+        peer = st.conn.execute(
+            "select seen_in_chat, seen_in_msg from peers where uri='tg:user:31'"
+        ).fetchone()
+        assert (peer["seen_in_chat"], peer["seen_in_msg"]) == (GROUP_ID, 403)
+
+        again = _gw([_page(_member(2), count=1)], reactions={GROUP_ID: {401: _list(35)}})
+        await ParticipantsCollector().collect(
+            _ctx(st, again, _settings(participant_reactions_budget=2))
+        )
+        assert again.reactions_calls == [(GROUP_ID, 401, None)]  # 403/402 fetched: resumable
+
+
+@pytest.mark.asyncio
+async def test_reaction_list_wall_is_a_recorded_skip(tmp_path):
+    reacted = {
+        "_": "MessageReactions", "results": [{"_": "ReactionCount", "count": 2, "reaction": {}}],
+    }
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        _seed_group_comment(st, 401, 2, reactions=reacted)
+        _seed_group_comment(st, 402, 2, reactions=reacted)
+        gw = _gw(
+            [_page(_member(2), count=1)],
+            reactions={GROUP_ID: {402: SkipAndRecord("BROADCAST_FORBIDDEN")}},
+        )
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        assert gw.reactions_calls == [(GROUP_ID, 402, None)]  # the wall ends the vector
+        assert res.counts["skipped"] == 1 and res.stopped is None

--- a/tests/test_collector_participants.py
+++ b/tests/test_collector_participants.py
@@ -1131,3 +1131,161 @@ async def test_no_access_hash_reason_names_the_running_phase(tmp_path):
         assert res.stopped is not None
         assert "participants group 77: no access hash known" in res.stopped
         assert "discussion group" not in res.stopped
+
+
+@pytest.mark.asyncio
+async def test_reaction_list_never_clobbers_a_min_reactors_identity(tmp_path):
+    """Round-4 correctness (blocking): the reactor's rich `User` is in the
+    response's own `users` vector; the per-reaction provenance write must use
+    it (or, when provenance is already known, not re-write the peer at all) —
+    never a bare `min` stub that would NULL a `min` peer's username/name/hash
+    under `upsert_peer`'s recency rule."""
+    reacted = {
+        "_": "MessageReactions", "results": [{"_": "ReactionCount", "count": 1, "reaction": {}}],
+    }
+    rich = _user(31, access_hash=3100, username="thirtyone", premium=True)
+    rlist = {
+        "_": "MessageReactionsList", "count": 2, "chats": [], "next_offset": None,
+        # 31 is present (rich); 32 reacts but is ABSENT from the users vector —
+        # the exact case the old per-reaction `min`-stub write NULLed.
+        "users": [rich],
+        "reactions": [
+            {"_": "MessagePeerReaction", "peer_id": {"_": "PeerUser", "user_id": u},
+             "date": 1767322500, "reaction": {"_": "ReactionEmoji", "emoticon": "x"}}
+            for u in (31, 32)
+        ],
+    }
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        _seed_group_comment(st, 401, 2, reactions=reacted)
+        # user 32 already has authorship provenance from an earlier message.
+        author32 = {"_": "User", "id": 32, "min": True, "username": "author32", "access_hash": 9999}
+        upsert_peer(
+            st, author32, st.add_raw("User", author32, "stranger", None),
+            "2026-01-01T00:00:00+00:00", seen_in_chat=GROUP_ID, seen_in_msg=200,
+        )
+        gw = _gw([_page(_member(2), count=1)], reactions={GROUP_ID: {401: rlist}})
+        await ParticipantsCollector().collect(_ctx(st, gw))
+        # 31 was new -> filled from the RICH object, not blanked
+        r31 = st.conn.execute(
+            "select username, access_hash, is_min, seen_in_chat, seen_in_msg "
+            "from peers where uri='tg:user:31'"
+        ).fetchone()
+        assert (r31["username"], r31["access_hash"]) == ("thirtyone", 3100)
+        assert (r31["seen_in_chat"], r31["seen_in_msg"]) == (GROUP_ID, 401)
+        # 32 already had provenance -> untouched (fill-only), authorship kept
+        r32 = st.conn.execute(
+            "select username, access_hash, seen_in_msg from peers where uri='tg:user:32'"
+        ).fetchone()
+        assert (r32["username"], r32["access_hash"], r32["seen_in_msg"]) == ("author32", 9999, 200)
+        # both edges still emitted
+        assert st.conn.execute(
+            "select count(*) from edges where predicate='reacted_to'"
+        ).fetchone()[0] == 2
+
+
+@pytest.mark.asyncio
+async def test_hidden_group_runs_the_oracle_and_reaction_fallback(tmp_path):
+    """Round-4 correctness (blocking): a `participants_hidden` linked group is
+    bulk-walled, but the getParticipant oracle and the reaction-list vector
+    are the designated fallback (spec §5/§6.2, plan D9) — they must run, with
+    ZERO `getParticipants` paging RPC and only ONE walled record."""
+    reacted = {
+        "_": "MessageReactions", "results": [{"_": "ReactionCount", "count": 1, "reaction": {}}],
+    }
+    rlist = {"_": "MessageReactionsList", "count": 1, "chats": [], "next_offset": None,
+             "users": [_user(31, access_hash=3100)],
+             "reactions": [{"_": "MessagePeerReaction", "peer_id": {"_": "PeerUser", "user_id": 31},
+                            "date": 1767322500,
+                            "reaction": {"_": "ReactionEmoji", "emoticon": "x"}}]}
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        _seed_group_comment(st, 401, 21, reactions=reacted)  # author 21 (a candidate), reacted msg
+        gw = _gw(
+            full_channel_by_id={GROUP_ID: _group_full(hidden=True)},
+            participant={GROUP_ID: {21: _answer(21)}},
+            reactions={GROUP_ID: {401: rlist}},
+        )
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        assert gw.participants_calls == []  # bulk paging never attempted
+        assert gw.participant_calls == [(GROUP_ID, 21)]  # oracle ran
+        assert res.counts["oracle"] == 1 and res.counts["reaction_lists"] == 1
+        assert st.conn.execute(
+            "select status from participants where uri='tg:user:21'"
+        ).fetchone()[0] == "member"
+        # exactly one RosterWalled for the group (recorded at preflight, not re-recorded)
+        walled = st.conn.execute(
+            "select count(*) from raw_records where kind='RosterWalled' "
+            "and json_extract(payload_json, '$.group_id')=?", (GROUP_ID,)
+        ).fetchone()[0]
+        assert walled == 1
+
+
+@pytest.mark.asyncio
+async def test_already_member_group_is_not_re_joined_across_runs(tmp_path):
+    """Round-4 adversarial (blocking): the join_to_send branch in `collect`
+    must consult membership like `_maybe_join` does, or it re-joins an
+    already-member group with an active audited write every run."""
+    with Store.open(tmp_path / "p.sqlite") as st:
+        # linked group is join_to_send; the peer row carries the flag.
+        _seed_channel(st, linked_flags={"join_to_send": True})
+        gw = FakeGateway({
+            "full_channel_by_id": {GROUP_ID: _group_full(left=False)},  # we ARE a member
+            "participants": {GROUP_ID: {"channelParticipantsRecent": [_page(_member(2), count=1)]}},
+            "join": {"_": "Updates", "updates": []},
+        })
+        for _ in range(3):
+            await ParticipantsCollector().collect(_ctx(st, gw, _settings(allow_join=True)))
+        # run 1 joins once (membership unknown); runs 2-3 read left=false and do not
+        assert gw.calls.count("join_channel") == 1
+        joins = st.conn.execute("select count(*) from run_events where kind='join'")
+        assert joins.fetchone()[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_join_to_send_linked_broadcast_is_never_joined(tmp_path):
+    """Round-4 adversarial (blocking): a join_to_send flag on a linked
+    BROADCAST peer must not trigger a join — it is walled (terminal) instead."""
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)  # linked peer defaults to megagroup; overwrite it broadcast-only
+        st.conn.execute(
+            "update peers set flags_json=? where uri=?",
+            (json.dumps({"broadcast": True, "join_to_send": True}), "tg:channel:77"),
+        )
+        gw = FakeGateway({
+            "full_channel_by_id": {GROUP_ID: {
+                "_": "ChatFull",
+                "full_chat": {
+                    "_": "channelFull", "id": GROUP_ID, "participants_count": 9, "pts": 1,
+                },
+                "chats": [{"_": "Channel", "id": GROUP_ID, "access_hash": 4242, "title": "B",
+                           "broadcast": True}],
+                "users": [],
+            }},
+            "join": {"_": "Updates", "updates": []},
+        })
+        res = await ParticipantsCollector().collect(_ctx(st, gw, _settings(allow_join=True)))
+        assert gw.calls.count("join_channel") == 0
+        assert gw.participants_calls == []  # a broadcast is never paged
+        assert res.counts["walled"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_member_without_join_flag_gets_no_join_suggestion(tmp_path):
+    """Round-4 correctness (minor): an already-member roster that comes back
+    short must not tell the operator to `--join` — they are already in."""
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st, kind="megagroup", linked=None, target_flags={"left": False})
+        gw = FakeGateway({
+            "participants": {
+                CHANNEL_ID: {"channelParticipantsRecent": [_page(_member(2), count=9)]},
+            },
+        })
+        res = await ParticipantsCollector().collect(_ctx(st, gw))  # no --join
+        assert res.stopped is None or "--join" not in res.stopped
+        # the shortfall is still recorded in the snapshot row
+        snap = st.conn.execute(
+            "select enumerated, true_count from participant_snapshots "
+            "where group_id=? and uri is null order by id desc limit 1", (CHANNEL_ID,)
+        ).fetchone()
+        assert snap["enumerated"] == 1 and snap["true_count"] == 9

--- a/tests/test_collector_participants.py
+++ b/tests/test_collector_participants.py
@@ -1,0 +1,366 @@
+"""The `participants` collector, spec §6: roster discovery within Telegram's walls."""
+
+from __future__ import annotations  # noqa: I001
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from paperboy.collectors.participants import ParticipantsCollector
+
+from paperboy.budget import PhaseStop, SkipAndRecord
+from paperboy.collectors.base import CollectContext
+from paperboy.config import load_settings
+from paperboy.store.channels import upsert_channel
+from paperboy.store.db import Store
+from paperboy.store.messages import upsert_message
+from paperboy.store.peers import upsert_peer
+from paperboy.targets import parse_target
+from tests.fakes import FakeGateway
+
+CHANNEL_ID = 5
+GROUP_ID = 77
+T0 = "2026-01-01T00:00:00+00:00"
+JOINED = 1735689600
+
+
+def _settings(**over):
+    return load_settings("default", {"unsafe": True, **over})
+
+
+def _ctx(st, gw, settings=None, tier="stranger"):
+    return CollectContext(
+        gw, st, settings or _settings(), parse_target("@x"),
+        {"channel_id": CHANNEL_ID, "access_hash": 9}, CHANNEL_ID, tier, logging.getLogger("t"),
+    )
+
+
+def _seed_channel(st: Store, *, linked: int | None = GROUP_ID, kind: str = "broadcast") -> None:
+    raw_id = st.add_raw(
+        "ChatFull", {"_": "ChatFull", "full_chat": {"id": CHANNEL_ID}}, "stranger",
+        {"channel_id": CHANNEL_ID}, observed_at=T0,
+    )
+    chan = {"_": "Channel", "id": CHANNEL_ID, "access_hash": 9, "title": "C", "username": "c"}
+    chan["broadcast" if kind == "broadcast" else "megagroup"] = True
+    upsert_channel(
+        st, {"_": "channelFull", "id": CHANNEL_ID, "pts": 1, "linked_chat_id": linked,
+             "participants_count": 10},
+        chan, raw_id, T0,
+    )
+    if linked:
+        upsert_peer(
+            st,
+            {"_": "Channel", "id": linked, "access_hash": 4242, "title": "G", "megagroup": True},
+            raw_id, T0, seen_in_chat=None, seen_in_msg=None,
+        )
+
+
+def _group_full(count: int = 3, *, left: bool = True, hidden: bool = False, users=()) -> dict:
+    return {
+        "_": "ChatFull",
+        "full_chat": {"_": "channelFull", "id": GROUP_ID, "participants_count": count, "pts": 1,
+                      "can_view_participants": not hidden, "participants_hidden": hidden},
+        "chats": [{"_": "Channel", "id": GROUP_ID, "access_hash": 4242, "title": "G",
+                   "megagroup": True, "left": left}],
+        "users": list(users),
+    }
+
+
+def _user(uid: int, **extra) -> dict:
+    return {"_": "User", "id": uid, "access_hash": uid * 10, "first_name": f"U{uid}", **extra}
+
+
+def _member(uid: int, **extra) -> dict:
+    return {"_": "ChannelParticipant", "user_id": uid, "date": JOINED + uid, "rank": None,
+            "subscription_until_date": None, **extra}
+
+
+def _page(*participants: dict, count: int | None = None, users=None) -> dict:
+    return {
+        "_": "ChannelParticipants",
+        "count": count if count is not None else len(participants),
+        "participants": list(participants), "chats": [],
+        "users": (
+            users if users is not None
+            else [_user(p["user_id"]) for p in participants if "user_id" in p]
+        ),
+    }
+
+
+def _gw(pages=None, **more) -> FakeGateway:
+    fx = {"full_channel_by_id": {GROUP_ID: _group_full()}}
+    if pages is not None:
+        fx["participants"] = {GROUP_ID: {"channelParticipantsRecent": pages}}
+    fx.update(more)
+    return FakeGateway(fx)
+
+
+@pytest.mark.asyncio
+async def test_broadcast_roster_is_a_stored_walled_outcome_and_the_group_is_enumerated(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        admin = {"_": "ChannelParticipantAdmin", "user_id": 1, "promoted_by": 9, "date": JOINED,
+                 "admin_rights": {"_": "ChatAdminRights"}, "rank": "mod", "is_self": None,
+                 "inviter_id": None}
+        gw = _gw([_page(admin, _member(2), _member(3, rank="vip"))])
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+
+        # 1. the broadcast channel's OWN roster: zero enumeration RPC, first-class stored outcome
+        assert all(c[0] == GROUP_ID for c in gw.participants_calls)
+        assert (CHANNEL_ID, "channelParticipantsRecent", 0) not in gw.participants_calls
+        assert gw.calls.count("get_participants") == 1  # the group's one Recent page (§11 zero-RPC)
+        walled = st.conn.execute(
+            "select payload_json, observed_at from raw_records where kind='RosterWalled'"
+        ).fetchone()
+        payload = json.loads(walled["payload_json"])
+        assert payload["group_id"] == CHANNEL_ID and payload["participants_count"] == 10
+        assert "broadcast" in payload["reason"]
+        assert walled["observed_at"] == T0  # from the ChatFull observation, never "now" (D5)
+        acct = st.conn.execute(
+            "select enumerated, true_count, reason from participant_snapshots "
+            "where group_id=? and uri is null",
+            (CHANNEL_ID,)).fetchone()
+        assert (acct["enumerated"], acct["true_count"]) == (0, 10) and "broadcast" in acct["reason"]
+        assert res.counts["walled"] == 1
+
+        # 2. the linked group: preflight ChatFull recorded, roster paged, projected
+        assert gw.calls.count("get_full_channel") == 1
+        assert gw.participants_calls == [(GROUP_ID, "channelParticipantsRecent", 0)]
+        rows = {
+            r["uri"]: r for r in
+            st.conn.execute("select * from participants where group_id=?", (GROUP_ID,))
+        }
+        assert rows["tg:user:1"]["status"] == "admin" and rows["tg:user:1"]["rank"] == "mod"
+        assert rows["tg:user:2"]["join_date"] == "2025-01-01T00:00:02+00:00"
+        assert rows["tg:user:3"]["rank"] == "vip"
+        users = {r["uri"] for r in st.conn.execute("select uri from users")}
+        assert users == {"tg:user:1", "tg:user:2", "tg:user:3"}  # the free full User objects
+        edges = {
+            (e["subject_uri"], e["predicate"])
+            for e in st.conn.execute("select subject_uri, predicate from edges")
+        }
+        assert ("tg:user:1", "admin_of") in edges and ("tg:user:2", "member_of") in edges
+        roster = st.conn.execute(
+            "select enumerated, true_count, reason from participant_snapshots "
+            "where group_id=? and uri is null",
+            (GROUP_ID,)).fetchone()
+        assert (roster["enumerated"], roster["true_count"], roster["reason"]) == (3, 3, None)
+        assert st.conn.execute(
+            "select count(*) from participant_snapshots where group_id=? and uri is not null",
+            (GROUP_ID,)).fetchone()[0] == 3
+        group_row = st.conn.execute(
+            "select kind, participants_count from channels where id=?", (GROUP_ID,)
+        ).fetchone()
+        assert (group_row["kind"], group_row["participants_count"]) == ("megagroup", 3)
+        kinds = [r["kind"] for r in st.conn.execute(
+            "select kind from raw_records where json_extract(context_json,'$.channel_id')=? "
+            "order by id", (GROUP_ID,))]
+        assert kinds == ["ChatFull", "channels.ChannelParticipants"]
+        event = json.loads(
+            st.conn.execute("select detail_json from run_events where kind='roster'").fetchone()[0]
+        )
+        assert (
+            event["group_id"], event["enumerated"], event["true_count"], event["walled"]
+        ) == (GROUP_ID, 3, 3, None)
+        assert res.stopped is None
+        assert (
+            res.counts["enumerated"] == 3
+            and res.counts["participants"] == 3
+            and res.counts["users"] == 3
+        )
+        # §6.5: admin-only sub-methods are detected via rights and SKIPPED — a recorded decision
+        skipped = json.loads(st.conn.execute(
+            "select detail_json from run_events where kind='admin_only_skipped'").fetchone()[0])
+        assert skipped["group_id"] == GROUP_ID and "channels.getAdminLog" in skipped["methods"]
+        assert st.conn.execute(
+            "select count(*) from run_events where kind='privacy_posture'"
+        ).fetchone()[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_no_linked_group_records_the_walled_channel_then_skips_the_phase(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st, linked=None)
+        gw = _gw()
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        assert res.stopped is not None and "linked" in res.stopped
+        assert gw.participants_calls == [] and gw.calls.count("get_full_channel") == 0
+        assert st.conn.execute(
+            "select count(*) from raw_records where kind='RosterWalled'"
+        ).fetchone()[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_recent_pages_until_a_short_page_and_labels_the_shortfall(tmp_path):
+    # The 78k->12 reality (spec §6.3): a full first page, then a short one,
+    # then STOP; enumerated / true_count is recorded, never presented as complete.
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        first = _page(*[_member(i) for i in range(1, 201)], count=78000)
+        second = _page(*[_member(i) for i in range(201, 213)], count=78000)
+        gw = _gw([first, second], full_channel_by_id={GROUP_ID: _group_full(78000)})
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        assert gw.participants_calls == [
+            (GROUP_ID, "channelParticipantsRecent", 0),
+            (GROUP_ID, "channelParticipantsRecent", 200),
+        ]
+        roster = st.conn.execute(
+            "select enumerated, true_count from participant_snapshots "
+            "where group_id=? and uri is null",
+            (GROUP_ID,)).fetchone()
+        assert (roster["enumerated"], roster["true_count"]) == (212, 78000)
+        assert res.stopped is not None and "212 of 78000" in res.stopped and "--join" in res.stopped
+        warning = json.loads(st.conn.execute(
+            "select detail_json from run_events where kind='warning'").fetchone()[0])
+        assert warning["code"] == "roster_partial" and warning["hint"] == "--join"
+
+
+@pytest.mark.asyncio
+async def test_a_repeating_page_ends_the_loop(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        same = _page(*[_member(i) for i in range(1, 201)], count=1000)
+        gw = _gw([same, same, same])
+        await ParticipantsCollector().collect(_ctx(st, gw))
+        assert len(gw.participants_calls) == 2  # page 2 added nothing new -> stop
+
+
+@pytest.mark.asyncio
+async def test_walled_group_is_recorded_with_its_reason_and_the_join_warning(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        gw = _gw(SkipAndRecord("CHAT_ADMIN_REQUIRED"))
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        walled = [json.loads(r[0]) for r in st.conn.execute(
+            "select payload_json from raw_records where kind='RosterWalled' order by id")]
+        assert [w["group_id"] for w in walled] == [CHANNEL_ID, GROUP_ID]
+        assert "CHAT_ADMIN_REQUIRED" in walled[1]["reason"]
+        roster = st.conn.execute(
+            "select enumerated, true_count, reason from participant_snapshots "
+            "where group_id=? and uri is null",
+            (GROUP_ID,)).fetchone()
+        assert (
+            (roster["enumerated"], roster["true_count"]) == (0, 3)
+            and "CHAT_ADMIN_REQUIRED" in roster["reason"]
+        )
+        assert res.stopped is not None and "--join" in res.stopped
+        assert res.counts["walled"] == 2
+
+
+@pytest.mark.asyncio
+async def test_session_age_gate_refuses_enumeration_without_unsafe(tmp_path):
+    young = {
+        "authorizations": [{"current": True, "date_created": datetime.now(UTC) - timedelta(days=1)}]
+    }
+    old_date = datetime.now(UTC) - timedelta(days=30)
+    old = {"authorizations": [{"current": True, "date_created": old_date}]}
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        gw = _gw([_page(_member(2))], authorizations=young)
+        res = await ParticipantsCollector().collect(_ctx(st, gw, _settings(unsafe=False)))
+        assert res.stopped is not None and "--unsafe" in res.stopped
+        assert gw.participants_calls == []
+        assert gw.calls.count("get_full_channel") == 0  # the gate runs BEFORE any group RPC (§6.1)
+        assert st.conn.execute(
+            "select count(*) from run_events where kind='warning'"
+        ).fetchone()[0] == 1
+        assert json.loads(st.conn.execute(
+            "select detail_json from run_events where kind='warning'"
+        ).fetchone()[0])["code"] == "session_age_gate"
+    with Store.open(tmp_path / "q.sqlite") as st:
+        _seed_channel(st)
+        gw = _gw([_page(_member(2))], authorizations=old)
+        res = await ParticipantsCollector().collect(_ctx(st, gw, _settings(unsafe=False)))
+        assert res.stopped is None and gw.participants_calls != []
+
+
+@pytest.mark.asyncio
+async def test_zero_rpc_vectors_run_even_when_the_gate_refuses(tmp_path):
+    young = {"authorizations": [{"current": True, "date_created": datetime.now(UTC)}]}
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        join = {"_": "MessageService", "id": 40, "date": JOINED,
+                "from_id": {"_": "PeerUser", "user_id": 8},
+                "action": {"_": "MessageActionChatJoinedByLink", "inviter_id": 4},
+                "peer_id": {"_": "PeerChannel", "channel_id": GROUP_ID}}
+        upsert_message(
+            st, GROUP_ID, join,
+            st.add_raw("MessageService", join, "stranger", {"channel_id": GROUP_ID}),
+            T0, "stranger",
+        )
+        gw = _gw([_page(_member(2))], authorizations=young)
+        res = await ParticipantsCollector().collect(_ctx(st, gw, _settings(unsafe=False)))
+        assert res.counts["service_joins"] == 1
+        assert st.conn.execute(
+            "select status from participants where uri='tg:user:8'"
+        ).fetchone()[0] == "member"
+        assert ("tg:user:8", "invited_by", "tg:user:4") in {
+            (e[0], e[1], e[2])
+            for e in st.conn.execute("select subject_uri, predicate, object_uri from edges")
+        }
+
+
+@pytest.mark.asyncio
+async def test_privacy_posture_is_recorded_once_per_run_across_both_person_phases(tmp_path):
+    from paperboy.collectors.profiles import ProfilesCollector
+
+    rules = {
+        "_": "account.PrivacyRules", "rules": [{"_": "PrivacyValueAllowContacts"}],
+        "chats": [], "users": [],
+    }
+    with Store.open(tmp_path / "p.sqlite") as st:
+        st.begin_run("run-1")
+        _seed_channel(st)
+        gw = _gw([_page(_member(2))], privacy={k: rules for k in ("phone", "lastseen", "photo")})
+        ctx = _ctx(st, gw)
+        await ParticipantsCollector().collect(ctx)
+        await ProfilesCollector().collect(ctx)
+        assert gw.calls.count("get_privacy") == 3  # participants recorded; profiles didn't repeat
+        assert st.conn.execute(
+            "select count(*) from run_events where kind='privacy_posture'"
+        ).fetchone()[0] == 1
+        st.begin_run("run-2")
+        await ProfilesCollector().collect(ctx)
+        assert gw.calls.count("get_privacy") == 6  # a new run records again
+
+
+@pytest.mark.asyncio
+async def test_preflight_answering_for_another_channel_does_not_enumerate(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        wrong = _group_full()
+        wrong["full_chat"]["id"] = 999
+        gw = _gw([_page(_member(2))], full_channel_by_id={GROUP_ID: wrong})
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        assert gw.participants_calls == [] and res.counts["skipped"] == 1
+        assert st.conn.execute("select count(*) from participants").fetchone()[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_a_megagroup_target_enumerates_its_own_roster_from_stored_flags(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st, linked=None, kind="megagroup")
+        pages = {"channelParticipantsRecent": [_page(_member(2), count=10)]}
+        gw = FakeGateway({"participants": {CHANNEL_ID: pages}})
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        assert gw.calls.count("get_full_channel") == 0  # target's ChatFull already in `channels`
+        assert gw.participants_calls == [(CHANNEL_ID, "channelParticipantsRecent", 0)]
+        assert st.conn.execute(
+            "select count(*) from raw_records where kind='RosterWalled'"
+        ).fetchone()[0] == 0
+        assert res.counts["rosters"] == 1 and res.counts["enumerated"] == 1
+
+
+@pytest.mark.asyncio
+async def test_phase_stop_without_channel_context(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        ctx = _ctx(st, _gw())
+        ctx.channel_id = None
+        with pytest.raises(PhaseStop):
+            await ParticipantsCollector().collect(ctx)
+
+
+def test_applies_to_channel_like_targets():
+    assert ParticipantsCollector().applies_to(parse_target("@durov"))
+    assert not ParticipantsCollector().applies_to(parse_target("+15551234567"))

--- a/tests/test_collector_participants.py
+++ b/tests/test_collector_participants.py
@@ -460,6 +460,27 @@ async def test_oracle_wall_ends_the_oracle_loop_for_that_group(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_oracle_confirmed_members_count_toward_enumerated(tmp_path):
+    """A positive oracle answer writes the SAME kind of confirmed-member row
+    (`participants`, `member_of`) as a roster page, so it must count toward
+    the run's `enumerated` total too -- found running the Leg 3 DoD smoke:
+    the shortfall warning (built from the same, oracle-mutated `enumerated`
+    set) disagreed with `res.counts["enumerated"]`, which stopped counting
+    before the oracle ran."""
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        _seed_group_comment(st, 301, 21)
+        gw = _gw(
+            [_page(_member(2), count=3)],
+            participant={GROUP_ID: {21: _answer(21)}},
+        )
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        assert res.counts["oracle"] == 1
+        assert res.counts["enumerated"] == 2, "the roster's 1 + the oracle's confirmed 21"
+        assert res.stopped is not None and "2 of 3" in res.stopped
+
+
+@pytest.mark.asyncio
 async def test_join_flag_joins_a_left_group_then_pages_admins_and_bots(tmp_path):
     with Store.open(tmp_path / "p.sqlite") as st:
         _seed_channel(st)

--- a/tests/test_collector_participants.py
+++ b/tests/test_collector_participants.py
@@ -39,7 +39,7 @@ def _ctx(st, gw, settings=None, tier="stranger"):
 
 def _seed_channel(
     st: Store, *, linked: int | None = GROUP_ID, kind: str = "broadcast",
-    linked_flags: dict | None = None,
+    linked_flags: dict | None = None, target_flags: dict | None = None,
 ) -> None:
     raw_id = st.add_raw(
         "ChatFull", {"_": "ChatFull", "full_chat": {"id": CHANNEL_ID}}, "stranger",
@@ -47,6 +47,7 @@ def _seed_channel(
     )
     chan = {"_": "Channel", "id": CHANNEL_ID, "access_hash": 9, "title": "C", "username": "c"}
     chan["broadcast" if kind == "broadcast" else "megagroup"] = True
+    chan.update(target_flags or {})
     upsert_channel(
         st, {"_": "channelFull", "id": CHANNEL_ID, "pts": 1, "linked_chat_id": linked,
              "participants_count": 10},
@@ -911,6 +912,43 @@ async def test_broadcast_targets_own_recent_reactions_sample_is_swept(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_broadcast_with_no_linked_group_still_sweeps_its_own_recent_reactions(tmp_path):
+    """Round-3 review (blocking): a BROADCAST target with NO linked discussion
+    group — the single most common paperboy target — must still sweep its
+    own zero-RPC `recent_reactions` sample before the phase reports its full
+    skip. The previous fix moved the sweep above the `if isinstance(linked,
+    str):` block textually but the `return` for the no-comment-section case
+    was still ABOVE it, so `zero_rpc_ids` was never reached on this exact
+    path; the existing `test_broadcast_targets_own_recent_reactions_sample_is_swept`
+    never caught it because `_seed_channel`'s default `linked=GROUP_ID`
+    skipped the `return` branch entirely."""
+    reacted = {
+        "_": "MessageReactions", "results": [{"_": "ReactionCount", "count": 1, "reaction": {}}],
+        "recent_reactions": [
+            {"_": "MessagePeerReaction", "peer_id": {"_": "PeerUser", "user_id": 51},
+             "date": 1767322500, "reaction": {"_": "ReactionEmoji", "emoticon": "👍"}},
+        ],
+    }
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st, linked=None)  # broadcast target, no linked discussion group
+        post = {"_": "Message", "id": 900, "message": "post", "date": 1767322000,
+                "peer_id": {"_": "PeerChannel", "channel_id": CHANNEL_ID}, "reactions": reacted}
+        raw_id = st.add_raw("Message", post, "stranger", {"channel_id": CHANNEL_ID}, observed_at=T0)
+        upsert_message(st, CHANNEL_ID, post, raw_id, T0, "stranger")
+        gw = _gw()
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        assert res.counts["reactors"] == 1
+        assert ("tg:user:51", "reacted_to", "tg:msg:5/900") in {
+            (e["subject_uri"], e["predicate"], e["object_uri"])
+            for e in st.conn.execute("select subject_uri, predicate, object_uri from edges")
+        }
+        # the phase still reports its full skip — the fix does not change
+        # that, it only ensures the free vectors ran first.
+        assert res.stopped is not None and "zero-RPC vectors still swept" in res.stopped
+        assert gw.calls.count("get_full_channel") == 0  # still zero-RPC
+
+
+@pytest.mark.asyncio
 async def test_reaction_list_pagination_is_hard_capped_against_a_repeating_offset(tmp_path):
     """Unlike `_page` (three independent stop conditions: empty page, short
     page, no-new-members), a reaction list's only natural stop is a falsy
@@ -931,6 +969,16 @@ async def test_reaction_list_pagination_is_hard_capped_against_a_repeating_offse
         res = await ParticipantsCollector().collect(_ctx(st, gw))
         assert res.counts["reaction_lists"] == 50  # capped (`_REACTIONS_MAX_PAGES`), not 60
         assert res.stopped is None
+        # Round-3 review: a truncated reactor list is a partial observation —
+        # recorded, counted, and NOT treated as done by the next run.
+        from paperboy.store.reactions import fetched_reaction_lists
+
+        assert res.counts["skipped"] == 1
+        truncated = json.loads(st.conn.execute(
+            "select detail_json from run_events where kind='warning' order by id desc limit 1"
+        ).fetchone()[0])
+        assert (truncated["code"], truncated["msg_id"]) == ("reaction_list_truncated", 401)
+        assert fetched_reaction_lists(st, GROUP_ID) == set()
 
 
 @pytest.mark.asyncio
@@ -976,3 +1024,110 @@ async def test_user_snapshot_method_matches_the_producing_rpc(tmp_path):
         }
         assert methods["tg:user:2"] == "channels.getParticipants"
         assert methods["tg:user:21"] == "channels.getParticipant"
+
+
+@pytest.mark.asyncio
+async def test_join_flag_never_rejoins_a_megagroup_target_already_a_member(tmp_path):
+    """Round-3 review (blocking): the TARGET's roster carried no membership
+    flags, so `--join` on a megagroup target we already belong to issued an
+    active `channels.joinChannel` on EVERY run."""
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st, linked=None, kind="megagroup", target_flags={"left": False})
+        gw = FakeGateway({
+            "participants": {
+                CHANNEL_ID: {"channelParticipantsRecent": [_page(_member(2), count=1)]},
+            },
+            "join": {"_": "Updates", "updates": []},
+        })
+        for _ in range(2):
+            await ParticipantsCollector().collect(_ctx(st, gw, _settings(allow_join=True)))
+        assert "join_channel" not in gw.calls
+        joins = st.conn.execute("select count(*) from run_events where kind='join'")
+        assert joins.fetchone()[0] == 0
+        # known membership still unlocks the member-only filters
+        assert [c[1] for c in gw.participants_calls[:3]] == [
+            "channelParticipantsRecent", "channelParticipantsAdmins", "channelParticipantsBots",
+        ]
+    with Store.open(tmp_path / "q.sqlite") as st:
+        _seed_channel(st, linked=None, kind="megagroup", target_flags={"left": True})
+        gw = FakeGateway({
+            "participants": {
+                CHANNEL_ID: {"channelParticipantsRecent": [_page(_member(2), count=1)]},
+            },
+            "join": {"_": "Updates", "updates": []},
+        })
+        await ParticipantsCollector().collect(_ctx(st, gw, _settings(allow_join=True)))
+        assert gw.calls.count("join_channel") == 1  # a group we have left IS joined, once
+        joins = st.conn.execute("select count(*) from run_events where kind='join'")
+        assert joins.fetchone()[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_run_level_budgets_are_shared_across_rosters(tmp_path):
+    """Round-3 review: `participant_reactions_budget` is a per-RUN cap; a
+    megagroup target with a linked group has TWO rosters and must not spend
+    it twice."""
+    reacted = {
+        "_": "MessageReactions", "results": [{"_": "ReactionCount", "count": 1, "reaction": {}}],
+    }
+    def _list(uid: int) -> dict:
+        return {"_": "MessageReactionsList", "count": 1, "chats": [], "next_offset": None,
+                "users": [_user(uid)],
+                "reactions": [{
+                    "_": "MessagePeerReaction", "peer_id": {"_": "PeerUser", "user_id": uid},
+                    "date": 1767322500, "reaction": {"_": "ReactionEmoji", "emoticon": "x"},
+                }]}
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st, kind="megagroup", target_flags={"left": False})
+        for mid in (701, 702):
+            post = {"_": "Message", "id": mid, "message": "p", "date": 1767322000,
+                    "peer_id": {"_": "PeerChannel", "channel_id": CHANNEL_ID}, "reactions": reacted}
+            rid = st.add_raw(
+                "Message", post, "stranger", {"channel_id": CHANNEL_ID}, observed_at=T0
+            )
+            upsert_message(st, CHANNEL_ID, post, rid, T0, "stranger")
+        _seed_group_comment(st, 801, 2, reactions=reacted)
+        _seed_group_comment(st, 802, 3, reactions=reacted)
+        gw = FakeGateway({
+            "full_channel_by_id": {GROUP_ID: _group_full(left=False)},
+            "participants": {
+                CHANNEL_ID: {"channelParticipantsRecent": [_page(_member(2), count=1)]},
+                GROUP_ID: {"channelParticipantsRecent": [_page(_member(2), count=1)]},
+            },
+            "reactions": {CHANNEL_ID: {701: _list(31), 702: _list(32)},
+                          GROUP_ID: {801: _list(33), 802: _list(34)}},
+        })
+        res = await ParticipantsCollector().collect(
+            _ctx(st, gw, _settings(participant_reactions_budget=3))
+        )
+        assert res.counts["rosters"] == 2
+        assert len(gw.reactions_calls) == 3  # 2 on the target + 1 on the group, never 4
+        assert [c[0] for c in gw.reactions_calls] == [CHANNEL_ID, CHANNEL_ID, GROUP_ID]
+
+
+@pytest.mark.asyncio
+async def test_preflight_without_a_channel_object_is_walled_not_enumerated(tmp_path):
+    """Round-3 review: `broadcast`/`megagroup` live on the `Channel` object;
+    with no Channel in the chats vector the wall check could not see them,
+    so a broadcast could have been paged. Now an audited preflight wall."""
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        no_channel = {**_group_full(), "chats": []}
+        gw = _gw([_page(_member(2))], full_channel_by_id={GROUP_ID: no_channel})
+        res = await ParticipantsCollector().collect(_ctx(st, gw))
+        assert gw.participants_calls == []
+        walled = [json.loads(r[0]) for r in st.conn.execute(
+            "select payload_json from raw_records where kind='RosterWalled' order by id")]
+        assert walled[-1]["group_id"] == GROUP_ID and "no Channel object" in walled[-1]["reason"]
+        assert res.counts["walled"] == 2  # the broadcast target + the unreadable group
+
+
+@pytest.mark.asyncio
+async def test_no_access_hash_reason_names_the_running_phase(tmp_path):
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _seed_channel(st)
+        st.conn.execute("update peers set access_hash=NULL where uri='tg:channel:77'")
+        res = await ParticipantsCollector().collect(_ctx(st, _gw()))
+        assert res.stopped is not None
+        assert "participants group 77: no access hash known" in res.stopped
+        assert "discussion group" not in res.stopped

--- a/tests/test_store_reactions.py
+++ b/tests/test_store_reactions.py
@@ -78,6 +78,40 @@ def test_reacted_message_ids_newest_first_and_fetched_set(tmp_path):
         assert fetched_reaction_lists(st, GROUP_ID) == {12}
 
 
+def test_fetched_reaction_lists_excludes_a_message_truncated_mid_list(tmp_path):
+    """A message interrupted mid-list (a `HardStop`, or the participants
+    collector's hard per-message page cap) must not be reported as done just
+    because SOME page was recorded — only the MOST RECENTLY recorded page's
+    `next_offset` decides, so a later run resumes it instead of silently
+    treating a partial reactor list as complete forever (round-3 review)."""
+    with Store.open(tmp_path / "p.sqlite") as st:
+        _raw_message(st, 20, {
+            "_": "MessageReactions",
+            "results": [{"_": "ReactionCount", "count": 5, "reaction": {}}],
+        })
+        # page 1: more to come.
+        st.add_raw(
+            "messages.MessageReactionsList",
+            {"_": "MessageReactionsList", "count": 2, "reactions": [], "next_offset": "p2"},
+            "stranger", {"channel_id": GROUP_ID, "msg_id": 20, "offset": ""},
+        )
+        assert fetched_reaction_lists(st, GROUP_ID) == set()  # not done yet
+        # page 2: still truncated (e.g. the hard page cap fired here).
+        st.add_raw(
+            "messages.MessageReactionsList",
+            {"_": "MessageReactionsList", "count": 2, "reactions": [], "next_offset": "p3"},
+            "stranger", {"channel_id": GROUP_ID, "msg_id": 20, "offset": "p2"},
+        )
+        assert fetched_reaction_lists(st, GROUP_ID) == set()  # latest page STILL truncated
+        # page 3: the list actually ends.
+        st.add_raw(
+            "messages.MessageReactionsList",
+            {"_": "MessageReactionsList", "count": 2, "reactions": [], "next_offset": None},
+            "stranger", {"channel_id": GROUP_ID, "msg_id": 20, "offset": "p3"},
+        )
+        assert fetched_reaction_lists(st, GROUP_ID) == {20}
+
+
 def test_recent_reactions_never_replace_an_existing_provenance(tmp_path):
     # A reaction is not a documented inputPeerFromMessage context; the edge is
     # still recorded, but a provenance the store already holds is kept.


### PR DESCRIPTION
Leg 3 of 5 of the person layer (#41): the `participants` collector — roster discovery within Telegram's walls. Walled-broadcast record (zero enumeration RPC), linked-group `Recent` enumeration with enumerated/true_count accounting, the bounded `getParticipant` oracle (incl. the hidden-member-group fallback), `--join` → Admins ∪ Bots, bounded+resumable reaction lists, the zero-RPC service-message/reaction/#11 vectors, the per-phase session-age gate, membership/invite/reacted_to edges. Targets the dev branch `feat/person-layer` (a tier merge — Gate B is the later `feat/person-layer → main` PR). Plan: Tasks 8–9.

# DoD report — person layer LEG 3 (`participants` collector), branch `fix/person-layer-leg3-review2` @ `6a7b3af`

Base: `feat/person-layer` @ `0580a5e` (merge-base). Issue #41. Plan: `docs/superpowers/plans/2026-08-27-person-layer.md`, Tasks 8–9.

## Changes (from `git diff --name-only feat/person-layer...HEAD` — 9 files changed, 2439 insertions(+), 108 deletions(-); 6 commits: 2 plan tasks, 2 workflow review-round fixes, 1 round-3 fix, 1 round-4 fix)

Files: `src/paperboy/collectors/channel.py src/paperboy/collectors/discussion.py src/paperboy/collectors/participants.py src/paperboy/collectors/profiles.py src/paperboy/store/channels.py src/paperboy/store/peers.py src/paperboy/store/reactions.py tests/test_collector_participants.py tests/test_store_reactions.py`

- `src/paperboy/collectors/participants.py` (new) — `ParticipantsCollector` (Tasks 8+9): the walled-broadcast `RosterWalled` record with ZERO enumeration RPC against the channel; the megagroup TARGET's own hidden-participants wall recorded on the same side of the session gate; the **zero-RPC vectors** (#11 backfill, join/leave service messages, `recent_reactions`) sweep the target's own id AND the linked group **before** any early return, so a broadcast with no comment section still keeps its free reactor sample and then reports the full phase skip (`… no enumerable roster …; zero-RPC vectors still swept`); the per-phase session-age gate BEFORE any group RPC; once-per-run privacy posture via the shared helper; linked-group preflight `getFullChannel` — a peer that turns out to be a **broadcast** (`linked_chat_id` is bidirectional), a hidden roster, or a `ChatFull` with **no `Channel` object** in its chats vector is an audited wall, never paged; `Recent` paging with one roster-page-scoped `enumerated` (self reconciled into it, since Telegram's `count` includes the collecting account) used by the snapshot row, the `roster` event, the shortfall predicate AND its warning text; the `--join` shortfall warning as the phase's stopped reason; `_Roster.flags` (the stored channel flags) for target and linked group alike, so `--join` **never re-joins a group whose `left` is already `False`**; `--join` → `Recent ∪ Admins ∪ Bots` via the shared audited `join_or_skip`; `join_to_send` honoured for a roster read; the bounded `channels.getParticipant` oracle (budget applied AFTER resolvability, so a dead ref never occupies a slot; `USER_NOT_PARTICIPANT` stored as a definitive `left`); bounded `messages.getMessageReactionsList` newest-first, hard-capped at 50 pages/message with a **`reaction_list_truncated` `run_events` row + `skipped` count** when the cap fires; **run-level** `participant_oracle_budget`/`participant_reactions_budget` shared across both rosters of a megagroup-target-with-linked-group run; reaction-list peer provenance **fill-only** (never overwrites an authorship context); `admin_only_skipped` record; `_project_users_vector` records the producing RPC as `user_snapshots.method` at all four call sites.
- `src/paperboy/store/reactions.py` — `fetched_reaction_lists` treats a message as done only when its MOST RECENTLY recorded page ended the list (falsy `next_offset`), so a list truncated by a `HardStop` or the page cap is revisited by a later run instead of being complete forever.
- `src/paperboy/collectors/discussion.py` — `linked_group(ctx, phase)` / `join_or_skip(ctx, phase, group_id, input_channel)` extracted as module functions (Task 8); both name the calling phase in their reason strings.
- `src/paperboy/collectors/channel.py` — `_pick_channel` → public `pick_channel` (alias kept). `src/paperboy/store/channels.py` — `_channel_flags` → public `channel_flags` (alias kept). `src/paperboy/store/peers.py` — `upsert_full_peer(store, obj, source_raw_id, observed_at)`, shared by `participants` and `profiles`. `src/paperboy/collectors/profiles.py` — switched to `upsert_full_peer`; its duplicate static helper and unused imports removed.
- Tests: `tests/test_collector_participants.py` (new, 36 tests — the plan's Task 8/9 tests, the workflow rounds' additions, and the round-3 tests: no-linked-group broadcast still sweeps its own reactions; a megagroup target already a member is never re-joined while a left one is joined exactly once; run-level budgets shared across two rosters; a preflight with no `Channel` object is walled, not enumerated; the truncated reaction list is recorded, counted and NOT done; the no-access-hash reason names the running phase), `tests/test_store_reactions.py` (+1: truncated-mid-list message is not done until its latest page ends the list).

## Round-4 changes (`6a7b3af`) — both reviewers rejected `fb1f448`

- **One join site with a membership check** (adversarial blocker): the
  `join_to_send` branch in `collect` re-joined an already-member group on
  every run (the round-3 fix covered only `_maybe_join`). It now checks
  `channels.flags_json` (written by a prior run's preflight; unknown on run 1
  → join once) and the stored broadcast flag before joining, and marks the
  roster `prejoined` so the two join sites are mutually exclusive.
- **Hidden-group oracle/reaction fallback** (correctness blocker):
  `_roster_wall_reason` now returns `(reason, terminal)`; a
  `participants_hidden` group is bulk-only — `_enumerate` skips paging but
  runs the getParticipant oracle and the reaction-list vector (spec §5/§6.2,
  plan D9), recording the wall once.
- **Non-clobbering reaction provenance** (correctness blocker): `_reactions`
  filled a NEW peer from the response's own `users` vector (never a bare
  `min` stub, which NULLed a `min` peer's identity), and skips the write
  entirely when provenance is already known.
- Minors: a reaction list truncated by the page cap resumes from the last
  offset (converges) instead of restarting page 1; a member reached without
  `--join` gets no `--join` suggestion; the wrong-channel preflight and the
  oracle wall now record `preflight_mismatch`/`oracle_walled` events.

## Why the round-3 commit (`fb1f448`) exists

The `single-feature-run` panel rejected rounds 1–2 (round-1 blockers: linked broadcast peer enumerated/joined, reaction provenance overwriting authorship, shortfall predicate vs `count` including self — fixed in `512913d`; round-2 blockers: the no-linked-group broadcast returned before the zero-RPC sweep, and the megagroup target's roster carried no membership flags so `--join` re-joined every run) and the third re-implement agent died on a lost connection. Its uncommitted work (which already addressed both round-2 blockers, the run-level budgets, the pre-gate megagroup wall, the truncation record, the `Channel`-less preflight, the page-level reaction resume and the phase-named reason) was recovered from its worktree, reviewed, completed (`_Roster.flags` in place of a mis-typed `chan`, plus the six tests above) and landed as `fb1f448`.

## Tests (pasted, run on `6a7b3af`)

```
$ TMPDIR=/Volumes/Storage/tmp uv run pytest -q --basetemp=/Volumes/Storage/tmp/pytest-leg3
568 passed in 121.75s (0:02:01)
$ TMPDIR=/Volumes/Storage/tmp uv run pytest tests/test_collector_participants.py -q --basetemp=/Volumes/Storage/tmp/pytest-leg3
46 passed
$ uv run ruff check
All checks passed!
$ uv run pyright
0 errors, 0 warnings, 0 informations
```

`tests/test_reproject_parity.py` is in that run; its golden is unchanged (`participants` is not in the default set until Task 11).

## Smoke test transcript

**1. Running-system smoke without the network** — `recipes.collect_channel` with `[ChannelCollector(), HistoryCollector(), DiscussionCollector(), ParticipantsCollector(), ProfilesCollector()]` against `FakeGateway` fixtures into real `Store`s under `/Volumes/Storage/tmp` (driver `/Volumes/Storage/tmp/leg3_smoke.py`, run on `fb1f448` as `PYTHONPATH=/Volumes/Storage/Projects/paperboy TMPDIR=/Volumes/Storage/tmp uv run python /Volumes/Storage/tmp/leg3_smoke.py`; its own `OK:` lines and final total):

```
=== SCENARIO 1: broadcast target + linked megagroup, full coverage ===
OK: walled broadcast + linked-group enumeration + single privacy_posture row
=== SCENARIO 2: partial roster -> --join warning + bounded oracle ===
OK: shortfall warning + oracle spent exactly its 2-slot budget
=== SCENARIO 3: CHAT_ADMIN_REQUIRED on the linked group ===
OK: the group's own wall is recorded with its reason, distinct from the broadcast's
=== SCENARIO 4: session-age gate refuses without --unsafe ===
OK: gate refused before any group RPC; the service-message join still projected
=== SCENARIO 5: --join joins a left group, pages Admins+Bots; skips if already a member ===
OK: joined the left group, then paged Recent+Admins+Bots
OK: an already-member group is never re-joined, but still gets Admins+Bots
=== SCENARIO 6: reaction lists bounded per run, resumable across two runs ===
OK: reaction lists bounded to budget=2 per run, and resumable across runs
=== SCENARIO 7: a megagroup TARGET enumerates its own roster ===
OK: no linked group needed -- the megagroup target enumerates itself
=== SCENARIO 8: no linked group at all -- a full phase skip ===
OK: broadcast with no linked group -- walled once, then a full phase skip
row counts (reprojected): {'raw_records': 6262, 'peers': 160, 'messages': 5496, 'message_metrics': 4202, 'edges': 2522, 'media': 449, 'custody_log': 599, 'web_snapshots': 362}
OK: reprojected row counts match Leg 2's golden; person tables empty
SMOKE TOTAL: 8 FakeGateway scenarios + 1 offline reproject exercised and asserted OK (walled-broadcast zero-RPC, linked-group Recent enumeration+accounting, partial-roster --join warning, bounded getParticipant oracle, CHAT_ADMIN_REQUIRED wall, session-age gate + zero-RPC vectors still running, --join Admins/Bots incl. already-member skip, bounded+resumable reaction lists, megagroup self-enumeration, no-linked-group full skip, reproject parity with Leg 2's golden + empty person tables)
```

Two of the driver's expectations were stale from round 1 and were corrected to the reviewed semantics (the shortfall warning is roster-page-scoped — `1 of 300` — while the run's `enumerated` count also includes the oracle's confirmed member; the full-skip reason now says the zero-RPC vectors still swept). No collector defect was found by the smoke.

**2. Offline `paperboy reproject` of the real archive** (30,887,936-byte `data/default/paperboy.sqlite`, source read-only, zero network, zero keychain; `participants` is not detected by replay until Task 10, and `discussion.py`'s extraction is on the replay path):

```
$ uv run paperboy reproject --profile default --out /Volumes/Storage/tmp/leg3-reprojected-<time>.sqlite
  raw_records 6258 → 6262 | peers 158 → 160 | messages 5496 → 5496 | message_metrics 4020 → 4202
  edges 2503 → 2522 | media 451 → 449 | custody_log 607 → 599 | web_snapshots 362 → 362
$ sqlite3 <out> "select group_concat(name,' ') from schema_migrations;"
0001_init 0002_web 0003_run_id 0004_people
$ sqlite3 <out> "select (select count(*) from users)||' '||(select count(*) from participants)||' '||(select count(*) from participant_snapshots);"
0 0 0
```

Every count equals Leg 2's baseline digit-for-digit; the `media` phase's `phase_stop` on one legacy run is the pre-existing missing-media-file behaviour (`docs/features/reproject.md:438`).

**3. Live Telegram smoke: deferred to plan Task 12** (main thread, Keychain) — `participants` is not CLI-reachable until Task 11.

## Deviations from plan (recorded; none weakens a test)

- `_Roster` carries `flags` (the stored channel flags) instead of the plan's `chan` object; `--join` reads `left` from it for the target and the linked group alike.
- The zero-RPC sweep includes the target's own id and runs before the no-linked-group full skip (the plan's collector ran it for the linked group only, after the early return).
- Run-level oracle/reactions budgets are threaded through `_enumerate` (the plan read them per roster).
- `fetched_reaction_lists` is page-aware (the plan's done-set was keyed on message id alone); a capped list is recorded as `reaction_list_truncated`.
- The linked group's `join_to_send` is honoured for a roster read via `join_or_skip` (the plan enumerated it un-joined).
- A `ChatFull` without a `Channel` in its chats vector is an audited preflight wall (the plan fell through with an empty flags dict).
- `linked_group` takes `phase` (reason strings name the running phase); `_project_users_vector` takes the producing `method`.

## Bugs found and fixed in this leg (no-shed)

- Round 1: a supergroup target enumerated — and under `--join` joined — its linked BROADCAST channel; reaction-list peer writes overwrote the author's `inputUserFromMessage` provenance; the shortfall predicate compared `enumerated` (self excluded) with Telegram's `count` (self included); oracle budget wasted on unresolvable refs; `user_snapshots.method` wrong for three of four producers — `512913d`.
- Round 2: the no-linked-group broadcast returned before the zero-RPC sweep; `--join` re-joined a megagroup target every run; budgets spent per roster instead of per run; a capped reactor list silently complete forever; a `Channel`-less preflight could page a broadcast; hidden-megagroup wall recorded on the wrong side of the gate; reason strings hard-coding "discussion" — `fb1f448`.

## Known limitations (to be stated in `docs/features/person-layer.md`, Task 12)

- A reaction list truncated by the 50-page cap resumes from the last recorded offset across runs, converging over ceil(reactors / (50·page)) runs; a genuinely unbounded server list is the only non-converging case.
- Roster paging depth is Telegram's (spec §6.3): `enumerated / true_count` is recorded every run and a shortfall is labelled, never presented as completeness.

## Follow-ups (orthogonal)

- None new. #44 (`.gitignore`) stands.

## Reviewer Verdict — adversarial-reviewer (Opus), on `6a7b3af`
PASS (round 4). Independently re-ran the full suite
(`TMPDIR=/Volumes/Storage/tmp uv run pytest -q --basetemp=/Volumes/Storage/tmp/pytest-adv3`
→ 568 passed, 0 failed/skipped; matches the DoD), the participants + reactions files
(45 passed), `ruff check` (clean) and `pyright` (0 errors). Confirmed `git diff
fb1f448..6a7b3af -- tests/` adds 5 tests and removes no assertions.

Re-probed round-3's blocker and both minors at the root:
- join_to_send `collect` branch now gates on `_already_member` + `_stored_group_flags`
  and marks the roster `prejoined`; an already-member group is joined exactly once
  across 3 runs (self-probe: `[[77],[],[]]`, 1 audited join), never double-joined in a
  run, and a linked broadcast is never joined (real ChannelCollector stores it as
  `{broadcast:true}`; the pathological broadcast+join_to_send stub is refused).
- Cap-truncated reaction lists resume from the last recorded `next_offset`
  (`reaction_resume_offsets`) and converge to `done` with every reactor accumulated
  (self-probe with an offset-honouring server: 50→100→130 over 3 runs).
- Correctness's fixes verified in passing: a hidden-member group builds a roster that
  runs the oracle + reaction fallback without paging; the oracle wall is recorded
  (`oracle_walled`); reaction provenance is non-clobbering (fill-from-rich-user, never a
  bare min stub over an existing identity).

No skipped or weakened tests, swallowed errors, stubbed returns, cast-to-None, masked
root causes, missing edge cases, or dishonest DoD claims found.

## Reviewer Verdict — correctness-reviewer (Opus), on `6a7b3af`
PASS (re-review). Traced the full `git diff fb1f448..6a7b3af` and re-verified both prior
blocking findings against a real `Store`:
- **Reaction provenance no longer clobbers identity.** `_reactions` indexes the response's
  `users`/`chats` vectors; a new reactor is filled from the rich object, a reactor with
  existing provenance is not re-written (only `#12`-guarded + edge). Verified for a min
  reactor in the vector, a pre-provenanced peer, and a reactor absent from the vector.
- **Hidden-member group runs the oracle + reaction fallback.** A
  `participants_hidden`/`can_view_participants=false` roster is walled bulk-only
  (`bulk_walled`), so `_enumerate` pages nothing but runs `_oracle` (with a correct empty
  `enumerated` set) and `_reactions`; the wall is recorded exactly once (raw/snapshot/event
  = 1 per group), for both a linked group and a hidden megagroup target.
- **Minors addressed:** no `--join` suggestion to an existing member; >50-page reactor lists
  converge across runs via `reaction_resume_offsets`; `preflight_mismatch`/`oracle_walled`
  are now stored run_events.
Full suite: 568 passed. No test assertion removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01748NEmbdPayBnjfQJaqNDV
