### PR TITLE
docs(person-layer): feature doc, ADR-0006, status (Task 12) (#41)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,13 @@ transcript). `watch` and `lookup` are Phase 2 stubs. `paperboy reproject`
 credentials — see `docs/features/reproject.md`) shipped on `feat/reproject`;
 its run-structure redesign (`raw_records.run_id`, replay once per historical
 run — see `docs/adr/0005-run-structure.md`) has landed on top of it.
-Phase 2 collectors: `discussion`/`graph`/`media`/`web` are implemented;
-`participants`/`profiles` are not started.
+Phase 2 collectors: `discussion`/`graph`/`media`/`web`/`participants`/`profiles`
+are implemented — the person layer shipped on `feat/person-layer` (#41): the
+`participants` roster collector and the `profiles` enrichment collector, both
+default-on (`profiles` full enrichment behind `--profiles`), with the `users`/
+`user_snapshots`/`user_photos`/`participants`/`participant_snapshots` tables
+(migration `0004_people.sql`) and reproject-replay support. See
+`docs/features/person-layer.md` and `docs/adr/0006-person-layer-storage.md`.
 
 ## Read these first
 
@@ -49,6 +54,10 @@ Phase 2 collectors: `discussion`/`graph`/`media`/`web` are implemented;
 - **`pts` is the sync primitive** (`updates.getChannelDifference`), not
   `last_message_id`; messages are versioned (`message_revisions`), deletions
   are tombstones, counters are time series.
+- Profile richness lives in `users`/`user_snapshots`, **never** in `peers`
+  (keeps the `upsert_peer` #38/#39 lattice untouched); tri-state fields are
+  `present | absent | hidden_from_you` in `field_states_json`, and "no photo"
+  is never recorded as a fact (ADR-0006).
 - `min` peers are stored with `(seen_in_chat, seen_in_msg)` provenance and
   fetched via `inputUserFromMessage`; optional user fields are tri-state
   (present / not-set / hidden-from-you) — never record "no photo".

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ share one store and one set of guardrails.
 | Raw-TL preservation + normalized projections + FTS5 | ✅ |
 | JSONL export | ✅ |
 | Opsec preflight (`paperboy doctor`) | ✅ |
-| Media download, comment threads, people & profiles, forward/mention/similar-channel graph, web-archive snapshots, `watch`, phone `lookup` | 🔜 Phase 2 |
+| Comment threads, people & profiles (the person layer), forward/mention/similar-channel graph, media download, web-archive snapshots | ✅ Phase 2 |
+| `watch`, phone `lookup` | 🔜 Phase 2 (not yet implemented) |
 
 ## Requirements
 
@@ -136,7 +137,8 @@ The collecting account's own record is scrubbed from exports.
 |---|---|
 | `paperboy auth` | Interactive login; saves the session to the Keychain. |
 | `paperboy doctor` | Opsec preflight; blocks `collect` on failure unless `--unsafe`. |
-| `paperboy collect TARGET [--phases …] [--unsafe] [--profile P]` | Collect channel metadata + history. |
+| `paperboy collect TARGET [--phases …] [--unsafe] [--profile P]` | Collect channel metadata, history, the linked group's roster, and per-user profiles. |
+| `paperboy collect TARGET --profiles [--profile-budget N]` | Also run full profile enrichment (`getFullUser`, photo history, avatars) — the expensive opt-in on top of the always-on `getUsers` triage. |
 | `paperboy status [TARGET] [--profile P]` | Summarize stored data. |
 | `paperboy export TARGET --format jsonl --out DIR [--profile P]` | Export to JSONL. |
 | `paperboy reproject [--out PATH] [--phases …] [--profile P]` | Rebuild every projection from `raw_records` into a fresh DB — offline, no network, no credentials. |

--- a/docs/adr/0006-person-layer-storage.md
+++ b/docs/adr/0006-person-layer-storage.md
@@ -1,0 +1,160 @@
+# ADR-0006: Person-layer storage — a `users` table distinct from `peers`, tri-state fields, and a scheduling key distinct from the provenance benchmark
+
+## Status
+
+Accepted (2026-09-01). Implements the approved person-layer design
+(`docs/superpowers/specs/2026-08-26-person-layer-design.md`) on
+`feat/person-layer` across five legs (#41; PRs #45/#47/#48/#49). Amends the
+plan's D3 and D6 (`docs/superpowers/plans/2026-08-27-person-layer.md`) with
+what the leg-2/leg-3 reviews forced; records the reproject-fidelity residuals
+as #50.
+
+## Context
+
+The person layer turns the `min` peer stubs paperboy already collects into
+full people (`profiles`) and discovers the linked group's roster
+(`participants`). Two storage questions had to be settled before either
+collector could be written:
+
+1. **Where does profile richness live?** `peers` is the min-provenance stub
+   table whose `upsert_peer` merge lattice already carries two open
+   order-dependence residuals (#38/#39). Folding bios, photos, birthdays,
+   tri-state privacy signals and a per-run enrichment cursor into it would
+   entangle every new field with that lattice.
+2. **How is "absent" recorded?** Telegram enforces privacy by *omitting*
+   fields, not by failing calls — there is no privacy-denial error. The
+   constitution's "never record 'no photo'" MUST therefore needs a real
+   storage shape, not a convention: absence and "hidden from you" are
+   different facts and only the second is ever positively provable.
+
+Two further questions surfaced only under review, each after a K=3 workflow
+escalation on #41:
+
+3. **What drives the `profiles` enrichment rotation?** The plan (D3) derived
+   the position from `users.enriched_at`. That overloads one column with two
+   incompatible contracts.
+4. **What does reproject replay of the person layer need from `Settings`?**
+
+## Options considered
+
+- **A. Profile richness in `peers`** (extend the stub table). Rejected: ties
+  every field to the #38/#39 lattice and the min-merge rules.
+- **B. A `users` current-state table + `user_snapshots` append-only log**,
+  mirroring `channels`/`channel_snapshots`; `peers` untouched. Chosen.
+- **Tri-state:** (a) a `not_set | present | hidden_from_you` enum as the spec
+  drafted it; (b) `present | absent | hidden_from_you`. Chosen: (b) — a plain
+  wire absence can never honestly be called "not set" (that is the very "no
+  photo" claim the constitution forbids); `not_set` is unprovable.
+- **Rotation key:** (a) `users.enriched_at` (D3 as drafted); (b) a distinct
+  `profile_attempts` table written where budget is spent. Chosen: (b).
+
+## Decision
+
+1. **`users` / `user_snapshots` / `user_photos`, never `peers`**
+   (`0004_people.sql`). Profile richness — identity, tri-state field states,
+   the enrichment benchmark, dated avatar history — lives in the new tables;
+   `peers` stays the min-provenance stub table and its `upsert_peer` SQL is
+   never touched by this layer. The full `User` objects the roster/profile
+   RPCs return are still projected into `peers` (via `upsert_full_peer`,
+   which preserves any stored `(seen_in_chat, seen_in_msg)` provenance), so a
+   `min` stub is healed without the identity ever being lost.
+
+2. **Tri-state is `present | absent | hidden_from_you`** in
+   `users.field_states_json` (keys `phone, photo, status, about, birthday,
+   forwards, stories`). `hidden_from_you` is written only with a
+   machine-readable proof (`fallback_photo` present while `profile_photo` is
+   absent; `private_forward_name` present); a `userStatus*` keeps
+   `present` with `granularity`, and a coarse bucket's `coarse_cause` is
+   `self_privacy` when `by_me` is set — *our* account's privacy degrading the
+   data, not the target's opsec. Only a real `photo`/`Photo` constructor
+   counts as a photo (a `PhotoEmpty`/personal-photo shadow is `absent`). The
+   collecting account's own privacy posture is recorded once per run
+   (`account.getPrivacy` for phone/lastseen/photo) so a `by_me` observation
+   is attributable to us.
+
+3. **One SELF/REL chokepoint.** Every `users` column, including the
+   level-keyed `bot_json` (`{"user": …, "full": …}`), is derived from
+   `target_user_facts` / `target_full_facts`, which strip every fact-about-us
+   (`contact`, `bot_can_edit`, `blocked`, `common_chats_count`, `note`, …).
+   The guardrail has a single enforcement point rather than a set plus a
+   prefix heuristic (leg-1 review).
+
+4. **`users.enriched_at` is a provenance benchmark; `profile_attempts` is the
+   scheduling key (D3 as amended).** `enriched_at` moves only when full
+   columns were actually applied — so it cannot also be the round-robin
+   cursor, or a user whose `getFullUser` permanently fails sits at the head
+   of every run and starves the rest (reproduced twice in the leg-2 review:
+   first in the refresh pass, then, with `enriched_at IS NOT NULL` as the
+   leading sort term, for a never-enriched permanent failure). The rotation
+   is `profile_attempts (uri PK, attempted_at, outcome, detail)`, written at
+   the ONE point a budget slot is spent (`attempted`, before the RPC) and
+   replaced by whichever arm finishes it (`skipped`/`malformed`/
+   `not_projected`/`enriched`) — structurally unskippable. `_enrichment_
+   candidates` orders never-attempted first, then everyone strictly
+   least-recently-attempted, so a permanent failure costs one slot per lap
+   and can never block the refresh wrap. `profile_attempts` is bookkeeping
+   like `sync_state` — excluded from round-trip identity.
+
+5. **Synthetic raw kinds for observations with no TL payload** (precedent:
+   `MediaDownload`): `RosterWalled` (a walled roster is a first-class stored
+   outcome, never a silent zero), `UserNotParticipant` (the oracle's
+   definitive negative), `AvatarDownload` (a downloaded avatar's sha/path).
+   RPC-result envelopes are stamped with their TL namespace
+   (`users.UserFull`, `channels.ChannelParticipants`, …) because Telethon's
+   `to_dict()` emits the bare class name and the envelope collides with its
+   inner object.
+
+6. **New edge predicate `reacted_to`** (user → message), from the zero-RPC
+   `recent_reactions` sample and the bounded `messages.getMessageReactionsList`
+   vector (groups only; a broadcast answers `BROADCAST_FORBIDDEN`).
+   `member_of`/`admin_of`/`invited_by`/`added_by` are as the design reserved.
+
+7. **A structural wall is terminal; a hidden-member wall is bulk-only (leg-3
+   review).** `_roster_wall_reason` returns `(reason, terminal)`: a broadcast
+   peer is terminal (the per-user oracle is `CHAT_ADMIN_REQUIRED` too), but a
+   `participants_hidden` / `can_view_participants=false` group is walled for
+   BULK enumeration only — the `getParticipant` oracle and the reaction-list
+   vector are exactly the designated fallback there (spec §5/§6.2), so the
+   roster is still built and those vectors still run.
+
+8. **Reproject replays the person layer per run with lifted budgets and
+   `allow_join`/`unsafe` (D6 as amended).** Per historical run,
+   `enrich_profiles` is set from whether that run recorded a `users.UserFull`;
+   `unsafe=True` (the session-age gate has no live RPC to protect on replay);
+   `allow_join=True` (a `--join` source's sweep must not be skipped); and
+   `profile_budget` / `participant_oracle_budget` / `participant_reactions_budget`
+   are all lifted, because the live budget already bounded *what was recorded*
+   and a smaller replay budget would drop recorded observations. The five
+   person tables round-trip identically (collect → reproject); `profile_attempts`
+   and `sync_state` are excluded as bookkeeping.
+
+## Consequences
+
+- The `#38`/`#39` `peers` lattice is untouched; profile richness has its own
+  home and its own, simpler recency/richness rules in `store/users.py`.
+- "no photo" is never recorded; a Datasette reader sees `absent` vs
+  `hidden_from_you` (with the proof) vs `present`, and a coarse status with
+  its cause.
+- The enrichment sweep converges across runs and cannot be starved by a
+  permanently failing user; the choice is replay-deterministic.
+- Reproject rebuilds the person layer like every other phase (ADR-0002
+  "rebuildable from raw" holds for the new tables).
+- **Residual (#50):** reproject's lifted budget and forced `allow_join`
+  leave two divergences in the *reprojected* DB's bookkeeping — a phantom
+  `participants`/`join` `run_events` row on a passively-enumerated source,
+  and the lifted `profile_budget` written verbatim into `sync_state`. Both
+  are excluded from round-trip identity (no data table, no round-trip test
+  affected); tracked for a clean fix or an accepted-residual note.
+- The default collector set is now `channel, history, discussion,
+  participants, profiles, graph`; `participants` and `profiles`-triage are
+  read-only and bounded, so both are default-on. Full profile enrichment
+  (`getFullUser`/photos/avatars) stays behind `--profiles`.
+
+## Notes
+
+- Spec: `docs/superpowers/specs/2026-08-26-person-layer-design.md`.
+- Plan (with the D3/D6 amendments): `docs/superpowers/plans/2026-08-27-person-layer.md`.
+- Feature doc + DoD smoke: `docs/features/person-layer.md`.
+- Builds on ADR-0002 (raw-first), ADR-0003 (guardrails/budget), ADR-0005
+  (run structure / reproject).
+- Reproject-fidelity residual: [#50](https://github.com/SpencerNorris/paperboy/issues/50).

--- a/docs/features/person-layer.md
+++ b/docs/features/person-layer.md
@@ -1,0 +1,155 @@
+# Feature: person layer — `participants` + `profiles`
+
+**Status:** implemented on `feat/person-layer` (#41; PRs #45/#47/#48/#49 —
+schema+store+gateway, `profiles`, `participants`, reproject-replay+wiring).
+**Spec:** `docs/superpowers/specs/2026-08-26-person-layer-design.md`.
+**Plan:** `docs/superpowers/plans/2026-08-27-person-layer.md` (D3/D6 amended).
+**ADR:** `docs/adr/0006-person-layer-storage.md`.
+
+## Purpose
+
+Turn the `min` peer stubs paperboy already collects into full people, and
+discover the linked discussion group's roster — within Telegram's hard walls,
+read-only and passive by default. Two collectors, both in the default set:
+
+- **`participants`** — the discovery front-end: enumerate the linked group's
+  roster where permitted (`channels.getParticipants` `Recent`, un-joined),
+  the per-user `channels.getParticipant` oracle for known users a partial
+  roster missed, `--join` → `Recent ∪ Admins ∪ Bots`, plus the zero-RPC
+  vectors (join/leave service messages, the `recent_reactions` sample, the
+  #11 forward/mention backfill) and the bounded `messages.getMessageReactionsList`.
+  Records join dates, rank, status, and `member_of`/`admin_of`/`invited_by`/
+  `added_by`/`reacted_to` edges.
+- **`profiles`** — the single enrichment authority: batched `users.getUsers`
+  triage for *every* discovered user (always on), then `users.getFullUser` +
+  `photos.getUserPhotos` + avatar download under `--profiles`, priority-ordered
+  (admins → authors → commenters → others), budgeted, and converging across
+  runs.
+
+## Inputs
+
+- `paperboy collect TARGET` runs both by default (`--phases` may select a
+  subset; `participants`/`profiles` each need `channel` in the same run).
+- `--profiles` turns on full enrichment (off = `getUsers` triage only + a
+  warning naming what was not fetched). `--profile-budget N` (default 2000)
+  caps `getFullUser` per run; `--profile-interval SECONDS` paces the
+  per-user profile RPCs through the budget chokepoint; `--profile-refresh-after
+  DURATION` (e.g. `7d`) skips re-enriching users seen more recently.
+- `--join` joins a linked group that gates reading (`join_to_send`) — the one
+  audited write, off by default. `--unsafe` skips the doctor gate and the
+  per-phase session-age gate.
+- Env: `PARTICIPANT_ORACLE_BUDGET` (100), `PARTICIPANT_REACTIONS_BUDGET`
+  (200), `ENRICH_PROFILES`, `PROFILE_INTERVAL`, `PROFILE_REFRESH_AFTER`,
+  `UNSAFE` mirror the flags.
+
+## Outputs
+
+- `users` (current profile state, tri-state `field_states_json`),
+  `user_snapshots` (append-only per-method observation log), `user_photos`
+  (dated avatar history + downloaded sha), `participants` (roster membership
+  facts keyed `(group_id, uri)`), `participant_snapshots` (per-run enumerated
+  set + `enumerated/true_count` accounting rows). Migration `0004_people.sql`.
+- `edges`: `member_of`, `admin_of`, `invited_by`, `added_by`, `reacted_to`.
+- `raw_records`: `users.UserFull`, `channels.ChannelParticipants`,
+  `channels.ChannelParticipant`, `photos.Photos`/`PhotosSlice`,
+  `messages.MessageReactionsList`, `account.PrivacyRules`, and the synthetic
+  `RosterWalled` / `UserNotParticipant` / `AvatarDownload`.
+- `run_events`: `roster`, `roster_walled`, `admin_only_skipped`,
+  `privacy_posture`, `preflight_mismatch`, `oracle_walled`, `join`, and
+  `warning` (`session_age_gate` / `roster_partial` / `profiles_enrichment_off`
+  / `reaction_list_truncated`).
+- `sync_state('profiles', <channel_id>)`: the convergence summary; the
+  `profile_attempts` table is the rotation cursor.
+- `paperboy status` shows `users` and `participants` counts; `paperboy
+  reproject` rebuilds all five person tables from raw.
+
+## How it works
+
+Behaviour statements live in the code's own docstrings (the reproject doc's
+single-source-of-truth rule); this section only orients:
+
+- `src/paperboy/collectors/participants.py` — the walls, the roster
+  accounting, the oracle, `--join`, the reaction vector. `_roster_wall_reason`
+  returns `(reason, terminal)` (broadcast terminal; hidden-member bulk-only —
+  the oracle+reaction fallback still runs). One join site with a membership
+  check (`_already_member` / `prejoined`).
+- `src/paperboy/collectors/profiles.py` — triage, the `--profiles` sweep, the
+  `profile_attempts` rotation (never derived from `enriched_at`), photos +
+  avatars. `src/paperboy/collectors/posture.py` — the once-per-run privacy
+  posture, shared with `participants`.
+- `src/paperboy/store/users.py` / `participants.py` / `message_peers.py` /
+  `reactions.py` — the projections; `store/users.py`'s module docstring is the
+  tri-state / two-benchmark authority.
+- `src/paperboy/replay.py` / `reproject.py` — the seven person-layer replay
+  methods, `detect_phases`, and the per-run replay settings (ADR-0006 §8).
+
+## Edge cases handled
+
+Walled broadcast roster (recorded, zero enumeration RPC); no linked group (a
+full phase skip, but the zero-RPC vectors on the target's own posts still
+run); `participants_hidden` group (bulk-walled → oracle + reactions fallback);
+session-age gate refusal before any group RPC; a preflight answering for the
+wrong channel / carrying no `Channel` object; the `getParticipant` oracle wall
+(`CHAT_ADMIN_REQUIRED`); `--join` never re-joining an already-member group nor
+joining a linked broadcast; reaction lists bounded, resumable and hard-capped;
+a permanently-failing `getFullUser` never starving the refresh rotation; a
+`UserEmpty` triage answer never spending an enrichment slot; a `min` reactor's
+identity never clobbered by the reaction write; `PhotoEmpty` never recorded as
+a photo; the collecting account never projected as a subject (#12).
+
+## Known limitations
+
+- The `channelParticipantsMentions(top_msg_id)` per-thread-root union is
+  deferred (its identities are redundant with a completed `discussion` sweep;
+  see #41 follow-up); reactor lists are never fetched on a broadcast.
+- Photo history is the first `getUserPhotos` page (limit 100) per run.
+- Avatar downloads are sequential (no media-DC parallelism yet).
+- A reproject of a multi-target profile serves per-user records by `user_id`
+  within a run (plan D14); reprojected bookkeeping has two documented
+  residuals (#50).
+
+## Definition-of-Done smoke transcript
+
+**Round-trip smoke (offline, no network) — PASSED.** The full default set
+(`channel, history, discussion, participants, profiles, graph`) run with
+`enrich_profiles=True` against `FakeGateway` fixtures into a real `Store`,
+then `paperboy reproject`, round-trips all five person tables row-for-row; a
+triage-only source reprojects triage-only. Driver + transcript:
+`/Volumes/Storage/tmp/leg4_smoke.py` (leg-4 DoD). The person-layer replay
+round-trip is also pinned by `tests/test_reproject_people.py` and the
+regenerated frozen-clock golden (`tests/test_reproject_parity.py`), and each
+collector's behaviour by `tests/test_collector_participants.py` /
+`tests/test_collector_profiles.py`. Full suite: 586 passed, ruff + pyright
+clean (leg-4).
+
+**Live-Telegram smoke — DEFERRED (environment gap, handed off).** The design's
+live DoD (`@national_resistance_movement` + its linked group *NRM Chat*, 307
+members) MUST run on the main thread (Keychain) and requires the configured
+proxy. In the implementing environment `require_proxy` is set but no proxy is
+configured, so `doctor` blocks `collect` — running it would mean a direct-IP
+connection from the collecting account, the exact opsec exposure the proxy
+guards against. This is a verifier handoff, not "done":
+
+> With the opsec proxy configured (`PAPERBOY_PROXY=socks5://…`) and a valid
+> session in the Keychain, on the main thread:
+>
+> 1. `uv run paperboy doctor --profile default` → PASS (proxy present).
+> 2. `uv run paperboy collect @national_resistance_movement --profile default`
+>    (default set, passive — no `--join`). Expect: `RosterWalled` for the
+>    broadcast channel (zero enumeration RPC against it); NRM Chat's `Recent`
+>    roster enumerated with an `enumerated/307` accounting row; join dates /
+>    rank / `member_of`/`admin_of` edges; `getUsers` triage over every
+>    discovered user + the `profiles_enrichment_off` warning; `privacy_posture`
+>    recorded once.
+> 3. `uv run paperboy collect @national_resistance_movement --profile default
+>    --profiles --profile-budget 5` → 5 `getFullUser` + photo history +
+>    avatars; tri-state states populated (look for a `hidden_from_you` with its
+>    `why`); a second `--profiles` run enriches the next 5 (convergence).
+> 4. `uv run paperboy reproject --profile default --out /tmp/np.sqlite` →
+>    the five person tables round-trip.
+> 5. Guardrails: no third-party phone in `paperboy.log`; no `joinChannel`
+>    without `--join`; `run_events` `join` count 0.
+>
+> Paste the transcript here and into #41 when run.
+
+Verification steps recorded in #41.


### PR DESCRIPTION
Task 12 docs for the person layer (#41): `docs/features/person-layer.md` (offline round-trip DoD smoke passed; the live-Telegram smoke is a documented verifier handoff — the implementing env has `require_proxy` set with no proxy configured, so a live collect would be a direct-IP connection), `docs/adr/0006-person-layer-storage.md`, and the CLAUDE.md/README status updates. Docs-only; no code changed. Full suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01748NEmbdPayBnjfQJaqNDV