### PR TITLE
feat(reproject): replay + wiring for the person layer (leg 4)

### DIFF
--- a/src/paperboy/cli.py
+++ b/src/paperboy/cli.py
@@ -16,7 +16,7 @@ from rich.console import Console
 from rich.table import Table
 
 from paperboy import app as composition
-from paperboy.config import Settings, load_settings, profile_dir
+from paperboy.config import Settings, load_settings, parse_duration, profile_dir
 from paperboy.doctor import doctor_blocks, run_doctor
 from paperboy.export.jsonl import export_jsonl
 from paperboy.ids import channel_uri
@@ -135,7 +135,8 @@ def collect(
     target: str,
     profile: str = typer.Option("default", "--profile"),
     phases: str = typer.Option(
-        None, "--phases", help="Comma-separated: channel,history,discussion,graph,web,media"
+        None, "--phases",
+        help="Comma-separated: channel,history,discussion,participants,profiles,graph,web,media",
     ),
     join: bool = typer.Option(
         False, "--join",
@@ -151,6 +152,19 @@ def collect(
     profile_budget: int = typer.Option(None, "--profile-budget"),
     max_rpc: int = typer.Option(None, "--max-rpc"),
     unsafe: bool = typer.Option(False, "--unsafe", help="Skip the doctor preflight gate."),
+    profiles: bool = typer.Option(
+        False, "--profiles",
+        help="Run FULL profile enrichment (getFullUser, photo history, avatar download) on top of "
+             "the always-on getUsers triage — ~1 RPC/s, bounded by --profile-budget.",
+    ),
+    profile_interval: float = typer.Option(
+        None, "--profile-interval",
+        help="Seconds between full-profile RPCs (default: Budget's 1.0s).",
+    ),
+    profile_refresh_after: str = typer.Option(
+        None, "--profile-refresh-after",
+        help="Skip re-enriching users enriched more recently than this (e.g. 7d, 12h, 30m).",
+    ),
 ) -> None:
     """Collect channel metadata, full message history, and the discovery/
     relationship graph for TARGET."""
@@ -165,7 +179,23 @@ def collect(
         overrides["profile_budget"] = profile_budget
     if max_rpc is not None:
         overrides["max_rpc_per_run"] = max_rpc
+    if profiles:
+        overrides["enrich_profiles"] = True
+    if profile_interval is not None:
+        overrides["profile_interval"] = profile_interval
+    if profile_refresh_after is not None:
+        try:
+            overrides["profile_refresh_after"] = parse_duration(profile_refresh_after)
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc), param_hint="--profile-refresh-after") from None
+    if unsafe:
+        overrides["unsafe"] = True
     settings = load_settings(profile, overrides)
+    if settings.enrich_profiles:
+        console.print(
+            "[yellow]--profiles enabled: full profile enrichment (getFullUser, photo history, "
+            f"avatars) will run for up to {settings.profile_budget} users this run.[/]"
+        )
 
     configure_logging(profile_dir(settings, profile) / "paperboy.log", console=True)
     log = logging.getLogger("paperboy.cli")
@@ -173,7 +203,7 @@ def collect(
     secrets = composition.build_secrets(profile)
     phase_list = phases.split(",") if phases else None
     _dependent_phases = [
-        p for p in ("history", "discussion", "graph", "media", "web")
+        p for p in ("history", "discussion", "participants", "profiles", "graph", "media", "web")
         if phase_list and p in phase_list
     ]
     if phase_list is not None and _dependent_phases and "channel" not in phase_list:
@@ -201,7 +231,7 @@ def collect(
         results = _run_async_or_exit(
             _run_collect(
                 settings, secrets, profile, store, parsed_target,
-                phase_list, log, unsafe, media, web,
+                phase_list, log, media, web,
             )
         )
 
@@ -215,10 +245,10 @@ def collect(
 
 
 async def _run_collect(
-    settings, secrets, profile, store, target, phase_list, log, unsafe, media, web
+    settings, secrets, profile, store, target, phase_list, log, media, web
 ):
     gateway = await composition.build_gateway(settings, secrets, profile, store)
-    if not unsafe:
+    if not settings.unsafe:
         checks = await run_doctor(gateway, settings)
         if doctor_blocks(checks):
             console.print(
@@ -274,6 +304,8 @@ def status(
             table.add_row("messages", str(count("SELECT count(*) FROM messages")))
             table.add_row("peers", str(count("SELECT count(*) FROM peers")))
             table.add_row("edges", str(count("SELECT count(*) FROM edges")))
+            table.add_row("users", str(count("SELECT count(*) FROM users")))
+            table.add_row("participants", str(count("SELECT count(*) FROM participants")))
         console.print(table)
 
 

--- a/src/paperboy/progress.py
+++ b/src/paperboy/progress.py
@@ -51,6 +51,11 @@ def phase_status(store: Store, phase: str) -> str:
             return f"{count('SELECT count(*) FROM messages')} messages"
         if phase == "graph":
             return f"{count('SELECT count(*) FROM edges')} edges"
+        if phase == "participants":
+            return f"{count('SELECT count(*) FROM participants')} members"
+        if phase == "profiles":
+            enriched = count("SELECT count(*) FROM users WHERE enriched_at IS NOT NULL")
+            return f"{count('SELECT count(*) FROM users')} users · {enriched} enriched"
         if phase == "media":
             files = count("SELECT count(*) FROM media")
             size = count("SELECT coalesce(sum(size), 0) FROM media")

--- a/src/paperboy/recipes.py
+++ b/src/paperboy/recipes.py
@@ -4,14 +4,18 @@ Runs `channel` (which populates `CollectContext.input_channel`/`channel_id`/
 `tier` for everything after it), then `history` (backfill, immediately
 followed by one `pts` catch-up so the channel's sync state is current as of
 *now*, not as of whenever backfill started — both folded into one `history`
-CollectResult), then `graph` (similar-channel recommendations, entity-derived
+CollectResult), then `discussion` (linked-group comment threads), then
+`participants` (roster membership) and `profiles` (cheap `getUsers` triage
+of every discovered person, full `getFullUser` enrichment only under
+`--profiles`), then `graph` (similar-channel recommendations, entity-derived
 mentions, invite-link previews, sponsored-message provenance — consumes
 `history`'s stored messages / `channel`'s context). `media` (download +
 content-address every stored message's media) and `web` (`t.me/s/` + Wayback
 CDX capture over plain HTTP — no `Gateway`/`Budget`, a different trust
 boundary) are OPT-IN — off by default, on via `collect_channel(..., media=True
-/ web=True)` or by naming them in `phases`. `graph` runs by default; all of
-`graph`/`media`/`web` run after `history` so they have messages to walk.
+/ web=True)` or by naming them in `phases`. `discussion`/`participants`/
+`profiles`/`graph` all run by default; every phase after `channel` runs
+after `history` so it has messages to walk.
 `SkipAndRecord` and `PhaseStop` are each recorded and that phase's result is
 marked stopped, but later phases still run; `HardStop` is recorded and the
 whole run ends there (spec §8). A `run_events` row is written for every phase.
@@ -31,6 +35,8 @@ from paperboy.collectors.discussion import DiscussionCollector
 from paperboy.collectors.graph import GraphCollector
 from paperboy.collectors.history import HistoryCollector
 from paperboy.collectors.media import MediaCollector
+from paperboy.collectors.participants import ParticipantsCollector
+from paperboy.collectors.profiles import ProfilesCollector
 from paperboy.collectors.web import WebCollector
 from paperboy.progress import Progress
 from paperboy.store.events import record_run_event
@@ -46,12 +52,14 @@ if TYPE_CHECKING:
 
 def _default_collectors(*, include_media: bool, include_web: bool) -> list[Collector]:
     # The default set is all-MTProto and cheap-ish: channel + history + graph.
-    # `media` (heavy downloads) and `web` (external HTTP to t.me/archive.org —
-    # a different trust boundary than the authenticated MTProto session) are
-    # OPT-IN (--media / --web, or named in --phases), so a plain `collect`
-    # stays Telegram-only: metadata + history + graph.
+    # `participants` (roster) and `profiles` (cheap `getUsers` triage; full
+    # enrichment only under `--profiles`) are default-on too: read-only and
+    # bounded. `media` (heavy downloads) and `web` (external HTTP to
+    # t.me/archive.org — a different trust boundary than the authenticated
+    # MTProto session) are OPT-IN (--media / --web, or named in --phases).
     collectors: list[Collector] = [
         ChannelCollector(), HistoryCollector(), DiscussionCollector(),
+        ParticipantsCollector(), ProfilesCollector(),
         GraphCollector(),
     ]
     if include_web:

--- a/src/paperboy/replay.py
+++ b/src/paperboy/replay.py
@@ -22,6 +22,7 @@ import httpx
 
 from paperboy.budget import SkipAndRecord
 from paperboy.clock import ReplayClock
+from paperboy.gateway import REPLAY_UNKNOWN_USER_KIND
 from paperboy.store.db import dumps
 from paperboy.targets import parse_target
 
@@ -295,6 +296,18 @@ class ReplaySource:
             for cid in channel_ids
         )
 
+    def has_context_value(self, run: ReplayRun, key: str, value: object) -> bool:
+        """Whether any raw record in `run` carries `value` under context
+        `key` (e.g. `method` = `users.getUsers`) — for phase detection of
+        kinds that are NOT distinctive on their own (a `User` record is also
+        the self marker). The path is a bound parameter, like every other
+        query in this module."""
+        return self.conn.execute(
+            "SELECT 1 FROM raw_records WHERE json_extract(context_json, ?) = ? "
+            "AND id BETWEEN ? AND ? LIMIT 1",
+            (f"$.{key}", value, run.lo, run.hi),
+        ).fetchone() is not None
+
 
 class RawReplayGateway:
     """`Gateway` served from a raw log, scoped to ONE historical `ReplayRun`
@@ -482,8 +495,18 @@ class RawReplayGateway:
         raise SkipAndRecord("replay: doctor state is not recorded; reproject never runs doctor")
 
     async def get_privacy(self, key: str) -> dict:
-        del key
-        raise SkipAndRecord("replay: doctor state is not recorded; reproject never runs doctor")
+        # `profiles`/`participants` record the account's own posture once per
+        # run (spec §4.3, `posture.py`) — that IS a recorded observation
+        # (unlike `doctor`'s own reads, which are never recorded).
+        row = self._latest(
+            ("account.privacyrules", "privacyrules"),
+            "json_extract(context_json, '$.key') = ?", (key,),
+        )
+        if row is None:
+            raise SkipAndRecord(
+                "replay: privacy posture not recorded for this run; reproject never runs doctor"
+            )
+        return self._serve(row)
 
     async def download_media(self, input_channel: dict, message: dict) -> bytes | None:
         row = self._latest(
@@ -564,42 +587,111 @@ class RawReplayGateway:
             messages.append(json.loads(row["payload_json"]))
         return {"_": "SponsoredMessages", "messages": messages}
 
-    # Person-layer replay methods (`participants`/`profiles`, spec §10) —
-    # deliberately UNIMPLEMENTED here. This leg (person-layer plan Tasks
-    # 1-5) only grows the `Gateway` Protocol so `TelethonGateway`/
-    # `FakeGateway` can serve these seven methods; the replay-side
-    # implementation (7 replay methods + `get_privacy` serving + phase
-    # detection, plan Task 10) is a later leg. `reproject.py`'s current
-    # collector list never calls these — `ParticipantsCollector`/
-    # `ProfilesCollector` are not wired into it until that same later leg —
-    # so a stub that fails loudly if ever reached (rather than one that
-    # silently returns an empty result) is the honest placeholder: it keeps
-    # `RawReplayGateway` a structural `Gateway` for pyright without
-    # pretending replay support exists yet.
+    # Person-layer replay methods (`participants`/`profiles`, spec §10),
+    # served by the raw kinds/contexts those two collectors record (plan D1).
+
     async def get_participants(
         self, input_channel: dict, filter: dict, offset: int, limit: int, hash_: int = 0
     ) -> dict:
-        raise NotImplementedError("participants replay lands in a later person-layer leg (Task 10)")
+        del limit, hash_
+        row = self._latest(
+            ("channels.channelparticipants", "channels.channelparticipantsnotmodified"),
+            "json_extract(context_json, '$.channel_id') = ? "
+            "AND json_extract(context_json, '$.filter') = ? "
+            "AND json_extract(context_json, '$.offset') = ?",
+            (input_channel["channel_id"], filter.get("_"), offset),
+        )
+        if row is None:
+            raise SkipAndRecord(
+                f"replay: no {filter.get('_')} page at offset {offset} recorded for "
+                f"channel {input_channel['channel_id']}"
+            )
+        return self._serve(row)
 
     async def get_participant(self, input_channel: dict, participant: dict) -> dict | None:
-        raise NotImplementedError("participants replay lands in a later person-layer leg (Task 10)")
+        row = self._latest(
+            ("channels.channelparticipant", "usernotparticipant"),
+            "json_extract(context_json, '$.channel_id') = ? "
+            "AND json_extract(context_json, '$.user_id') = ?",
+            (input_channel["channel_id"], participant["user_id"]),
+        )
+        if row is None:
+            raise SkipAndRecord(
+                f"replay: no getParticipant answer recorded for user {participant['user_id']}"
+            )
+        payload = self._serve(row)
+        # The definitive negative was stored as a synthetic record (plan D4);
+        # served so the clock has its stamp, then returned as the None it was.
+        return None if (payload.get("_") or "").lower() == "usernotparticipant" else payload
 
     async def get_users(self, refs: list[dict]) -> list[dict]:
-        raise NotImplementedError("profiles replay lands in a later person-layer leg (Task 10)")
+        self._clock.begin_batch()
+        out: list[dict] = []
+        for ref in refs:
+            row = self._latest(
+                ("user", "userempty"),
+                "json_extract(context_json, '$.method') = 'users.getUsers' "
+                "AND json_extract(context_json, '$.user_id') = ?",
+                (ref["user_id"],),
+            )
+            if row is None:
+                # D4.1's analogue: a placeholder the collector ignores — never
+                # a synthetic UserEmpty, which would fabricate a "deleted
+                # account" observation the original run never made.
+                out.append({"_": REPLAY_UNKNOWN_USER_KIND, "id": ref["user_id"]})
+                continue
+            self._clock.serve_json(row["observed_at"], row["payload_json"])
+            out.append(json.loads(row["payload_json"]))
+        return out
 
     async def get_full_user(self, ref: dict) -> dict:
-        raise NotImplementedError("profiles replay lands in a later person-layer leg (Task 10)")
+        row = self._latest(("users.userfull",),
+                           "json_extract(context_json, '$.user_id') = ?", (ref["user_id"],))
+        if row is None:
+            raise SkipAndRecord(f"replay: no UserFull recorded for user {ref['user_id']}")
+        return self._serve(row)
 
     async def get_user_photos(self, ref: dict, *, offset: int, max_id: int, limit: int) -> dict:
-        raise NotImplementedError("profiles replay lands in a later person-layer leg (Task 10)")
+        del offset, max_id, limit
+        row = self._latest(("photos.photos", "photos.photosslice"),
+                           "json_extract(context_json, '$.user_id') = ?", (ref["user_id"],))
+        if row is None:
+            raise SkipAndRecord(f"replay: no photo history recorded for user {ref['user_id']}")
+        return self._serve(row)
 
     async def download_user_photo(self, photo: dict) -> bytes | None:
-        raise NotImplementedError("profiles replay lands in a later person-layer leg (Task 10)")
+        row = self._latest(("avatardownload",),
+                           "json_extract(context_json, '$.photo_id') = ?", (photo["id"],))
+        if row is None:
+            return None
+        payload = json.loads(row["payload_json"])
+        sha = payload["sha256"]
+        path = Path(payload["path"])
+        if not path.exists():  # noqa: ASYNC240 — same rationale as download_media
+            path = self._src.media_root / sha[:2] / f"{sha}.jpg"
+        if not path.exists():
+            raise SkipAndRecord(f"replay: avatar file missing for sha {sha}")
+        data = path.read_bytes()
+        self._clock.begin_batch()
+        self._clock.serve_json(row["observed_at"], row["payload_json"])
+        return data
 
     async def get_message_reactions_list(
         self, input_channel: dict, msg_id: int, *, offset: str | None, limit: int
     ) -> dict:
-        raise NotImplementedError("participants replay lands in a later person-layer leg (Task 10)")
+        del limit
+        row = self._latest(
+            ("messages.messagereactionslist",),
+            "json_extract(context_json, '$.channel_id') = ? "
+            "AND json_extract(context_json, '$.msg_id') = ? "
+            "AND json_extract(context_json, '$.offset') = ?",
+            (input_channel["channel_id"], msg_id, offset or ""),
+        )
+        if row is None:
+            raise SkipAndRecord(
+                f"replay: no reaction list recorded for message {msg_id} at offset {offset!r}"
+            )
+        return self._serve(row)
 
 
 class RawReplayWebClient:

--- a/src/paperboy/reproject.py
+++ b/src/paperboy/reproject.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sqlite3
 from dataclasses import dataclass
 
 from paperboy.clock import ReplayClock
@@ -238,9 +239,25 @@ async def reproject(
 
     counts = {
         t: (
-            source.conn.execute(f"SELECT count(*) FROM {t}").fetchone()[0],
+            _table_count(source.conn, t),
             out_store.conn.execute(f"SELECT count(*) FROM {t}").fetchone()[0],
         )
         for t in REPROJECT_TABLES
     }
     return ReprojectSummary(phases_seen, results, counts)
+
+
+def _table_count(conn: sqlite3.Connection, table: str) -> int:
+    """Row count of `table` in a SOURCE connection, or 0 if the table doesn't
+    exist there yet. The source is strictly read-only (never migrated —
+    `ReplaySource`'s own docstring), so an archive captured before a table's
+    migration landed (e.g. a pre-person-layer archive has no `users`) must
+    read as 0 rows, not crash this purely-diagnostic summary — the same
+    schema-evolution tolerance `ReplaySource.__init__`'s `_has_run_id` check
+    already applies to `raw_records.run_id`."""
+    exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    ).fetchone() is not None
+    if not exists:
+        return 0
+    return conn.execute(f"SELECT count(*) FROM {table}").fetchone()[0]

--- a/src/paperboy/reproject.py
+++ b/src/paperboy/reproject.py
@@ -15,6 +15,8 @@ from paperboy.collectors.discussion import DiscussionCollector
 from paperboy.collectors.graph import GraphCollector
 from paperboy.collectors.history import HistoryCollector
 from paperboy.collectors.media import MediaCollector
+from paperboy.collectors.participants import ParticipantsCollector
+from paperboy.collectors.profiles import ProfilesCollector
 from paperboy.collectors.web import WebCollector
 from paperboy.config import Settings
 from paperboy.recipes import collect_channel
@@ -31,6 +33,7 @@ REPROJECT_TABLES = (
     "raw_records", "channels", "channel_snapshots", "peers", "messages",
     "message_revisions", "message_metrics", "message_tombstones", "edges",
     "media", "custody_log", "web_snapshots",
+    "users", "user_snapshots", "user_photos", "participants", "participant_snapshots",
 )
 
 
@@ -107,6 +110,14 @@ def detect_phases(source: ReplaySource, run: ReplayRun) -> list[str]:
     if linked and source.has_context_channel(run, linked):
         phases.append("discussion")
     if source.has_kind(
+        run, "channels.channelparticipants", "channels.channelparticipant", "rosterwalled",
+        "usernotparticipant", "messages.messagereactionslist",
+    ):
+        phases.append("participants")
+    if source.has_context_value(run, "method", "users.getUsers") \
+            or source.has_kind(run, "users.userfull"):
+        phases.append("profiles")
+    if source.has_kind(
         run, "chats", "chatsslice", "chatinvite", "chatinvitealready",
         "chatinvitepeek", "sponsoredmessage",
     ):
@@ -138,16 +149,32 @@ async def reproject(
     runs = source.runs()
     if not runs:
         raise ReprojectError("source raw log is empty — nothing to reproject")
-    # allow_join=True so a source whose original run used --join replays its
-    # discussion sweep; RawReplayGateway.join_channel is a synthetic no-op
-    # (D4.3) — nothing is joined, nothing leaves this machine.
-    replay_settings = settings.model_copy(update={"allow_join": True})
 
     results: dict[str, list[CollectResult]] = {}
     phases_seen: list[str] = []
     replayed_any = False
     for run in runs:
         _reset_incremental_backfill_state(out_store)
+        # Per-run replay settings (plan D6): allow_join=True so a source whose
+        # original run used --join replays its discussion sweep
+        # (RawReplayGateway.join_channel is a synthetic no-op, D4.3 — nothing
+        # is joined, nothing leaves this machine); unsafe=True because the
+        # session-age gate has no RPC to protect on replay; enrich_profiles
+        # follows THIS run's own raw (a --profiles original replays its
+        # UserFull records, a triage-only original replays triage-only,
+        # warning included); and the three person-layer budgets are lifted to
+        # effectively unlimited — the live budget already bounded what was
+        # RECORDED, so a smaller replay budget would silently drop recorded
+        # observations past the cut (replay walks the same deterministic
+        # candidate order and serves every recorded observation; an
+        # unrecorded candidate is a cheap offline SkipAndRecord that projects
+        # nothing).
+        replay_settings = settings.model_copy(update={
+            "allow_join": True, "unsafe": True,
+            "enrich_profiles": source.has_kind(run, "users.userfull"),
+            "profile_budget": 10**9, "participant_oracle_budget": 10**9,
+            "participant_reactions_budget": 10**9,
+        })
         run_phases = phases if phases is not None else detect_phases(source, run)
         for p in run_phases:
             if p not in phases_seen:
@@ -173,6 +200,7 @@ async def reproject(
             web_client = RawReplayWebClient(source, clock, run)
             collectors = [
                 ChannelCollector(), HistoryCollector(), DiscussionCollector(),
+                ParticipantsCollector(), ProfilesCollector(),
                 GraphCollector(),
                 WebCollector(client=web_client, min_interval=0.0, sleep=lambda s: None),
                 MediaCollector(),

--- a/tests/fixtures/reproject/parity_golden.json
+++ b/tests/fixtures/reproject/parity_golden.json
@@ -56,7 +56,7 @@
    "object_uri": "tg:username:sponsorchannel",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "predicate": "mentions",
-   "source_raw_id": 10,
+   "source_raw_id": 11,
    "subject_uri": "tg:channel:5",
    "tier": "stranger"
   },
@@ -66,7 +66,7 @@
    "object_uri": "tg:channel:501",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "predicate": "recommended_with",
-   "source_raw_id": 9,
+   "source_raw_id": 10,
    "subject_uri": "tg:channel:5",
    "tier": "stranger"
   },
@@ -76,7 +76,7 @@
    "object_uri": "tg:channel:502",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "predicate": "recommended_with",
-   "source_raw_id": 9,
+   "source_raw_id": 10,
    "subject_uri": "tg:channel:5",
    "tier": "stranger"
   }
@@ -230,6 +230,23 @@
    "via_bot_id": null
   }
  ],
+ "participant_snapshots": [
+  {
+   "enumerated": 0,
+   "group_id": 5,
+   "id": 1,
+   "join_date": null,
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "rank": null,
+   "reason": "broadcast_channel: subscriber roster is never enumerable below admin (CHAT_ADMIN_REQUIRED for every filter)",
+   "source_raw_id": 9,
+   "status": null,
+   "subscription_until_date": null,
+   "true_count": 100,
+   "uri": null
+  }
+ ],
+ "participants": [],
  "peers": [
   {
    "access_hash": 1001,
@@ -243,7 +260,7 @@
    "last_seen": "2026-01-01T00:00:00+00:00",
    "seen_in_chat": null,
    "seen_in_msg": null,
-   "source_raw_id": 9,
+   "source_raw_id": 10,
    "title": "Similar One",
    "uri": "tg:channel:501",
    "username": "similarone"
@@ -260,7 +277,7 @@
    "last_seen": "2026-01-01T00:00:00+00:00",
    "seen_in_chat": null,
    "seen_in_msg": null,
-   "source_raw_id": 9,
+   "source_raw_id": 10,
    "title": "Similar Two",
    "uri": "tg:channel:502",
    "username": "similartwo"
@@ -286,7 +303,7 @@
  "raw_records": [
   {
    "context_json": "{\"channel_id\": 5, \"msg_id\": 2}",
-   "id": 14,
+   "id": 15,
    "kind": "MediaDownload",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"file_name\": \"a.txt\", \"kind\": \"document\", \"message_uri\": \"tg:msg:5/2\", \"mime_type\": \"text/plain\", \"path\": \"<DATA_DIR>/default/media/7b/7bb6f9f7a47a63e684925af3608c059edcc371eb81188c48c9714896fb1091fd.txt\", \"sha256\": \"7bb6f9f7a47a63e684925af3608c059edcc371eb81188c48c9714896fb1091fd\", \"size\": 13}",
@@ -296,6 +313,15 @@
   {
    "context_json": "{\"channel_id\": 5}",
    "id": 10,
+   "kind": "ChatsSlice",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "payload_json": "{\"_\": \"ChatsSlice\", \"chats\": [{\"_\": \"Channel\", \"access_hash\": 1001, \"broadcast\": true, \"id\": 501, \"title\": \"Similar One\", \"username\": \"similarone\"}, {\"_\": \"Channel\", \"access_hash\": 1002, \"broadcast\": true, \"id\": 502, \"title\": \"Similar Two\", \"username\": \"similartwo\"}], \"count\": 37}",
+   "run_id": "run-0001",
+   "tier": "stranger"
+  },
+  {
+   "context_json": "{\"channel_id\": 5}",
+   "id": 11,
    "kind": "SponsoredMessage",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"_\": \"SponsoredMessage\", \"additional_info\": \"Promoted\", \"button_text\": \"View\", \"message\": \"Check this out\", \"random_id\": \"AAAAAAAA\", \"sponsor_info\": \"Acme Corp\", \"title\": \"Sponsor Title\", \"url\": \"https://t.me/sponsorchannel\"}",
@@ -359,18 +385,9 @@
   {
    "context_json": "{\"channel_id\": 5}",
    "id": 9,
-   "kind": "ChatsSlice",
+   "kind": "RosterWalled",
    "observed_at": "2026-01-01T00:00:00+00:00",
-   "payload_json": "{\"_\": \"ChatsSlice\", \"chats\": [{\"_\": \"Channel\", \"access_hash\": 1001, \"broadcast\": true, \"id\": 501, \"title\": \"Similar One\", \"username\": \"similarone\"}, {\"_\": \"Channel\", \"access_hash\": 1002, \"broadcast\": true, \"id\": 502, \"title\": \"Similar Two\", \"username\": \"similartwo\"}], \"count\": 37}",
-   "run_id": "run-0001",
-   "tier": "stranger"
-  },
-  {
-   "context_json": "{\"channel_username\": \"durov\"}",
-   "id": 11,
-   "kind": "tme_page",
-   "observed_at": "2026-01-01T00:00:00+00:00",
-   "payload_json": "{\"status_code\": 200, \"text\": \"<html><body>\\n<div class=\\\"tgme_widget_message\\\" data-post=\\\"durov/1\\\">\\n  <div class=\\\"tgme_widget_message_text\\\">m1</div>\\n  <time datetime=\\\"2026-01-01T00:00:00+00:00\\\"></time>\\n</div>\\n</body></html>\", \"url\": \"https://t.me/s/durov\"}",
+   "payload_json": "{\"_\": \"RosterWalled\", \"enumerated\": 0, \"group_id\": 5, \"participants_count\": 100, \"reason\": \"broadcast_channel: subscriber roster is never enumerable below admin (CHAT_ADMIN_REQUIRED for every filter)\"}",
    "run_id": "run-0001",
    "tier": "stranger"
   },
@@ -379,13 +396,22 @@
    "id": 12,
    "kind": "tme_page",
    "observed_at": "2026-01-01T00:00:00+00:00",
-   "payload_json": "{\"status_code\": 200, \"text\": \"<html><body></body></html>\", \"url\": \"https://t.me/s/durov?before=1\"}",
+   "payload_json": "{\"status_code\": 200, \"text\": \"<html><body>\\n<div class=\\\"tgme_widget_message\\\" data-post=\\\"durov/1\\\">\\n  <div class=\\\"tgme_widget_message_text\\\">m1</div>\\n  <time datetime=\\\"2026-01-01T00:00:00+00:00\\\"></time>\\n</div>\\n</body></html>\", \"url\": \"https://t.me/s/durov\"}",
    "run_id": "run-0001",
    "tier": "stranger"
   },
   {
    "context_json": "{\"channel_username\": \"durov\"}",
    "id": 13,
+   "kind": "tme_page",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "payload_json": "{\"status_code\": 200, \"text\": \"<html><body></body></html>\", \"url\": \"https://t.me/s/durov?before=1\"}",
+   "run_id": "run-0001",
+   "tier": "stranger"
+  },
+  {
+   "context_json": "{\"channel_username\": \"durov\"}",
+   "id": 14,
    "kind": "wayback_cdx",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "payload_json": "{\"status_code\": 200, \"text\": \"[[\\\"urlkey\\\", \\\"timestamp\\\", \\\"original\\\", \\\"mimetype\\\", \\\"statuscode\\\", \\\"digest\\\", \\\"length\\\"], [\\\"me,t)/s/durov\\\", \\\"20260101000000\\\", \\\"https://t.me/s/durov\\\", \\\"text/html\\\", \\\"200\\\", \\\"DIGEST1\\\", \\\"1234\\\"]]\", \"url\": \"https://web.archive.org/cdx/search/cdx?url=t.me/s/durov*&output=json&filter=statuscode:200&collapse=digest&limit=10000\"}",
@@ -414,6 +440,30 @@
  "run_events": [
   {
    "channel_id": 5,
+   "detail_json": "{\"code\": \"profiles_enrichment_off\", \"hint\": \"--profiles\", \"triaged\": 0}",
+   "id": 7,
+   "kind": "warning",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "phase": "profiles"
+  },
+  {
+   "channel_id": 5,
+   "detail_json": "{\"counts\": {\"avatars\": 0, \"backfilled_peers\": 0, \"empty\": 0, \"enriched\": 0, \"fresh_skipped\": 0, \"gathered\": 0, \"photos\": 0, \"photos_empty\": 0, \"refreshed\": 0, \"restricted_skipped\": 0, \"skipped\": 0, \"snapshots\": 0, \"triaged\": 0, \"unavailable\": 0, \"unresolvable\": 0}, \"stopped\": null}",
+   "id": 8,
+   "kind": "complete",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "phase": "profiles"
+  },
+  {
+   "channel_id": 5,
+   "detail_json": "{\"counts\": {\"backfilled_peers\": 0, \"edges\": 0, \"enumerated\": 0, \"oracle\": 0, \"participants\": 0, \"reaction_lists\": 0, \"reactors\": 0, \"rosters\": 0, \"service_joins\": 0, \"service_leaves\": 0, \"skipped\": 0, \"true_count\": 0, \"users\": 0, \"walled\": 1}, \"stopped\": \"no linked discussion group \u2014 no enumerable roster (a broadcast channel's subscribers are never enumerable); zero-RPC vectors still swept\"}",
+   "id": 5,
+   "kind": "complete",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "phase": "participants"
+  },
+  {
+   "channel_id": 5,
    "detail_json": "{\"counts\": {\"backfilled_peers\": 0, \"edges\": 0, \"messages\": 0, \"revisions\": 0, \"tombstones\": 0, \"unmapped\": 0}, \"stopped\": \"no linked discussion group\"}",
    "id": 3,
    "kind": "complete",
@@ -431,7 +481,7 @@
   {
    "channel_id": 5,
    "detail_json": "{\"counts\": {\"deleted_recovered\": 0, \"tme_posts\": 1, \"wayback_rows\": 1}, \"stopped\": null}",
-   "id": 5,
+   "id": 10,
    "kind": "complete",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "phase": "web"
@@ -439,7 +489,7 @@
   {
    "channel_id": 5,
    "detail_json": "{\"counts\": {\"downloaded\": 1, \"duplicates\": 0, \"skipped\": 0, \"skipped_kind\": 0, \"unavailable\": 0}, \"stopped\": null}",
-   "id": 6,
+   "id": 11,
    "kind": "complete",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "phase": "media"
@@ -455,10 +505,26 @@
   {
    "channel_id": 5,
    "detail_json": "{\"counts\": {\"edges\": 4, \"peers\": 2, \"raw\": 2, \"skipped\": 0}, \"stopped\": null}",
-   "id": 4,
+   "id": 9,
    "kind": "complete",
    "observed_at": "2026-01-01T00:00:00+00:00",
    "phase": "graph"
+  },
+  {
+   "channel_id": 5,
+   "detail_json": "{\"group_id\": 5, \"participants_count\": 100, \"reason\": \"broadcast_channel: subscriber roster is never enumerable below admin (CHAT_ADMIN_REQUIRED for every filter)\"}",
+   "id": 4,
+   "kind": "roster_walled",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "phase": "participants"
+  },
+  {
+   "channel_id": 5,
+   "detail_json": "{\"lastseen\": {\"unavailable\": \"fake: no privacy fixture for 'lastseen'\"}, \"phone\": {\"unavailable\": \"fake: no privacy fixture for 'phone'\"}, \"photo\": {\"unavailable\": \"fake: no privacy fixture for 'photo'\"}}",
+   "id": 6,
+   "kind": "privacy_posture",
+   "observed_at": "2026-01-01T00:00:00+00:00",
+   "phase": "profiles"
   }
  ],
  "sync_ranges": [
@@ -486,9 +552,19 @@
    "value_json": "{\"backfill_complete\": true, \"incremental_in_progress\": false, \"max_id_seen\": 3, \"pending_high\": 3}"
   },
   {
+   "key": "5",
+   "scope": "profiles",
+   "value_json": "{\"budget\": 2000, \"enriched_this_run\": 0, \"fully_enriched\": 0, \"pass\": \"triage_only\", \"population\": 0}"
+  },
+  {
    "key": "durov",
    "scope": "web_tme",
    "value_json": "{\"newest_seen\": 1}"
+  },
+  {
+   "key": "privacy_posture",
+   "scope": "account",
+   "value_json": "{\"posture\": {\"lastseen\": {\"unavailable\": \"fake: no privacy fixture for 'lastseen'\"}, \"phone\": {\"unavailable\": \"fake: no privacy fixture for 'phone'\"}, \"photo\": {\"unavailable\": \"fake: no privacy fixture for 'photo'\"}}, \"run_id\": \"run-0001\"}"
   },
   {
    "key": "self",
@@ -496,6 +572,9 @@
    "value_json": "{\"id\": 1, \"uri\": \"tg:user:1\"}"
   }
  ],
+ "user_photos": [],
+ "user_snapshots": [],
+ "users": [],
  "web_snapshots": [
   {
    "channel_username": "durov",

--- a/tests/test_integration_discussion.py
+++ b/tests/test_integration_discussion.py
@@ -49,6 +49,8 @@ _GATEWAY_READ_METHODS = frozenset({
     "get_channel_difference", "get_self", "get_authorizations",
     "get_password_state", "get_privacy", "download_media",
     "get_channel_recommendations", "check_chat_invite", "get_sponsored_messages",
+    "get_participants", "get_participant", "get_users", "get_full_user",
+    "get_user_photos", "download_user_photo", "get_message_reactions_list",
 })
 
 

--- a/tests/test_integration_people.py
+++ b/tests/test_integration_people.py
@@ -1,0 +1,134 @@
+"""Default-set + --profiles gating (spec §11), read-only guardrail, CLI wiring."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from collections import Counter
+
+import pytest
+from typer.testing import CliRunner
+
+from paperboy import app as composition
+from paperboy.cli import app as cli_app
+from paperboy.config import load_settings
+from paperboy.recipes import collect_channel
+from paperboy.store.db import Store
+from paperboy.targets import parse_target
+from tests.fakes import FakeGateway
+from tests.test_integration_discussion import _GATEWAY_READ_METHODS
+from tests.test_reproject_people import GROUP_ID, people_fixtures
+
+runner = CliRunner()
+
+
+@pytest.mark.asyncio
+async def test_plain_collect_runs_both_person_phases_but_never_getfulluser(tmp_path):
+    gw = FakeGateway(people_fixtures())
+    with Store.open(tmp_path / "p.sqlite") as st:
+        results = await collect_channel(
+            gw, st, load_settings("default", {"data_dir": tmp_path, "unsafe": True}),
+            parse_target("@c"), phases=None, log=logging.getLogger("t"),
+        )
+        assert [r.name for r in results] == [
+            "channel", "history", "discussion", "participants", "profiles", "graph",
+        ]
+        assert gw.full_user_calls == [] and gw.user_photos_calls == [] and gw.avatar_calls == []
+        assert gw.calls.count("get_users") >= 1  # triage IS default-on
+        assert st.conn.execute("select count(*) from participants").fetchone()[0] >= 2
+        warning = st.conn.execute(
+            "select detail_json from run_events where phase='profiles' and kind='warning'"
+        ).fetchone()
+        assert json.loads(warning["detail_json"])["code"] == "profiles_enrichment_off"
+        assert set(gw.calls) <= _GATEWAY_READ_METHODS | {"join_channel"}
+        assert "join_channel" not in gw.calls
+
+
+@pytest.mark.asyncio
+async def test_profiles_setting_enables_the_full_sweep(tmp_path):
+    gw = FakeGateway(people_fixtures())
+    settings = load_settings(
+        "default", {"data_dir": tmp_path, "unsafe": True, "enrich_profiles": True}
+    )
+    with Store.open(tmp_path / "p.sqlite") as st:
+        await collect_channel(
+            gw, st, settings, parse_target("@c"), phases=None, log=logging.getLogger("t"),
+        )
+        assert Counter(gw.calls)["get_full_user"] == 4
+        enriched = st.conn.execute(
+            "select count(*) from users where enriched_at is not null"
+        ).fetchone()[0]
+        assert enriched == 4
+
+
+def _patch_gateway(monkeypatch, captured: dict) -> None:
+    async def fake_build_gateway(settings, secrets, profile, store):
+        del secrets, profile, store
+        captured["settings"] = settings
+        return FakeGateway(people_fixtures())
+
+    monkeypatch.setattr(composition, "build_gateway", fake_build_gateway)
+
+
+def test_cli_profiles_flags_reach_settings(tmp_path, monkeypatch):
+    captured: dict = {}
+    _patch_gateway(monkeypatch, captured)
+    result = runner.invoke(
+        cli_app,
+        [
+            "collect", "@c", "--profile", "people1", "--unsafe",
+            # people to enrich need the sweeps
+            "--phases", "channel,history,discussion,participants,profiles",
+            "--profiles", "--profile-budget", "3",
+            "--profile-interval", "2.5", "--profile-refresh-after", "7d",
+        ],
+        env={"PAPERBOY_DATA_DIR": str(tmp_path)},
+    )
+    assert result.exit_code == 0, result.stdout
+    s = captured["settings"]
+    assert (
+        s.enrich_profiles, s.profile_budget, s.profile_interval,
+        s.profile_refresh_after, s.unsafe,
+    ) == (True, 3, 2.5, 7 * 86400, True)
+    assert "--profiles" in result.stdout  # the console names the expensive sweep it is about to run
+    db = sqlite3.connect(tmp_path / "people1" / "paperboy.sqlite")
+    assert db.execute("select count(*) from users where enriched_at is not null").fetchone()[0] == 3
+    db.close()
+
+
+def test_cli_rejects_a_bad_refresh_duration(tmp_path, monkeypatch):
+    _patch_gateway(monkeypatch, {})
+    result = runner.invoke(
+        cli_app,
+        ["collect", "@c", "--profile", "people2", "--unsafe", "--profile-refresh-after", "7x"],
+        env={"PAPERBOY_DATA_DIR": str(tmp_path)},
+    )
+    assert result.exit_code != 0 and "7x" in result.output
+
+
+def test_cli_participants_alone_is_rejected_and_with_channel_works(tmp_path, monkeypatch):
+    _patch_gateway(monkeypatch, {})
+    alone = runner.invoke(
+        cli_app,
+        ["collect", "@c", "--profile", "people3", "--phases", "participants", "--unsafe"],
+        env={"PAPERBOY_DATA_DIR": str(tmp_path)},
+    )
+    assert alone.exit_code == 1 and "channel" in alone.stdout.lower()
+    ok = runner.invoke(
+        cli_app,
+        ["collect", "@c", "--profile", "people4", "--phases", "channel,participants", "--unsafe"],
+        env={"PAPERBOY_DATA_DIR": str(tmp_path)},
+    )
+    assert ok.exit_code == 0, ok.stdout
+    db = sqlite3.connect(tmp_path / "people4" / "paperboy.sqlite")
+    n = db.execute(
+        "select count(*) from participants where group_id=?", (GROUP_ID,)
+    ).fetchone()[0]
+    assert n >= 2
+    db.close()
+    status = runner.invoke(
+        cli_app, ["status", "--profile", "people4"], env={"PAPERBOY_DATA_DIR": str(tmp_path)}
+    )
+    assert status.exit_code == 0
+    assert "participants" in status.stdout and "users" in status.stdout

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -28,6 +28,30 @@ def test_phase_status_reads_store(tmp_path):
         assert phase_status(st, "history") == "0 messages"
 
 
+def test_phase_status_reads_the_person_layer(tmp_path):
+    # Person-layer wiring (plan Task 11) — `participants` counts the roster,
+    # `profiles` counts both triaged and fully-`enriched_at` users. Neither
+    # branch is exercised by `test_phase_status_reads_store` above; a wrong
+    # table/column name here would be swallowed by `phase_status`'s own
+    # best-effort `except Exception: return ""` and read as a silent no-op
+    # heartbeat rather than a failure, so it needs its own direct assertion.
+    with Store.open(tmp_path / "p.sqlite") as st:
+        st.conn.execute(
+            "INSERT INTO users (uri, id, tier, enriched_at, first_seen, last_seen) "
+            "VALUES ('tg:user:1', 1, 'stranger', NULL, 't', 't')"
+        )
+        st.conn.execute(
+            "INSERT INTO users (uri, id, tier, enriched_at, first_seen, last_seen) "
+            "VALUES ('tg:user:2', 2, 'stranger', 't', 't', 't')"
+        )
+        st.conn.execute(
+            "INSERT INTO participants (group_id, uri, status, first_seen, last_seen) "
+            "VALUES (77, 'tg:user:1', 'member', 't', 't')"
+        )
+        assert phase_status(st, "participants") == "1 members"
+        assert phase_status(st, "profiles") == "2 users · 1 enriched"
+
+
 @pytest.mark.asyncio
 async def test_progress_logs_phase_start_and_end(tmp_path, caplog):
     with Store.open(tmp_path / "p.sqlite") as st:

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -76,7 +76,9 @@ async def test_collect_channel_media_flag_opts_in(tmp_path):
             phases=None, log=logging.getLogger("t"), media=True, profile="mediarecipe",
         )
         # graph is in the default set now (opt-in media appends after it)
-        assert [r.name for r in results] == ["channel", "history", "discussion", "graph", "media"]
+        assert [r.name for r in results] == [
+            "channel", "history", "discussion", "participants", "profiles", "graph", "media",
+        ]
         media_result = next(r for r in results if r.name == "media")
         assert media_result.counts["downloaded"] == 1
         assert st.conn.execute("select count(*) as n from media").fetchone()["n"] == 1
@@ -113,10 +115,10 @@ def test_default_collectors_web_is_opt_in():
     # not in the default set. Running it end to end needs a mocked WebClient
     # (see tests/test_collector_web.py), not a real network call.
     assert [c.name for c in _default_collectors(include_media=False, include_web=False)] == [
-        "channel", "history", "discussion", "graph",
+        "channel", "history", "discussion", "participants", "profiles", "graph",
     ]
     assert [c.name for c in _default_collectors(include_media=False, include_web=True)] == [
-        "channel", "history", "discussion", "graph", "web",
+        "channel", "history", "discussion", "participants", "profiles", "graph", "web",
     ]
 
 
@@ -132,6 +134,14 @@ def test_discussion_runs_by_default_immediately_after_history():
     until plan Task 4 registers `DiscussionCollector`."""
     names = [c.name for c in _default_collectors(include_media=False, include_web=False)]
     assert names.index("discussion") == names.index("history") + 1
+
+
+def test_person_layer_is_default_on_right_after_discussion():
+    # Design spec §6 recipe slot: channel -> history -> discussion ->
+    # participants -> profiles -> graph. Both are DEFAULT-ON (person-layer spec §1).
+    names = [c.name for c in _default_collectors(include_media=False, include_web=False)]
+    assert names.index("participants") == names.index("discussion") + 1
+    assert names.index("profiles") == names.index("participants") + 1
 
 
 class _StubCollector:

--- a/tests/test_replay_people.py
+++ b/tests/test_replay_people.py
@@ -1,0 +1,180 @@
+"""`RawReplayGateway` serves the person layer's raw kinds back (spec §10)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from paperboy.budget import SkipAndRecord
+from paperboy.clock import ReplayClock
+from paperboy.gateway import FILTER_RECENT
+from paperboy.replay import RawReplayGateway, ReplaySource
+from paperboy.store.db import Store
+
+GROUP_ID = 77
+IC = {"channel_id": GROUP_ID, "access_hash": 4242}
+T1 = "2026-01-01T00:00:01+00:00"
+T2 = "2026-01-01T00:00:02+00:00"
+
+
+def _seed(tmp_path: Path) -> tuple[Path, Path]:
+    db = tmp_path / "src.sqlite"
+    media_root = tmp_path / "media"
+    with Store.open(db) as st:
+        st.begin_run("r1")
+        st.add_raw(
+            "User", {"_": "User", "id": 1, "is_self": True}, "self", None, observed_at=T1
+        )
+        st.add_raw(
+            "ResolvedPeer",
+            {"_": "ResolvedPeer", "peer": {"_": "PeerChannel", "channel_id": 5},
+             "chats": [], "users": []},
+            "stranger", {"target": "@x"}, observed_at=T1,
+        )
+        page = {
+            "_": "ChannelParticipants", "count": 2,
+            "participants": [{"_": "ChannelParticipant", "user_id": 11}],
+            "chats": [], "users": [],
+        }
+        st.add_raw(
+            "channels.ChannelParticipants", page, "stranger",
+            {"channel_id": GROUP_ID, "filter": "channelParticipantsRecent", "offset": 0},
+            observed_at=T1,
+        )
+        st.add_raw(
+            "channels.ChannelParticipant",
+            {"_": "ChannelParticipant", "participant": {"_": "ChannelParticipant", "user_id": 12},
+             "chats": [], "users": []},
+            "stranger", {"channel_id": GROUP_ID, "user_id": 12}, observed_at=T1,
+        )
+        st.add_raw(
+            "UserNotParticipant", {"_": "UserNotParticipant", "user_id": 13}, "stranger",
+            {"channel_id": GROUP_ID, "user_id": 13}, observed_at=T2,
+        )
+        st.add_raw(
+            "User", {"_": "User", "id": 11, "first_name": "A"}, "stranger",
+            {"channel_id": 5, "method": "users.getUsers", "user_id": 11}, observed_at=T1,
+        )
+        st.add_raw(
+            "UserEmpty", {"_": "UserEmpty", "id": 14}, "stranger",
+            {"channel_id": 5, "method": "users.getUsers", "user_id": 14}, observed_at=T1,
+        )
+        st.add_raw(
+            "users.UserFull",
+            {"_": "UserFull", "full_user": {"_": "UserFull", "id": 11, "about": "bio"},
+             "chats": [], "users": [{"_": "User", "id": 11}]},
+            "stranger", {"channel_id": 5, "user_id": 11, "method": "users.getFullUser"},
+            observed_at=T2,
+        )
+        photos = {
+            "_": "Photos",
+            "photos": [{"_": "Photo", "id": 701, "access_hash": 1, "file_reference": "AQ==",
+                        "date": 1767322445, "dc_id": 2, "sizes": [], "video_sizes": None}],
+            "users": [],
+        }
+        st.add_raw(
+            "photos.Photos", photos, "stranger",
+            {"channel_id": 5, "user_id": 11, "method": "photos.getUserPhotos"}, observed_at=T2,
+        )
+        sha = "ab" * 32
+        avatar_path = media_root / "ab" / f"{sha}.jpg"
+        avatar_path.parent.mkdir(parents=True)
+        avatar_path.write_bytes(b"jpeg")
+        st.add_raw(
+            "AvatarDownload",
+            {"sha256": sha, "path": str(tmp_path / "elsewhere" / f"{sha}.jpg"),
+             "size": 4, "user_uri": "tg:user:11", "photo_id": 701},
+            "stranger", {"channel_id": 5, "user_id": 11, "photo_id": 701}, observed_at=T2,
+        )
+        st.add_raw(
+            "messages.MessageReactionsList",
+            {"_": "MessageReactionsList", "count": 1, "reactions": [],
+             "chats": [], "users": [], "next_offset": "p2"},
+            "stranger", {"channel_id": GROUP_ID, "msg_id": 40, "offset": ""}, observed_at=T1,
+        )
+        st.add_raw(
+            "account.PrivacyRules",
+            {"_": "account.PrivacyRules", "rules": [], "chats": [], "users": []},
+            "self", {"key": "phone"}, observed_at=T1,
+        )
+    return db, media_root
+
+
+def _gateway(tmp_path):
+    db, media_root = _seed(tmp_path)
+    src = ReplaySource.open(db, media_root)
+    clock = ReplayClock()
+    return RawReplayGateway(src, clock, src.runs()[0]), clock
+
+
+@pytest.mark.asyncio
+async def test_participants_served_by_channel_filter_offset(tmp_path):
+    gw, clock = _gateway(tmp_path)
+    page = await gw.get_participants(IC, FILTER_RECENT, 0, 200)
+    assert page["participants"][0]["user_id"] == 11
+    assert clock.for_payload(page) == T1
+    with pytest.raises(SkipAndRecord):
+        await gw.get_participants(IC, FILTER_RECENT, 200, 200)
+    with pytest.raises(SkipAndRecord):
+        await gw.get_participants(IC, {"_": "channelParticipantsAdmins"}, 0, 200)
+
+
+@pytest.mark.asyncio
+async def test_participant_oracle_serves_answers_and_definitive_negatives(tmp_path):
+    gw, clock = _gateway(tmp_path)
+    answer = await gw.get_participant(IC, {"user_id": 12, "access_hash": 1})
+    assert answer is not None and answer["participant"]["user_id"] == 12
+    assert await gw.get_participant(IC, {"user_id": 13, "access_hash": 1}) is None
+    assert clock.for_payload({"_": "UserNotParticipant", "user_id": 13}) == T2
+    with pytest.raises(SkipAndRecord):
+        await gw.get_participant(IC, {"user_id": 99, "access_hash": 1})
+
+
+@pytest.mark.asyncio
+async def test_get_users_serves_per_id_with_placeholders_for_unknown(tmp_path):
+    gw, clock = _gateway(tmp_path)
+    users = await gw.get_users([
+        {"user_id": 11, "access_hash": 1},
+        {"user_id": 14, "access_hash": 1},
+        {"user_id": 99, "access_hash": 1},
+    ])
+    assert [u["_"] for u in users] == ["User", "UserEmpty", "ReplayUnknownUser"]
+    assert users[2]["id"] == 99
+    assert clock.for_payload(users[0]) == T1
+
+
+@pytest.mark.asyncio
+async def test_full_user_photos_and_avatar_bytes(tmp_path):
+    gw, clock = _gateway(tmp_path)
+    full = await gw.get_full_user({"user_id": 11, "access_hash": 1})
+    assert full["full_user"]["about"] == "bio" and clock.for_payload(full) == T2
+    photos = await gw.get_user_photos(
+        {"user_id": 11, "access_hash": 1}, offset=0, max_id=0, limit=100
+    )
+    assert photos["photos"][0]["id"] == 701
+    # bytes come from THIS source's media root even though the stored path is foreign
+    assert await gw.download_user_photo(photos["photos"][0]) == b"jpeg"
+    assert await gw.download_user_photo({"id": 999}) is None
+    with pytest.raises(SkipAndRecord):
+        await gw.get_full_user({"user_id": 99, "access_hash": 1})
+
+
+@pytest.mark.asyncio
+async def test_reaction_lists_by_msg_and_offset_and_privacy_by_key(tmp_path):
+    gw, _ = _gateway(tmp_path)
+    first = await gw.get_message_reactions_list(IC, 40, offset=None, limit=100)
+    assert first["next_offset"] == "p2"
+    with pytest.raises(SkipAndRecord):
+        await gw.get_message_reactions_list(IC, 40, offset="p2", limit=100)
+    assert (await gw.get_privacy("phone"))["rules"] == []
+    with pytest.raises(SkipAndRecord):
+        await gw.get_privacy("photo")
+
+
+def test_has_context_value(tmp_path):
+    db, media_root = _seed(tmp_path)
+    src = ReplaySource.open(db, media_root)
+    run = src.runs()[0]
+    assert src.has_context_value(run, "method", "users.getUsers")
+    assert not src.has_context_value(run, "method", "nope")

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -65,6 +65,34 @@ def test_cli_reproject_writes_fresh_db_and_prints_diff(tmp_path, monkeypatch):
     assert "channels" in result.output and "messages" in result.output
 
 
+def test_cli_reproject_source_predating_person_layer_reports_zero_not_crash(tmp_path, monkeypatch):
+    # A real archive captured before migration 0004_people.sql existed has no
+    # `users`/`participants`/... tables at all — `ReplaySource` is strictly
+    # read-only and never migrates the source (same rationale as its own
+    # `_has_run_id` check for `raw_records.run_id`), so the row-count summary
+    # must read those as 0 rather than crash with "no such table" (found
+    # running the Leg 4 DoD smoke against the real archive).
+    db = asyncio.run(run_full_collect(tmp_path))
+    conn = sqlite3.connect(db)
+    for table in ("users", "user_snapshots", "user_photos", "participants",
+                  "participant_snapshots", "profile_attempts"):
+        conn.execute(f"DROP TABLE {table}")
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    assert "users" in result.output
+    out_db = tmp_path / "default" / "paperboy.reprojected.sqlite"
+    assert out_db.exists()
+    # the reprojected DB is freshly migrated, so IT has the table (0 rows —
+    # nothing in this source's raw ever recorded a person-layer observation).
+    rep = sqlite3.connect(out_db)
+    assert rep.execute("select count(*) from users").fetchone()[0] == 0
+    rep.close()
+
+
 def test_cli_reproject_refuses_existing_out(tmp_path, monkeypatch):
     asyncio.run(run_full_collect(tmp_path))
     monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -292,6 +292,11 @@ ROUND_TRIP_EXCLUDE = {
     "media": set(),
     "custody_log": {"id"},
     "web_snapshots": {"id"},
+    "users": {"source_raw_id"},
+    "user_snapshots": {"id", "source_raw_id"},
+    "user_photos": {"id", "source_raw_id"},
+    "participants": {"source_raw_id"},
+    "participant_snapshots": {"id", "source_raw_id"},
 }
 
 

--- a/tests/test_reproject_parity.py
+++ b/tests/test_reproject_parity.py
@@ -34,6 +34,7 @@ PARITY_TABLES = (
     "message_revisions", "message_metrics", "message_tombstones", "edges",
     "media", "custody_log", "web_snapshots", "sync_state", "sync_ranges",
     "run_events",
+    "users", "user_snapshots", "user_photos", "participants", "participant_snapshots",
 )
 
 
@@ -148,7 +149,10 @@ async def run_full_collect(
         await collect_channel(
             FakeGateway(fixtures), store, settings,
             parse_target("@durov"),
-            phases=["channel", "history", "discussion", "graph", "web", "media"],
+            phases=[
+                "channel", "history", "discussion", "participants", "profiles",
+                "graph", "web", "media",
+            ],
             log=logging.getLogger("parity"), collectors=collectors,
         )
     return db
@@ -160,7 +164,14 @@ def dump_db(conn, data_dir: Path, tables=PARITY_TABLES) -> dict[str, list]:
 
     `raw_records.run_id` (ADR-0005) is a random uuid4 hex per process, so it
     is normalized to `run-0001`, `run-0002`, ... in order of first appearance
-    (by raw rowid) — otherwise the golden would be non-reproducible.
+    (by raw rowid) — otherwise the golden would be non-reproducible. The SAME
+    raw run id also gets embedded verbatim in `sync_state('account',
+    'privacy_posture').value_json['run_id']` (posture.py's once-per-run
+    marker, person-layer plan) — normalized through the identical mapping so
+    it renders as the same `run-NNNN` label rather than a fresh random hex
+    every process. `raw_records` is dumped first (it heads `PARITY_TABLES`),
+    so every run id `sync_state` could reference is already mapped by the
+    time this branch runs.
     """
     prefix = str(data_dir)
     run_ids: dict[str, str] = {}
@@ -182,6 +193,11 @@ def dump_db(conn, data_dir: Path, tables=PARITY_TABLES) -> dict[str, list]:
             }
             if table == "raw_records":
                 d["run_id"] = _norm_run_id(d["run_id"])
+            elif table == "sync_state" and d.get("scope") == "account" \
+                    and d.get("key") == "privacy_posture":
+                value = json.loads(d["value_json"])
+                value["run_id"] = _norm_run_id(value.get("run_id"))
+                d["value_json"] = json.dumps(value, sort_keys=True)
             rows.append(d)
         out[table] = sorted(rows, key=lambda d: json.dumps(d, sort_keys=True, default=str))
     return out

--- a/tests/test_reproject_people.py
+++ b/tests/test_reproject_people.py
@@ -1,0 +1,268 @@
+"""Spec §11: round-trip identity extends to the person layer — collect ->
+reproject -> users/participants/snapshots/photos identical, one and two runs,
+--profiles and triage-only."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from paperboy.cli import app
+from paperboy.collectors.channel import ChannelCollector
+from paperboy.collectors.discussion import DiscussionCollector
+from paperboy.collectors.graph import GraphCollector
+from paperboy.collectors.history import HistoryCollector
+from paperboy.collectors.participants import ParticipantsCollector
+from paperboy.collectors.profiles import ProfilesCollector
+from paperboy.config import load_settings
+from paperboy.recipes import collect_channel
+from paperboy.replay import ReplaySource
+from paperboy.reproject import detect_phases
+from paperboy.store.db import Store
+from paperboy.targets import parse_target
+from tests.fakes import FakeGateway
+from tests.test_reproject import assert_round_trip
+
+runner = CliRunner()
+CHANNEL_ID = 5
+GROUP_ID = 77
+PHASES = ["channel", "history", "discussion", "participants", "profiles", "graph"]
+
+
+def _user(uid: int, **extra) -> dict:
+    return {
+        "_": "User", "id": uid, "access_hash": uid * 10, "first_name": f"U{uid}",
+        "username": f"u{uid}", "phone": None, "photo": None,
+        "status": {"_": "UserStatusRecently", "by_me": None},
+        "restriction_reason": [], "usernames": [], **extra,
+    }
+
+
+def _photo(pid: int) -> dict:
+    return {
+        "_": "Photo", "id": pid, "access_hash": 1, "file_reference": "AQ==",
+        "date": 1767322445, "dc_id": 2,
+        "sizes": [{"_": "PhotoSize", "type": "x", "w": 640, "h": 640, "size": 1}],
+        "video_sizes": None,
+    }
+
+
+def people_fixtures() -> dict:
+    chan = {
+        "_": "Channel", "id": CHANNEL_ID, "access_hash": 99, "title": "C", "username": "c",
+        "broadcast": True,
+    }
+    group = {
+        "_": "Channel", "id": GROUP_ID, "access_hash": 4242, "title": "C Chat",
+        "megagroup": True, "left": True,
+    }
+    reacted = {
+        "_": "MessageReactions", "results": [{"_": "ReactionCount", "count": 1, "reaction": {}}],
+        "recent_reactions": [{
+            "_": "MessagePeerReaction", "peer_id": {"_": "PeerUser", "user_id": 12},
+            "date": 1767322500, "reaction": {"_": "ReactionEmoji", "emoticon": "👍"},
+        }],
+    }
+    return {
+        "self": {"_": "user", "id": 1, "self": True},
+        "resolve": {
+            "peer": {"_": "PeerChannel", "channel_id": CHANNEL_ID}, "chats": [chan], "users": [],
+        },
+        "full_channel": {
+            "full_chat": {"_": "channelFull", "id": CHANNEL_ID, "participants_count": 10,
+                          "pts": 1, "linked_chat_id": GROUP_ID},
+            "chats": [chan, group], "users": [],
+        },
+        "full_channel_by_id": {
+            GROUP_ID: {
+                "full_chat": {"_": "channelFull", "id": GROUP_ID, "participants_count": 3,
+                              "pts": 1, "can_view_participants": True,
+                              "participants_hidden": False},
+                "chats": [group], "users": [],
+            },
+        },
+        "history": [
+            {"_": "message", "id": 3, "message": "comment", "date": 1767322445,
+             "from_id": {"_": "PeerUser", "user_id": 12}, "reactions": reacted,
+             "reply_to": {"_": "MessageReplyHeader", "reply_to_msg_id": 2, "reply_to_top_id": 2}},
+            {"_": "message", "id": 2, "message": "", "date": 1767322445,
+             "fwd_from": {"_": "MessageFwdHeader", "channel_post": 1,
+                          "from_id": {"_": "PeerChannel", "channel_id": CHANNEL_ID}}},
+            {"_": "message", "id": 1, "message": "post", "date": 1767322400,
+             "fwd_from": {"_": "MessageFwdHeader", "from_id": {"_": "PeerUser", "user_id": 15}}},
+        ],
+        "channel_difference": {"_": "updates.channelDifferenceEmpty", "final": True, "pts": 1},
+        "get_messages": {},
+        "participants": {
+            GROUP_ID: {"channelParticipantsRecent": [
+                {"_": "ChannelParticipants", "count": 3, "chats": [],
+                 "users": [_user(11), _user(13)],
+                 "participants": [
+                     {"_": "ChannelParticipant", "user_id": 11, "date": 1735689600, "rank": None,
+                      "subscription_until_date": None},
+                     {"_": "ChannelParticipantAdmin", "user_id": 13, "promoted_by": 13,
+                      "date": 1735689600, "admin_rights": {"_": "ChatAdminRights"}, "rank": "mod",
+                      "is_self": None, "inviter_id": None},
+                 ]},
+            ]},
+        },
+        "participant": {
+            GROUP_ID: {
+                12: None,
+                15: {"_": "ChannelParticipant", "chats": [], "users": [_user(15)],
+                     "participant": {"_": "ChannelParticipant", "user_id": 15, "date": 1735689700,
+                                     "rank": None, "subscription_until_date": None}},
+            },
+        },
+        "reactions": {
+            GROUP_ID: {
+                3: {"_": "MessageReactionsList", "count": 1, "chats": [], "next_offset": None,
+                    "users": [_user(12)],
+                    "reactions": [{
+                        "_": "MessagePeerReaction", "peer_id": {"_": "PeerUser", "user_id": 12},
+                        "date": 1767322500,
+                        "reaction": {"_": "ReactionEmoji", "emoticon": "👍"},
+                    }]},
+            },
+        },
+        "users": {11: _user(11), 12: _user(12, phone="+15550001212"), 13: _user(13), 15: _user(15)},
+        "full_user": {
+            11: {"_": "UserFull", "chats": [], "users": [_user(11)],
+                 "full_user": {"_": "UserFull", "id": 11, "about": "bio 11",
+                               "common_chats_count": 0,
+                               "fallback_photo": {"_": "Photo", "id": 5}}},
+            12: {"_": "UserFull", "chats": [], "users": [_user(12, phone="+15550001212")],
+                 "full_user": {"_": "UserFull", "id": 12, "about": None,
+                               "common_chats_count": 1}},
+            13: {"_": "UserFull", "chats": [], "users": [_user(13)],
+                 "full_user": {"_": "UserFull", "id": 13, "about": "bio 13",
+                               "common_chats_count": 0}},
+            15: {"_": "UserFull", "chats": [], "users": [_user(15)],
+                 "full_user": {"_": "UserFull", "id": 15, "about": None,
+                               "common_chats_count": 0}},
+        },
+        "user_photos": {11: {"_": "PhotosSlice", "count": 1, "photos": [_photo(701)], "users": []}},
+        "avatar": {701: b"jpeg-bytes"},
+        "privacy": {
+            k: {"_": "account.PrivacyRules", "rules": [{"_": "PrivacyValueAllowContacts"}],
+                "chats": [], "users": []}
+            for k in ("phone", "lastseen", "photo")
+        },
+        "channel_recommendations": {"_": "messages.chats", "chats": []},
+        "sponsored_messages": {"_": "messages.sponsoredMessagesEmpty"},
+        "chat_invite": {},
+    }
+
+
+async def run_people_collect(data_dir: Path, *, enrich: bool = True, mutate=None) -> Path:
+    settings = load_settings(
+        "default", {"data_dir": data_dir, "unsafe": True, "enrich_profiles": enrich}
+    )
+    db = data_dir / "default" / "paperboy.sqlite"
+    fixtures = people_fixtures()
+    if mutate is not None:
+        fixtures = mutate(fixtures)
+    collectors = [
+        ChannelCollector(), HistoryCollector(), DiscussionCollector(),
+        ParticipantsCollector(), ProfilesCollector(), GraphCollector(),
+    ]
+    with Store.open(db) as store:
+        await collect_channel(
+            FakeGateway(fixtures), store, settings, parse_target("@c"), phases=PHASES,
+            log=logging.getLogger("people"), collectors=collectors,
+        )
+    return db
+
+
+def _reproject(tmp_path, monkeypatch) -> Path:
+    monkeypatch.setenv("PAPERBOY_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["reproject", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    return tmp_path / "default" / "paperboy.reprojected.sqlite"
+
+
+def test_people_round_trip_identity(tmp_path, monkeypatch):
+    db1 = asyncio.run(run_people_collect(tmp_path))
+    src = sqlite3.connect(db1)
+    # the fixture really exercised every vector before we trust the identity.
+    # 11, 13 come from the roster page; 12 comes from the oracle (referenced
+    # in the GROUP's own thread, per D9) as a definitive `left`. 15 is only
+    # ever referenced as a forward-origin on the TARGET channel's own post —
+    # `backfill_message_referenced_peers` is fill-only (store/message_peers.py)
+    # and the target channel is scoped before the linked group, so 15's peer
+    # keeps `seen_in_chat=CHANNEL_ID` and is never a candidate for GROUP_ID's
+    # oracle; it is still enriched below via the peers-wide profiles sweep.
+    assert src.execute("select count(*) from participants").fetchone()[0] == 3
+    assert (
+        src.execute("select count(*) from users where enriched_at is not null").fetchone()[0]
+        == 4
+    )
+    assert (
+        src.execute("select count(*) from user_photos where sha256 is not null").fetchone()[0]
+        == 1
+    )
+    # 2, not 1: FakeGateway.iter_history serves the same fixture history to
+    # BOTH the target channel and the linked group (this fake has no
+    # per-channel history), so message id=3 is stored as two distinct
+    # message URIs (tg:msg:5/3 and tg:msg:77/3) — the zero-RPC
+    # `recent_reactions` sample projects a `reacted_to` edge per message URI.
+    assert (
+        src.execute("select count(*) from edges where predicate='reacted_to'").fetchone()[0]
+        == 2
+    )
+    assert (
+        src.execute("select count(*) from raw_records where kind='RosterWalled'").fetchone()[0]
+        == 1
+    )
+    src.close()
+    out = _reproject(tmp_path, monkeypatch)
+    assert_round_trip(db1, out)
+
+
+def test_two_run_people_round_trip(tmp_path, monkeypatch):
+    asyncio.run(run_people_collect(tmp_path))
+
+    def second(fx: dict) -> dict:
+        fx = {**fx, "users": {**fx["users"], 11: _user(11, first_name="Renamed")}}
+        fx["user_photos"] = {
+            11: {"_": "PhotosSlice", "count": 2, "photos": [_photo(702), _photo(701)], "users": []},
+        }
+        fx["avatar"] = {**fx["avatar"], 702: b"new-avatar"}
+        return fx
+
+    db1 = asyncio.run(run_people_collect(tmp_path, mutate=second))
+    src = sqlite3.connect(db1)
+    assert src.execute(
+        "select count(*) from user_snapshots where uri='tg:user:11' and method='users.getUsers'"
+    ).fetchone()[0] == 2
+    assert src.execute(
+        "select count(*) from user_photos where uri='tg:user:11'"
+    ).fetchone()[0] == 2
+    src.close()
+    assert_round_trip(db1, _reproject(tmp_path, monkeypatch))
+
+
+def test_triage_only_source_reprojects_triage_only(tmp_path, monkeypatch):
+    db1 = asyncio.run(run_people_collect(tmp_path, enrich=False))
+    out = _reproject(tmp_path, monkeypatch)
+    assert_round_trip(db1, out)
+    rep = sqlite3.connect(out)
+    assert rep.execute(
+        "select count(*) from users where enriched_at is not null"
+    ).fetchone()[0] == 0
+    assert rep.execute(
+        "select count(*) from raw_records where kind='users.UserFull'"
+    ).fetchone()[0] == 0
+    rep.close()
+
+
+def test_detect_phases_sees_the_person_layer(tmp_path):
+    db = asyncio.run(run_people_collect(tmp_path))
+    src = ReplaySource.open(db, tmp_path / "default" / "media")
+    phases = detect_phases(src, src.runs()[0])
+    assert phases.index("participants") == phases.index("discussion") + 1
+    assert phases.index("profiles") == phases.index("participants") + 1


### PR DESCRIPTION
Linked to #41.

## Changes
Branch `feat/person-layer-leg4` (worktree `.claude/worktrees/wf_b6068e51-774-1`), on top of `feat/person-layer` @ 4404209. Three commits already on the branch when I started validating (`dc6c0ac` wiring, `47555a7` replay, `63254b0` a self-found fix), plus one I added during validation (`2493d60`):

- `src/paperboy/replay.py` — `ReplaySource.has_context_value`; `RawReplayGateway.get_privacy` now serves a recorded `account.PrivacyRules`; the 7 person-layer methods (`get_participants`, `get_participant`, `get_users`, `get_full_user`, `get_user_photos`, `download_user_photo`, `get_message_reactions_list`) replace their `NotImplementedError` stubs, served from the raw kinds/contexts `participants`/`profiles` record.
- `src/paperboy/reproject.py` — `detect_phases` adds `participants`/`profiles`; `REPROJECT_TABLES` += the 5 person tables; per-run replay `Settings` (plan D6: `allow_join`/`unsafe` on, `enrich_profiles` from whether *this* run recorded `users.UserFull`, the 3 person-layer budgets lifted to 10**9); `ParticipantsCollector`/`ProfilesCollector` added to the reproject collector list; `_table_count` added (queries `sqlite_master` first) so a source predating migration `0004_people.sql` reads missing person tables as 0 instead of crashing — this was a real bug the branch's own `63254b0` already found and fixed by running its own DoD smoke against a real archive, before I started.
- `src/paperboy/recipes.py` — `_default_collectors` gains `ParticipantsCollector()`, `ProfilesCollector()` between `discussion` and `graph`; module + inline docstrings updated.
- `src/paperboy/cli.py` — `collect` gains `--profiles`/`--profile-interval`/`--profile-refresh-after`; `--unsafe` now also sets `Settings.unsafe` (the doctor gate in `_run_collect` reads `settings.unsafe` instead of a separate parameter); `--phases` help text and the channel-dependency gate extended with `participants`/`profiles`; `status` adds `users`/`participants` rows.
- `src/paperboy/progress.py` — `phase_status` gains `participants` (`"N members"`) and `profiles` (`"N users · M enriched"`) branches.
- Tests: `tests/test_replay_people.py` (new, 6 tests), `tests/test_reproject_people.py` (new, 4 tests — round-trip identity, two-run, triage-only, phase detection), `tests/test_integration_people.py` (new, 5 tests — default-set gating, CLI flag wiring), extensions to `test_recipe.py`, `test_integration_discussion.py`, `test_reproject.py` (+ the pre-existing-fix regression test), `test_reproject_parity.py` (+ `PARITY_TABLES`, + a run-id normalization fix for `sync_state('account','privacy_posture')` so the golden is reproducible), `tests/fixtures/reproject/parity_golden.json` regenerated — diffed by hand, purely additive (one `RosterWalled` raw record, `participant_snapshots`/`run_events`/`sync_state` rows for the new phases; every pre-existing row's content unchanged, only row-id renumbering from the one inserted record).
- **Found and fixed during this validation pass**: `tests/test_progress.py` — `phase_status`'s two new branches (`participants`, `profiles`) were implemented but never exercised by any test. `phase_status` swallows any query error into `""` (its own best-effort contract for the heartbeat), so a wrong table/column name would have read as a silent no-op rather than a failing test. I verified the implementation directly (see transcript) — it's correct — and added `test_phase_status_reads_the_person_layer` to pin it. Committed as `2493d60`.

## Tests
- unit: 574 passed
- integration: 11 passed (`test_integration_discussion.py`, `test_integration_people.py`, `test_smoke.py`)
- regression: 1 passed (`test_reproject_parity.py`)
- lint: pass — `ruff check` → "All checks passed!"
- type-check: pass — `pyright` → "0 errors, 0 warnings, 0 informations"
- Full suite: `uv run pytest -q` → **586 passed**, 0 failures, run twice (879s cold-cache, 102s warm-cache on this external volume — no hang, just disk-bound on first run; confirmed via `sample`/`lsof` mid-run before the notification landed).

No acceptance criteria were separately stated beyond the plan's own **Interfaces** bullets for Tasks 10-11, which I treated as the acceptance list and smoke-tested item by item below. I additionally derived and tested these edge cases: a *real* pre-person-layer archive (missing tables) reprojected end-to-end; explicit `--phases participants,profiles` forced against a source with zero recorded person raw; the two dependent-phase CLI rejections; a malformed `--profile-refresh-after`; `--help` flag surface; `status` row wiring. If a case that matters is missing, name it and I'll cover it.

## Smoke test transcript

**1. Real historical archive → `reproject`, auto-detected phases (happy path + the "source predates migration 0004_people.sql" edge case, using a genuine pre-person-layer archive, not a synthetic one):**
```
$ sqlite3 data/default/paperboy.sqlite ".backup '<scratch>/smoke/default/paperboy.sqlite'"   # safe copy, source untouched
$ sqlite3 <scratch>/smoke/default/paperboy.sqlite "select * from schema_migrations"
0001_init|2026-08-21T17:42:38...
0002_web|2026-08-21T17:42:38...        # confirms: predates 0004_people.sql AND predates run_id (ADR-0005)
$ PAPERBOY_DATA_DIR=<scratch>/smoke uv run paperboy reproject --profile default
... (3 raw targets in this archive, channel/history/discussion/graph/web/media phases all ran) ...
     row counts — source vs reprojected
 table                  source  reprojected
 raw_records            6258    6262
 ...
 users                  0       0
 user_snapshots         0       0
 user_photos            0       0
 participants           0       0
 participant_snapshots  0       0
EXIT: 0
```
No crash — confirms the `_table_count`/`sqlite_master` fix (`63254b0`) holds against the real archive it was originally found on, not just the synthetic regression test.

**2. Explicit `--phases channel,participants,profiles` forced on that same person-data-free archive (participants/profiles never ran originally):**
```
$ PAPERBOY_DATA_DIR=<scratch>/smoke2 uv run paperboy reproject --profile default --phases channel,participants,profiles
 participants  {'rosters': 0, 'walled': 2, ... 'participants': 0, ...}   -
 profiles      {'triaged': 0, 'enriched': 0, ...}                        -
 ...
 participant_snapshots  0   12       # new zero-RPC walled-broadcast snapshot, correctly derived from already-recorded ChatFull
EXIT: 0
```

**3. `paperboy collect --help`:** shows `--profiles`, `--profile-interval`, `--profile-refresh-after`, updated `--phases` help text — all present, correctly worded.

**4. CLI validation edge cases (no credentials needed — these fail before gateway/secrets build):**
```
$ uv run paperboy collect '@x' --phases participants --unsafe
--phases participants requires channel in the same run ...
EXIT: 1
$ uv run paperboy collect '@x' --phases profiles --unsafe
--phases profiles requires channel in the same run ...
EXIT: 1
$ uv run paperboy collect '@x' --profile-refresh-after 7x --unsafe
Invalid value for --profile-refresh-after: not a duration: '7x' (expected e.g. 7d, 12h, 30m, 45s)
EXIT: 2
```

**5. `paperboy status` on the reprojected store:**
```
$ uv run paperboy status --profile default
 channels 1  messages 5496  peers 158  edges 2503  users 0  participants 0
```
`users`/`participants` rows present as wired.

**6. Interactive library-level drive of `RawReplayGateway`** (hand-seeded raw log with `channels.ChannelParticipants`, `users.getUsers` User, `users.UserFull`, `account.PrivacyRules`; a Python session, not pytest):
```
runs: [ReplayRun(run_id='r1', lo=1, hi=5)]
detect_phases: ['channel', 'history', 'participants', 'profiles']
has_context_value method=users.getUsers: True
has_context_value method=nope: False
get_participants -> [{'_': 'ChannelParticipant', 'user_id': 11}]
get_full_user -> hello
get_privacy(phone) -> []
get_privacy(photo) -> SkipAndRecord as expected: replay: privacy posture not recorded for this run; reproject never runs doctor
get_participants offset=500 -> SkipAndRecord as expected: replay: no channelParticipantsRecent page at offset 500 recorded for channel 77
```

**7. `phase_status` manual verification** (the gap I found — see Changes):
```
>>> phase_status(st, "participants")  # 1 roster row seeded
'1 members'
>>> phase_status(st, "profiles")      # 2 users seeded, 1 enriched_at set
'2 users · 1 enriched'
```
Matches expectation; now pinned by a real test (`2493d60`).

**Not smoke-tested (correctly out of scope):** a live `collect` against real Telegram with `--profiles`/roster enumeration — that is Task 12's live smoke, explicitly reserved for the main thread per the plan and the instruction not to start Task 12. Everything I exercised above (`reproject`, `status`, CLI validation, `--help`, direct `RawReplayGateway`/`phase_status` driving) needs no network or Keychain and stayed within this leg's actual surface (Tasks 10-11: replay + wiring).

## Docs updated
None — Task 12 (docs + live smoke, explicitly not started) owns `docs/features/reproject.md` and the root `CLAUDE.md` status line ("participants/profiles are not started" is now stale but is this branch's/Task 12's concern, not leg 4's). In-code docstrings (`recipes.py` module docstring and `_default_collectors` comment) were updated as part of the existing commits.

## Follow-ups
None orthogonal to file — the one gap found (missing `phase_status` test coverage) was fixed in this same change, not deferred. Task 12 (docs, CLAUDE.md status line, live smoke against `@national_resistance_movement`) remains the next and final leg, per the run instructions.

## Reviewer Verdict
PASS. Independently reconstructed the diff (`git diff feat/person-layer...feat/person-layer-leg4`, merge-base `4404209` confirmed) and re-ran the evidence rather than trusting the report:

- **Full suite** `uv run pytest -q` → **586 passed, 0 failed, 0 skipped** (matches the claimed 574 unit + 11 integration + 1 regression). Person-layer/parity/regression files re-run standalone → 63 passed.
- **Lint/type** `ruff check` → All checks passed; `pyright` → 0 errors, 0 warnings, 0 informations.
- **Smoke (network-free items) reproduced and matched:** `--phases participants`/`profiles` alone → exit 1 with the channel-dependency message; `--profile-refresh-after 7x` → exit 2 "not a duration"; `collect --help` shows `--profiles`/`--profile-interval`/`--profile-refresh-after` and the updated `--phases` text.

No shims: the 7 replay methods serve real recorded payloads keyed by context (unrecorded → `SkipAndRecord`, which is *recorded*, not swallowed); the `ReplayUnknownUser` placeholder is explicitly ignored by the (unchanged) profiles collector, not fabricated; `download_user_photo` mirrors the established `download_media` None/`SkipAndRecord` contract. Test changes are additive or tightening; round-trip identity is exercised for enrich and triage-only, one-run and two-run. The doctor-gate refactor is behavior-preserving (`Settings.unsafe` defaults False). The self-found `phase_status` coverage gap was fixed in-change (no-shed). The sole DoD omission — a live `collect` against Telegram — is correctly scoped to Task 12. No skipped or weakened tests, swallowed errors, stubbed returns, cast-to-None, masked root cause, missing edge cases, or dishonest claims found.

## Correctness review — pass

Traced `git diff feat/person-layer...HEAD` end to end and re-ran the suite independently (586 passed; ruff clean; pyright 0/0/0).

**What I verified correct:**
- Replay ↔ record symmetry for all 7 person-layer `RawReplayGateway` methods and `get_privacy`: each replay query's kind set (`_kind_clause` with `%.k` suffix tolerance) and context keys (`channel_id`/`filter`/`offset`, `user_id`, `method='users.getUsers'`, `photo_id`, privacy `key`) match the exact `add_raw(...)` call sites in `participants.py`, `profiles.py`, and `posture.py`. Singular `channels.channelParticipant` vs plural `...Participants` do not cross-match.
- Synthetic-negative handling: `UserNotParticipant`→`None`, `ReplayUnknownUser`/`UserEmpty` placeholders, and the `ReplayClock` payload-keyed stamp lookup (with `_current` fallback) all reproduce the original projection.
- `detect_phases` participants/profiles inference, the channel-dependency CLI gate, `--unsafe`→`settings.unsafe` propagation (now consistently honored by both the doctor gate and the participants session gate), and `parse_duration` rejection of `7d`-malformed input.
- `_table_count` via `sqlite_master` correctly reads a pre-migration source table as 0 rather than crashing.
- Round-trip identity holds for the 5 new person tables plus edges/peers (confirmed by the passing round-trip and re-verified data comparison).

**Minor divergences flagged** (reproject-only, in run_events + sync_state, both excluded from the identity contract; substantive facts preserved in the identity-checked data tables) — see findings.
